### PR TITLE
chore: standardize decision document titles

### DIFF
--- a/docs/decisions/0001-project-goals.md
+++ b/docs/decisions/0001-project-goals.md
@@ -1,4 +1,4 @@
-# 0001 – Project Goals and Non-Goals
+# Project Goals and Non-Goals
 
 ## Status
 Proposed

--- a/docs/decisions/0002-architecture-style.md
+++ b/docs/decisions/0002-architecture-style.md
@@ -1,6 +1,7 @@
-# 0002 – Architecture Style
+# Architecture Style
 
 ## Status
+
 Proposed
 
 ## Context
@@ -10,6 +11,7 @@ style that supports deliberate, incremental development while keeping
 complexity low as the domain is still forming.
 
 The chosen style should:
+
 - Enable clear ownership and boundaries
 - Make change impact easy to reason about
 - Avoid premature operational complexity
@@ -54,10 +56,12 @@ service-oriented architectures.
 ### Microservices from the start
 
 **Pros**
+
 - Independent deployment and scaling
 - Clear service boundaries if the domain is already stable
 
 **Cons**
+
 - High operational complexity early (deployment, networking, observability)
 - Distributed systems challenges before requirements are well understood
 - Slower iteration for an early-stage project
@@ -67,6 +71,7 @@ service-oriented architectures.
 ### Fully monolithic, no modular boundaries
 
 **Pros**
+
 - Simplest possible starting point
 - Minimal upfront structure
 

--- a/docs/decisions/0003-data-ownership.md
+++ b/docs/decisions/0003-data-ownership.md
@@ -1,6 +1,7 @@
-# 0003 – Data Ownership
+# Data Ownership
 
 ## Status
+
 Proposed
 
 ## Context

--- a/docs/decisions/0004-integration-style.md
+++ b/docs/decisions/0004-integration-style.md
@@ -1,6 +1,7 @@
-# 0004 – Integration Style
+# Integration Style
 
 ## Status
+
 Proposed
 
 ## Context

--- a/docs/decisions/0005-build-tool.md
+++ b/docs/decisions/0005-build-tool.md
@@ -1,4 +1,4 @@
-# 0005 – Build Tool
+# Build Tool
 
 ## Status
 Proposed

--- a/docs/decisions/0006-deployment-assumptions.md
+++ b/docs/decisions/0006-deployment-assumptions.md
@@ -1,4 +1,4 @@
-# 0006 – Deployment Assumptions
+# Deployment Assumptions
 
 ## Status
 Proposed

--- a/docs/decisions/0007-inventory-availability.md
+++ b/docs/decisions/0007-inventory-availability.md
@@ -1,4 +1,4 @@
-# 0007 – Inventory Availability Mode
+# Inventory Availability Mode
 
 ## Status
 Proposed

--- a/docs/decisions/0008-reservation-ownership-and-lifecycle.md
+++ b/docs/decisions/0008-reservation-ownership-and-lifecycle.md
@@ -1,4 +1,4 @@
-# 0008 – Reservation Ownership and Lifecycle
+# Reservation Ownership and Lifecycle
 
 ## Status
 Proposed

--- a/docs/decisions/0009-cart-to-order-conversion.md
+++ b/docs/decisions/0009-cart-to-order-conversion.md
@@ -1,4 +1,4 @@
-# 0009 – Cart to Order Conversion Rules
+# Cart to Order Conversion Rules
 
 ## Status
 

--- a/docs/decisions/0010-payment-lifecycle-and-guarantees.md
+++ b/docs/decisions/0010-payment-lifecycle-and-guarantees.md
@@ -1,4 +1,4 @@
-# 0010 – Payment Lifecycle and Guarantees
+# Payment Lifecycle and Guarantees
 
 ## Status
 

--- a/docs/decisions/0011-layering-and-facade-contracts.md
+++ b/docs/decisions/0011-layering-and-facade-contracts.md
@@ -1,4 +1,4 @@
-# 0011 – Layering and Facade Contracts
+# Layering and Facade Contracts
 
 ## Status
 Proposed

--- a/docs/decisions/0012-non-reservable-product-behavior.md
+++ b/docs/decisions/0012-non-reservable-product-behavior.md
@@ -1,6 +1,7 @@
-# 0012 – Non-Reservable Product Behavior
+# Non-Reservable Product Behavior
 
 ## Status
+
 Proposed
 
 ## Context

--- a/docs/decisions/0013-logging-and-observability.md
+++ b/docs/decisions/0013-logging-and-observability.md
@@ -1,4 +1,4 @@
-# Decision: Logging and Observability
+# Logging and Observability
 
 ## Status
 


### PR DESCRIPTION
## Summary
Standardizes the titles of existing decision documents for consistency.

Decision records use the filename as the canonical identifier. Earlier documents included the numeric identifier or the word “Decision” in the H1 title, which duplicated metadata already conveyed by the file location and name.

## Changes
- Removed numeric prefixes and `Decision:` from H1 titles in existing decision documents
- Left filenames and decision content unchanged

## Scope
- Documentation-only change
- No architectural or behavioral changes
- No renumbering or renaming of decision files

## Notes
This cleanup aligns existing documents with the documented ADR format and improves long-term readability without altering decision intent.

Closes #49