### PR TITLE
docs: add project and architecture READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,230 @@
-<p align="center" style="background-color: transparent;">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/kartoush-header-dark.png">
-    <img alt="Kartoush" src="./docs/assets/kartoush-header-light.png" width="360">
-  </picture>
-</p>
+# Kartoush
 
+> A modular monolith e-commerce platform built to demonstrate real-world system architecture, tradeoff-driven design, and production-minded engineering.
 
+Kartoush exists to showcase how a large, evolving system can be intentionally designed, documented, and implemented by a single engineer with enterprise experience.
 
-Kartoush is a work-in-progress software project focused on exploring and building solutions in the commerce and platform domain.  
-This repository currently serves as a home for early design exploration, decision-making, and project setup.
-
-## Status
-
-🚧 **Pre-implementation**
-
-No production code exists yet. The current focus is on clarifying goals, constraints, and architectural decisions before development begins.
-
-## Goals
-
-- Define a clear problem space and project scope
-- Make intentional, documented architectural and technology decisions
-- Establish a solid foundation before writing production code
-- Favor clarity, maintainability, and long-term ownership
-
-## Non-Goals
-
-- Rushing into implementation without documented decisions
-- Optimizing for premature performance or scale concerns
-- Building a one-off or throwaway prototype
-
-## Project Structure
-
-- `docs/decisions/`  
-  Records of open and accepted design decisions, including context and tradeoffs
-
-- `docs/architecture/`  
-  High-level architectural notes and diagrams (to be added)
-
-## Decisions
-
-Design decisions are captured as individual Markdown files under `docs/decisions`.  
-These may start as open questions and evolve into accepted decisions over time.
-
-## Contributing
-
-This project is currently in an early, exploratory phase.  
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and expectations.
+This is not a tutorial project.  
+This is a design-first system built the way real production platforms evolve.
 
 ---
 
