### PR TITLE
Add platform-types module

### DIFF
--- a/kartoush/platform-types/build.gradle
+++ b/kartoush/platform-types/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'com.kartoush'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/kartoush/settings.gradle
+++ b/kartoush/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'kartoush'
 include 'app'
+include 'platform-types'


### PR DESCRIPTION
## Summary

Adds the `platform-types` module as defined in ADR A001.

## Changes

- Created new Gradle module `platform-types`
- Configured module as `java-library`
- Enforced Java 25 toolchain alignment
- No framework dependencies introduced
- No domain types added yet

## Purpose

This module will contain low-level shared types that:

- Are framework-free
- Contain no business logic
- Change infrequently
- Can be safely depended on by domain modules

Establishes the structural foundation required for domain module separation.

Closes #71
Closes #67
