### PR TITLE
Use dedicated contract models for module facades

### DIFF
--- a/docs/architecture/decisions/A003-use-dedicated-contract-models-for-public-module-facades.md
+++ b/docs/architecture/decisions/A003-use-dedicated-contract-models-for-public-module-facades.md
@@ -1,0 +1,50 @@
+# Use dedicated contract models for public module facades
+
+Date: 2026-03-10
+
+## Status
+
+Proposed
+
+## Context
+
+Kartoush is being built as a modular monolith with explicit module boundaries.
+As module facades are introduced, starting with the Customer module, we need a consistent way to define the public contract exposed by each module.
+
+There are several options:
+
+1. Expose domain objects directly from module facades
+2. Expose dedicated contract models with generic names such as `*Dto`
+3. Expose dedicated contract models with role-based names such as `*Request` and `*View`
+
+This decision affects:
+
+- how modules publish their public APIs
+- whether internal domain and persistence models remain encapsulated
+- naming consistency across current and future modules
+- how consuming modules and the `app` module interact with module boundaries
+
+The Customer facade is the first concrete case where this decision is needed.
+
+## Decision
+
+Kartoush module facades will expose dedicated contract models rather than domain or persistence types.
+
+The following rules apply:
+
+1. Domain models remain internal to their owning module
+2. Persistence entities, embeddables, repositories, and persistence mappers remain internal to their owning module
+3. Public module facades publish explicit contract models for inputs and outputs
+4. Input contract models should use role-based names such as `*Request`
+5. Output contract models should use role-based names such as `*View`
+6. Generic `*Dto` naming is avoided for public module facade contracts unless there is a strong reason to do otherwise
+
+Example:
+
+```java
+public interface CustomerFacade {
+
+    CustomerView createCustomer(CreateCustomerRequest request);
+
+    Optional<CustomerView> getCustomerById(CustomerId customerId);
+}


### PR DESCRIPTION
## Summary

Adds an architecture decision defining how Kartoush module facades publish
their public contracts.

## Decision

- Domain and persistence types remain internal to modules
- Public module facades expose dedicated contract models
- Inputs use role-based names such as *Request
- Outputs use role-based names such as *View

## Why

The Customer module introduces the first real facade boundary in Kartoush.
Documenting this pattern now ensures consistent module boundaries and
prevents leakage of persistence or domain types across modules.

## Impact

This decision guides:
- Customer facade implementation (#79)
- Future module facades
- Naming and packaging conventions for module contracts

## Tracking

Part of #75
Refs #79
Closes #84