-*Kartoush is intentionally being designed before it is built.*
+## Why Kartoush Exists
+
+Most public GitHub projects fail to demonstrate:
+
+- Architectural ownership  
+- System-level tradeoffs  
+- Non-functional requirements  
+- Long-term maintainability  
+
+Kartoush was created to solve that gap.
+
+The goal is to demonstrate how I approach:
+
+- System decomposition  
+- Domain boundaries  
+- Performance and scalability  
+- Observability and operability  
+- Change over time  
+
+Everything in this repository exists to make engineering decisions explicit.
+
+### A Deliberate Learning Project
+
+Kartoush is also a deliberate learning investment.
+
+While it reflects patterns and practices I use professionally, it is intentionally designed to push into areas that are difficult to explore safely inside a large, existing production system.
+
+This includes:
+
+- Stress-testing architectural decisions at scale  
+- Revisiting tradeoffs with the benefit of hindsight  
+- Experimenting with alternative designs and documenting why they do or do not work  
+
+Where learning drives a decision, that context is documented explicitly. The goal is not to present a perfect system, but an honest one.
+
+Some decisions intentionally revisit problems I have encountered in production systems, particularly areas where earlier tradeoffs revealed shortcomings as systems scaled and evolved.
+
+---
+
+## Project Name
+
+The name **Kartoush** is a play on the word *cartouche*.
+
+A cartouche represents an enclosing boundary that gives structure and meaning to what is inside. In e-commerce systems, the cart plays a similar role, acting as the boundary where pricing, inventory, promotions, and fulfillment rules intersect.
+
+Kartoush was chosen to reflect that idea:
+
+- Clear boundaries matter  
+- Structure enables complexity  
+- Systems fail when responsibilities leak across layers  
+
+The slightly altered spelling is intentional. This project is inspired by real-world patterns, but it is not a clone of any single system. It exists as a space to explore, refine, and sometimes challenge architectural decisions.
+
+---
+
+## Design Philosophy
+
+Kartoush is guided by a few core principles.
+
+### Design for Change
+
+Real systems are never done.
+
+Kartoush favors:
+
+- Clear boundaries  
+- Stable interfaces and contracts  
+- Evolvable internals  
+
+### Make Tradeoffs Explicit
+
+Every meaningful architectural decision is documented, including:
+
+- Alternatives considered  
+- Reasons for rejection  
+- Known limitations  
+
+### Favor Boring, Understandable Architecture
+
+The system avoids unnecessary complexity in favor of:
+
+- Predictable behavior  
+- Debuggability  
+- Operational clarity  
+
+---
+
+## Architecture Overview
+
+Kartoush uses a **modular monolith** architecture, meaning the system is deployed as a single application but structured into clearly defined, independent modules.
+
+This allows:
+
+- Strong domain boundaries  
+- Independent evolution of modules  
+- Simplified local development  
+- A future path toward splitting modules into separate services if warranted  
+
+### High-Level Modules
+
+| Module | Responsibility |
+|------|---------------|
+| Core | Domain models and business rules |
+| Facades | Stable APIs that isolate callers from internal implementation details |
+| Services | Business logic and orchestration |
+| Persistence | Data access and storage concerns |
+| Storefront / API | Entry points into the system |
+
+Modules communicate through explicit contracts rather than hidden dependencies.
+
+---
+
+## Key Architectural Decisions
+
+Important decisions are captured as **Architecture Decision Records (ADRs)**.
+
+Examples include:
+
+- Modular monolith vs microservices  
+- Facade layering and communication rules  
+- Inventory reservation and backorder behavior  
+- Performance handling under high concurrency  
+- Logging and observability strategy  
+
+These live in the `/architecture/decisions` directory.
+
+> The documentation is as important as the code.
+
+---
+
+## Inventory Is a Core Concern
+
+Inventory is intentionally chosen as a core domain because it is deceptively difficult to model correctly over time.
+
+Kartoush accounts for real-world constraints such as:
+
+- Reservable vs non-reservable products  
+- Cart-based inventory reservations  
+- Reservation expiration  
+- Backorder eligibility tied to future supply  
+- Concurrent checkout behavior  
+
+Naive inventory models tend to fail under load or as systems scale.  
+Kartoush explicitly designs for those failure modes.
+
+---
+
+## Non-Functional Requirements
+
+Kartoush intentionally designs for performance, reliability, and observability from the start, rather than treating them as afterthoughts.
+
+### Performance
+
+- Designed to handle high-volume order spikes  
+- Avoids global locks and contention hotspots  
+- Documents scaling bottlenecks and mitigation strategies  
+
+### Observability
+
+- Structured logging through SLF4J  
+- Clear ownership of log responsibility  
+- Designed for future integration with centralized observability tools  
+
+### Reliability
+
+- Idempotent operations where required to ensure safe retries  
+- Explicit failure handling paths  
+- Defensive modeling of partial system failure  
+
+---
+
+## What This Project Is Not
+
+Kartoush is intentionally not:
+
+- A polished SaaS product  
+- A UI-heavy demo  
+- A framework showcase  
+- A tutorial codebase  
+
+It is a thinking artifact that happens to compile.
+
+---
+
+## Project Status
+
+Kartoush is an evolving system.
+
+Some components are:
+
+- Fully implemented  
+- Partially implemented  
+- Documented but intentionally deferred  
+
+This reflects how real systems are built and prioritized.
+
+---
+
+## How to Explore the Project
+
+If you are reviewing this as a hiring manager or engineer:
+
+1. Start with the Architecture Decision Records  
+2. Review the facade boundaries that isolate callers from internal implementation details  
+3. Examine inventory modeling and reservation flow  
+4. Review logging and performance decisions  
+5. Inspect commit history to see how decisions evolved  
+
+---
+
+## Independence Disclaimer
+
+This project is an independent work created on personal time and equipment. It is not affiliated with, derived from, or representative of any employer or proprietary system.
+
+---
+
+## License
+
+This project is licensed under the Apache License, Version 2.0. See the [LICENSE](LICENSE) file for details.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,155 @@
+# Architecture Overview
+
+This directory contains the architectural documentation for Kartoush.
+
+The purpose of this documentation is not to describe a finished system, but to make architectural thinking, tradeoffs, and evolution explicit and reviewable.
+
+If you want to understand how and why Kartoush is structured the way it is, start here.
+
+---
+
+## How to Read This Documentation
+
+Kartoush is designed to evolve over time. As a result, architectural documentation is treated as a living artifact rather than a static snapshot.
+
+A good reading order is:
+
+1. This document  
+2. Architecture Decision Records (ADRs)  
+3. Module-level documentation (as the system grows)  
+
+You do not need to read everything at once. Each document is intended to stand on its own.
+
+---
+
+## Architecture Decision Records (ADRs)
+
+The `/architecture/decisions` directory contains **Architecture Decision Records (ADRs)**.
+
+Each ADR documents:
+- A specific architectural decision
+- The context in which the decision was made
+- Alternatives that were considered
+- The reasons a particular option was chosen
+- Known limitations and follow-up considerations
+
+ADRs exist to answer the question:
+> “Why does the system work this way?”
+
+They are preferred over tribal knowledge or undocumented assumptions.
+
+### Changing Decisions
+
+Architectural decisions are not immutable.
+
+When a decision changes:
+- A new ADR is added
+- The original ADR remains unchanged
+- The relationship between decisions is documented explicitly
+
+This preserves historical context and makes architectural evolution visible.
+
+---
+
+## Design Philosophy in Practice
+
+The architectural choices in Kartoush are guided by a few consistent themes.
+
+### Boundaries First
+
+Clear boundaries are prioritized over premature optimization.
+
+This means:
+- Modules have explicit responsibilities
+- Communication flows are intentional
+- Dependencies are constrained and documented
+
+The goal is to reduce accidental complexity as the system grows.
+
+---
+
+### Design for Change
+
+Kartoush assumes that requirements will change.
+
+As a result:
+- Interfaces are favored over concrete implementations
+- Internal details are isolated behind stable entry points
+- The system is structured to allow refactoring without widespread breakage
+
+This favors long-term maintainability over short-term convenience.
+
+---
+
+### Tradeoffs Over Absolutes
+
+No architectural choice is presented as universally correct.
+
+Every significant decision documents:
+- What was gained
+- What was given up
+- What risks were accepted
+
+This documentation is intentionally candid. Tradeoffs are part of responsible system design.
+
+---
+
+## Scope and Intentional Gaps
+
+Not every idea discussed in the architecture documentation is fully implemented.
+
+Some decisions are:
+- Implemented incrementally
+- Documented ahead of implementation
+- Deferred intentionally
+
+This mirrors real-world systems, where architecture often leads implementation rather than follows it.
+
+Where gaps exist, they are documented explicitly rather than hidden.
+
+---
+
+## Relationship to the Codebase
+
+Architectural documentation is expected to align with the code, but not duplicate it.
+
+The documentation answers:
+
+- Why boundaries exist
+- Why responsibilities are assigned as they are
+- Why certain constraints are enforced
+
+The code answers:
+
+- How those decisions are implemented
+
+If documentation and code ever diverge, that is considered a bug and should be corrected.
+
+---
+
+## What This Documentation Is Not
+
+This directory is intentionally not:
+- A tutorial on system design
+- A catalog of design patterns
+- A justification of “best practices”
+
+It exists to document **this system**, its constraints, and the reasoning behind it.
+
+---
+
+## How This Evolves Over Time
+
+As Kartoush grows, this directory may expand to include:
+
+- Module-level architecture overviews
+- Diagrams where they add clarity
+- Retrospectives on changed or reversed decisions
+
+The goal is consistency, not completeness.
+
+---
+
+## Independence Disclaimer
+
+This architectural documentation reflects an independent project created on personal time. It is not affiliated with, derived from, or representative of any employer or proprietary system.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,98 @@
+# Architecture Decision Records
+
+This directory contains **Architecture Decision Records (ADRs)** for Kartoush.
+
+ADRs are used to document significant architectural decisions, including the context in which they were made and the tradeoffs involved.
+
+Their purpose is simple: to make architectural reasoning explicit and durable.
+
+---
+
+## What Is an ADR?
+
+An Architecture Decision Record captures:
+
+- A specific architectural decision
+- The problem or context that led to the decision
+- Alternatives that were considered
+- The reasons a particular option was chosen
+- Known consequences and limitations
+
+ADRs exist to answer the question:
+
+> Why does the system work this way?
+
+They are preferred over undocumented assumptions or relying on memory.
+
+---
+
+## When to Write an ADR
+
+An ADR should be written when a decision:
+
+- Affects system structure or boundaries  
+- Introduces constraints that will be difficult to reverse  
+- Impacts multiple modules or domains  
+- Represents a meaningful tradeoff rather than an obvious choice  
+
+Not every technical decision needs an ADR.  
+If a decision is easy to change or isolated in scope, documentation in code or a task description is usually sufficient.
+
+---
+
+## How ADRs Evolve
+
+Architectural decisions are not permanent.
+
+When a decision changes:
+
+- A **new ADR** is created
+- The original ADR remains unchanged
+- The newer ADR references the earlier one
+
+This preserves historical context and makes architectural evolution visible over time.
+
+ADRs are not rewritten to reflect current thinking. They represent what was believed to be correct at the time.
+
+---
+
+## Relationship to the Code
+
+ADRs explain **why** a decision was made.  
+The code shows **how** that decision is implemented.
+
+If the code no longer reflects an ADR:
+
+- Either the code has drifted  
+- Or a new ADR is needed  
+
+In both cases, the mismatch should be resolved explicitly.
+
+---
+
+## Format and Naming
+
+ADRs are stored as Markdown files and named using a simple numeric prefix:
+
+- 0001-use-modular-monolith-architecture.md
+- 0002-introduce-facade-layer.md
+
+Lower numbers indicate earlier decisions. Gaps in numbering are acceptable.
+
+---
+
+## What ADRs Are Not
+
+ADRs are intentionally not:
+
+- Design documents for every class or method
+- Tutorials on architecture patterns
+- Justifications of best practices
+
+They exist to document **decisions**, not implementations.
+
+---
+
+## Independence Disclaimer
+
+These Architecture Decision Records are part of an independent project created on personal time and equipment. They are not affiliated with, derived from, or representative of any employer or proprietary system.


### PR DESCRIPTION
### Summary

This PR adds foundational project documentation, including:

- A top-level README describing project goals, scope, and design philosophy
- An architecture README explaining how to understand and navigate architectural documentation
- An ADR README defining how architectural decisions are recorded and evolve over time

### Notes

This change is documentation-only and does not introduce any functional or architectural changes to the codebase.

Closes #44