### PR TITLE
Add customer domain module

### DIFF
--- a/kartoush/customer/README.md
+++ b/kartoush/customer/README.md
@@ -1,0 +1,15 @@
+# Customer
+
+Customer domain module.
+
+## Ownership
+
+This module owns:
+- Customer domain model
+- Customer persistence model and migrations
+- Published interfaces for cross-module access (facades / ports)
+
+## Constraints
+
+- Other modules must not access internal packages or persistence directly
+- Cross-module access must go through published contracts

--- a/kartoush/customer/build.gradle
+++ b/kartoush/customer/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'com.kartoush'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+dependencies {
+    // Keep this module framework-light for now.
+    // Add Spring/JPA/Flyway when we implement persistence (next tasks).
+
+    api project(':platform-types')
+
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/kartoush/settings.gradle
+++ b/kartoush/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'kartoush'
 include 'app'
 include 'platform-types'
+include 'customer'


### PR DESCRIPTION
## Summary

Adds the `customer` domain module as a new Gradle subproject.

## Changes

- Included `customer` in `settings.gradle`
- Added `customer` module skeleton using `java-library`
- Added unit test setup for the module
- Customer depends on `platform-types` via public API

## Notes

No persistence, migrations, or API endpoints are introduced in this PR.

This establishes the structural foundation for the Customer domain slice.

Closes #76
