### PR TITLE
Publish initial customer facade contract

### DIFF
--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
@@ -1,14 +1,14 @@
 package com.kartoush.customer.domain;
 
+import com.kartoush.platform.types.AddressId;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.types.CustomerStatus;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-
-import com.kartoush.platform.types.CustomerId;
-import com.kartoush.platform.types.CustomerStatus;
-import org.springframework.util.StringUtils;
 
 public final class Customer {
 
@@ -17,29 +17,43 @@ public final class Customer {
     private String email;
     private final String passwordHash;
     private final CustomerStatus status;
-    private final List<CustomerAddress> addresses;
+
+    private final List<CustomerAddress> addresses = new ArrayList<>();
 
     private final Instant createdAt;
     private Instant updatedAt;
 
-    public Customer(
+    private Customer(
             CustomerId id,
             CustomerProfile profile,
             String email,
             String passwordHash,
             CustomerStatus status,
-            List<CustomerAddress> addresses,
             Instant createdAt,
-            Instant updatedAt
-    ) {
-        this.id = Objects.requireNonNull(id, "id");
-        this.profile = Objects.requireNonNull(profile, "profile");
+            Instant updatedAt) {
+        this.id = Objects.requireNonNull(id);
+        this.profile = Objects.requireNonNull(profile);
         this.email = normalizeEmail(email);
-        this.passwordHash = requireNonBlank(passwordHash, "passwordHash");
-        this.status = Objects.requireNonNull(status, "status");
-        this.addresses = new ArrayList<>(Objects.requireNonNull(addresses, "addresses"));
-        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
-        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+        this.passwordHash = passwordHash;
+        this.status = Objects.requireNonNull(status);
+        this.createdAt = Objects.requireNonNull(createdAt);
+        this.updatedAt = Objects.requireNonNull(updatedAt);
+    }
+
+    public static Customer createNew(
+            CustomerId id,
+            CustomerProfile profile,
+            String email,
+            String passwordHash,
+            Instant now) {
+        return new Customer(
+                id,
+                profile,
+                email,
+                passwordHash,
+                CustomerStatus.ACTIVE,
+                now,
+                now);
     }
 
     public static Customer fromPersistence(
@@ -50,29 +64,17 @@ public final class Customer {
             CustomerStatus status,
             List<CustomerAddress> addresses,
             Instant createdAt,
-            Instant updatedAt
-    ) {
-        return new Customer(id, profile, email, passwordHash, status, addresses, createdAt, updatedAt);
-    }
-
-    public static Customer createNew(
-            CustomerId id,
-            CustomerProfile profile,
-            String email,
-            String passwordHash,
-            Instant now) {
-        Objects.requireNonNull(now, "now");
-
-        return new Customer(
+            Instant updatedAt) {
+        Customer customer = new Customer(
                 id,
                 profile,
                 email,
                 passwordHash,
-                CustomerStatus.ACTIVE,
-                List.of(),
-                now,
-                now
-        );
+                status,
+                createdAt,
+                updatedAt);
+        customer.addresses.addAll(addresses);
+        return customer;
     }
 
     public CustomerId getId() {
@@ -108,7 +110,7 @@ public final class Customer {
     }
 
     public void updateProfile(CustomerProfile newProfile, Instant now) {
-        this.profile = Objects.requireNonNull(newProfile, "newProfile");
+        this.profile = Objects.requireNonNull(newProfile);
         touch(now);
     }
 
@@ -117,26 +119,80 @@ public final class Customer {
         touch(now);
     }
 
-    public boolean matchesPasswordHash(String candidatePasswordHash) {
-        return StringUtils.hasText(candidatePasswordHash) && candidatePasswordHash.equals(this.passwordHash);
+    public void addAddress(final CustomerAddress address, final Instant now) {
+        Objects.requireNonNull(address, "address");
+
+        if (address.isDefaultShipping()) {
+            clearDefaultShipping(now);
+        }
+
+        if (address.isDefaultBilling()) {
+            clearDefaultBilling(now);
+        }
+
+        addresses.add(address);
+        touch(now);
+    }
+
+    public void setDefaultShippingAddress(final AddressId addressId, final Instant now) {
+        final CustomerAddress address = findAddress(addressId);
+
+        clearDefaultShipping(now);
+        address.setDefaultShipping(true, now);
+        touch(now);
+    }
+
+    public void setDefaultBillingAddress(final AddressId addressId, final Instant now) {
+        final CustomerAddress address = findAddress(addressId);
+
+        clearDefaultBilling(now);
+        address.setDefaultBilling(true, now);
+        touch(now);
+    }
+
+    public void removeAddress(final AddressId addressId, final Instant now) {
+        final boolean removed = addresses.removeIf(address -> address.getId().equals(addressId));
+
+        if (!removed) {
+            throw new IllegalArgumentException("address not found: " + addressId.value());
+        }
+
+        touch(now);
+    }
+
+    private void clearDefaultShipping(final Instant now) {
+        for (final CustomerAddress address : addresses) {
+            if (address.isDefaultShipping()) {
+                address.setDefaultShipping(false, now);
+            }
+        }
+    }
+
+    private void clearDefaultBilling(final Instant now) {
+        for (final CustomerAddress address : addresses) {
+            if (address.isDefaultBilling()) {
+                address.setDefaultBilling(false, now);
+            }
+        }
+    }
+
+    private CustomerAddress findAddress(final AddressId addressId) {
+        return addresses.stream()
+                .filter(address -> address.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("address not found: " + addressId.value()));
     }
 
     private void touch(Instant now) {
-        Objects.requireNonNull(now, "now");
         if (now.isAfter(updatedAt)) {
             updatedAt = now;
         }
     }
 
     private static String normalizeEmail(String value) {
-        String trimmed = requireNonBlank(value, "email");
-        return trimmed.toLowerCase(Locale.ROOT);
-    }
-
-    private static String requireNonBlank(String value, String fieldName) {
-        if (!StringUtils.hasText(value)) {
-            throw new IllegalArgumentException(fieldName + " is required");
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("email must not be blank");
         }
-        return value.trim();
+        return value.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/CustomerAddress.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/CustomerAddress.java
@@ -2,60 +2,174 @@ package com.kartoush.customer.domain;
 
 import com.kartoush.platform.types.AddressId;
 import com.kartoush.platform.types.AddressType;
-import org.springframework.util.StringUtils;
 
-public record CustomerAddress(
-        AddressId id,
-        Customer customer,
-        String label,
-        String line1,
-        String line2,
-        String city,
-        String stateOrProvince,
-        String postalCode,
-        String countryCode,      // ISO-3166-1 alpha-2 recommended, but Phase 1 keeps it simple
-        AddressType type,
-        boolean defaultShipping,
-        boolean defaultBilling
-) {
-    public CustomerAddress {
-        if (id != null && !StringUtils.hasText(id.value())){
-            throw new IllegalArgumentException("id must not be blank");
-        }
-        if (customer != null && customer.getId() != null && !StringUtils.hasText(customer.getId().value())) {
-            throw new IllegalArgumentException("customer must not be null");
-        }
-        if (!StringUtils.hasText(line1)) {
-            throw new IllegalArgumentException("line1 must not be blank");
-        }
-        if (!StringUtils.hasText(city)) {
-            throw new IllegalArgumentException("city must not be blank");
-        }
-        if (!StringUtils.hasText(stateOrProvince)) {
-            throw new IllegalArgumentException("stateOrProvince must not be blank");
-        }
-        if (!StringUtils.hasText(postalCode)) {
-            throw new IllegalArgumentException("postalCode must not be blank");
-        }
-        if (!StringUtils.hasText(countryCode)) {
-            throw new IllegalArgumentException("countryCode must not be blank");
-        }
-        if (type == null) {
-            throw new IllegalArgumentException("type must not be null");
-        }
+import java.time.Instant;
+import java.util.Objects;
+
+public final class CustomerAddress {
+
+    private final AddressId id;
+    private final String label;
+    private final String line1;
+    private final String line2;
+    private final String city;
+    private final String stateOrProvince;
+    private final String postalCode;
+    private final String countryCode;
+    private final AddressType type;
+
+    private boolean defaultShipping;
+    private boolean defaultBilling;
+
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    public CustomerAddress(
+            final AddressId id,
+            final String label,
+            final String line1,
+            final String line2,
+            final String city,
+            final String stateOrProvince,
+            final String postalCode,
+            final String countryCode,
+            final AddressType type,
+            final boolean defaultShipping,
+            final boolean defaultBilling,
+            final Instant createdAt,
+            final Instant updatedAt
+    ) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.label = normalizeOptional(label);
+        this.line1 = requireNonBlank(line1, "line1");
+        this.line2 = normalizeOptional(line2);
+        this.city = requireNonBlank(city, "city");
+        this.stateOrProvince = requireNonBlank(stateOrProvince, "stateOrProvince");
+        this.postalCode = requireNonBlank(postalCode, "postalCode");
+        this.countryCode = requireNonBlank(countryCode, "countryCode");
+        this.type = Objects.requireNonNull(type, "type");
+        this.defaultShipping = defaultShipping;
+        this.defaultBilling = defaultBilling;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
     }
 
-    public CustomerAddress withDefaultShipping(boolean value) {
+    public static CustomerAddress createNew(
+            final AddressId id,
+            final String label,
+            final String line1,
+            final String line2,
+            final String city,
+            final String stateOrProvince,
+            final String postalCode,
+            final String countryCode,
+            final AddressType type,
+            final boolean defaultShipping,
+            final boolean defaultBilling,
+            final Instant now
+    ) {
+        Objects.requireNonNull(now, "now");
+
         return new CustomerAddress(
-                id, customer, label, line1, line2, city, stateOrProvince, postalCode, countryCode, type,
-                value, defaultBilling
+                id,
+                label,
+                line1,
+                line2,
+                city,
+                stateOrProvince,
+                postalCode,
+                countryCode,
+                type,
+                defaultShipping,
+                defaultBilling,
+                now,
+                now
         );
     }
 
-    public CustomerAddress withDefaultBilling(boolean value) {
-        return new CustomerAddress(
-                id, customer, label, line1, line2, city, stateOrProvince, postalCode, countryCode, type,
-                defaultShipping, value
-        );
+    public AddressId getId() {
+        return id;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getLine1() {
+        return line1;
+    }
+
+    public String getLine2() {
+        return line2;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getStateOrProvince() {
+        return stateOrProvince;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public AddressType getType() {
+        return type;
+    }
+
+    public boolean isDefaultShipping() {
+        return defaultShipping;
+    }
+
+    public boolean isDefaultBilling() {
+        return defaultBilling;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setDefaultShipping(final boolean value, final Instant now) {
+        this.defaultShipping = value;
+        touch(now);
+    }
+
+    public void setDefaultBilling(final boolean value, final Instant now) {
+        this.defaultBilling = value;
+        touch(now);
+    }
+
+    private void touch(final Instant now) {
+        Objects.requireNonNull(now, "now");
+
+        if (now.isAfter(updatedAt)) {
+            updatedAt = now;
+        }
+    }
+
+    private static String requireNonBlank(final String value, final String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+
+        return value.trim();
+    }
+
+    private static String normalizeOptional(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return value.trim();
     }
 }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/CustomerProfile.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/CustomerProfile.java
@@ -1,17 +1,15 @@
 package com.kartoush.customer.domain;
 
-import org.springframework.util.StringUtils;
-
 public record CustomerProfile(
         String firstName,
         String lastName,
         String phoneNumber
 ) {
     public CustomerProfile {
-        if (!StringUtils.hasText(firstName)) {
+        if (firstName == null || firstName.isBlank()){
             throw new IllegalArgumentException("firstName must not be blank");
         }
-        if (!StringUtils.hasText(lastName)) {
+        if (lastName == null || lastName.isBlank()){
             throw new IllegalArgumentException("lastName must not be blank");
         }
     }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/CustomerFacade.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/CustomerFacade.java
@@ -1,0 +1,14 @@
+package com.kartoush.customer.facade;
+
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.facade.model.CustomerView;
+import com.kartoush.platform.types.CustomerId;
+
+import java.util.Optional;
+
+public interface CustomerFacade {
+
+    CustomerView createCustomer(CreateCustomerRequest request);
+
+    Optional<CustomerView> getCustomerById(CustomerId customerId);
+}

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
@@ -1,0 +1,9 @@
+package com.kartoush.customer.facade.model;
+
+public record CreateCustomerRequest(
+        String email,
+        String password,
+        String phoneNumber,
+        String firstName,
+        String lastName) {
+}

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CustomerView.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CustomerView.java
@@ -1,0 +1,18 @@
+package com.kartoush.customer.facade.model;
+
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.types.CustomerStatus;
+
+public record CustomerView(
+        CustomerId customerId,
+        String email,
+        String phoneNumber,
+        String firstName,
+        String lastName,
+        CustomerStatus status
+) {
+
+    public boolean isActive () {
+        return status == CustomerStatus.ACTIVE;
+    }
+}

--- a/kartoush/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -1,0 +1,85 @@
+package com.kartoush.customer.internal.facade;
+
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.domain.CustomerProfile;
+import com.kartoush.customer.facade.CustomerFacade;
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.facade.model.CustomerView;
+import com.kartoush.customer.internal.validation.CreateCustomerRequestValidator;
+import com.kartoush.customer.persistence.mapper.CustomerMapper;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import com.kartoush.customer.persistence.repository.CustomerRepository;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.ulid.UlidGenerator;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+public class DefaultCustomerFacade implements CustomerFacade {
+
+    /* TODO(#82): Move credential handling to authentication module.
+        Customer should not own passwordHash long-term. */
+    private static final String TEMPORARY_PASSWORD_HASH = "TEMPORARY_PASSWORD_HASH";
+
+    private final CustomerRepository customerRepository;
+    private final CustomerMapper customerMapper;
+    private final UlidGenerator ulidGenerator;
+    private final CreateCustomerRequestValidator validator;
+
+    public DefaultCustomerFacade(
+            final CustomerRepository customerRepository,
+            final CustomerMapper customerMapper,
+            final UlidGenerator ulidGenerator,
+            final CreateCustomerRequestValidator validator) {
+        this.customerRepository = customerRepository;
+        this.customerMapper = customerMapper;
+        this.ulidGenerator = ulidGenerator;
+        this.validator = validator;
+    }
+
+    @Override
+    public CustomerView createCustomer(final CreateCustomerRequest request) {
+        validator.validate(request);
+
+        CustomerProfile profile = CustomerProfile.of(
+                request.firstName(),
+                request.lastName(),
+                request.phoneNumber());
+
+        final Customer customer = Customer.createNew(
+                CustomerId.newId(ulidGenerator),
+                profile,
+                request.email(),
+                TEMPORARY_PASSWORD_HASH,
+                Instant.now());
+
+        final var savedCustomer = saveCustomer(customer);
+
+        return toCustomerView(savedCustomer);
+    }
+
+    @Override
+    public Optional<CustomerView> getCustomerById(final CustomerId customerId) {
+        return customerRepository.findById(
+                CustomerIdEmbeddable.from(customerId))
+                .map(customerMapper::toDomain)
+                .map(this::toCustomerView);
+    }
+
+    private CustomerView toCustomerView(final Customer customer) {
+        return new CustomerView(
+                customer.getId(),
+                customer.getEmail(),
+                customer.getProfile().phoneNumber(),
+                customer.getProfile().firstName(),
+                customer.getProfile().lastName(),
+                customer.getStatus());
+    }
+
+    private Customer saveCustomer(final Customer customer) {
+        final var savedEntity = customerRepository.save(customerMapper.toEntity(customer));
+        return customerMapper.toDomain(savedEntity);
+    }
+}

--- a/kartoush/customer/src/main/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidator.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidator.java
@@ -1,0 +1,91 @@
+package com.kartoush.customer.internal.validation;
+
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.platform.validation.RequestValidationException;
+import com.kartoush.platform.validation.ValidationError;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CreateCustomerRequestValidator {
+
+    private static final String VALIDATION_MESSAGE = "Request validation failed";
+    private static final String PHONE_NUMBER_PATTERN = "^\\+?[0-9]{7,15}$";
+
+    public void validate(final CreateCustomerRequest request) {
+        final List<ValidationError> errors = new ArrayList<>();
+
+        validateRequest(request, errors);
+
+        if (request == null) {
+            throwIfErrors(errors);
+            return;
+        }
+
+        validateEmail(request, errors);
+        validateFirstName(request, errors);
+        validateLastName(request, errors);
+        validatePhoneNumber(request, errors);
+
+        throwIfErrors(errors);
+    }
+
+    private void validateRequest(final CreateCustomerRequest request, final List<ValidationError> errors) {
+        if (request == null) {
+            errors.add(new ValidationError("request", "request must not be null"));
+        }
+    }
+
+    private void validateEmail(final CreateCustomerRequest request, final List<ValidationError> errors) {
+        if (request.email() == null || request.email().isBlank()) {
+            errors.add(new ValidationError("email", "email must not be blank"));
+            return;
+        }
+
+        if (!looksLikeEmail(request.email())) {
+            errors.add(new ValidationError("email", "email must be a valid email address"));
+        }
+    }
+
+    private void validateFirstName(final CreateCustomerRequest request, final List<ValidationError> errors) {
+        requireNonBlank(request.firstName(), "firstName", errors);
+    }
+
+    private void validateLastName(final CreateCustomerRequest request, final List<ValidationError> errors) {
+        requireNonBlank(request.lastName(), "lastName", errors);
+    }
+
+    private void validatePhoneNumber(final CreateCustomerRequest request, final List<ValidationError> errors) {
+        final String phoneNumber = request.phoneNumber();
+
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            return;
+        }
+
+        if (!phoneNumber.matches(PHONE_NUMBER_PATTERN)) {
+            errors.add(new ValidationError(
+                    "phoneNumber",
+                    "phoneNumber must contain only digits and may optionally start with +"));
+        }
+    }
+
+    private void requireNonBlank(final String value, final String field, final List<ValidationError> errors) {
+        if (value == null || value.isBlank()) {
+            errors.add(new ValidationError(field, field + " must not be blank"));
+        }
+    }
+
+    private boolean looksLikeEmail(final String email) {
+        final int atIndex = email.indexOf('@');
+
+        return atIndex > 0 && atIndex < email.length() - 1;
+    }
+
+    private void throwIfErrors(final List<ValidationError> errors) {
+        if (!errors.isEmpty()) {
+            throw new RequestValidationException(VALIDATION_MESSAGE, errors);
+        }
+    }
+}

--- a/kartoush/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -1,0 +1,95 @@
+package com.kartoush.customer.internal.facade;
+
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.domain.CustomerProfile;
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.facade.model.CustomerView;
+import com.kartoush.customer.internal.validation.CreateCustomerRequestValidator;
+import com.kartoush.customer.persistence.entity.CustomerEntity;
+import com.kartoush.customer.persistence.mapper.CustomerMapper;
+import com.kartoush.customer.persistence.repository.CustomerRepository;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.types.CustomerStatus;
+import com.kartoush.platform.ulid.UlidGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultCustomerFacadeTest {
+
+    private static final String EMAIL = "jack@kartoush.com";
+    private static final String PASSWORD = "password";
+    private static final String PHONE_NUMBER = "3125882300";
+    private static final String FIRST_NAME = "Jack";
+    private static final String LAST_NAME = "Kartoush";
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @Mock
+    private CustomerMapper customerMapper;
+
+    @Mock
+    private UlidGenerator ulidGenerator;
+
+    @Mock
+    private CreateCustomerRequestValidator validator;
+
+    @InjectMocks
+    private DefaultCustomerFacade facade;
+
+    @Test
+    void shouldCreateCustomer() {
+
+        // given
+        final var request = new CreateCustomerRequest(
+                EMAIL,
+                PASSWORD,
+                PHONE_NUMBER,
+                FIRST_NAME,
+                LAST_NAME);
+
+        final var customerId = CustomerId.of("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        final var profile = CustomerProfile.of(FIRST_NAME, LAST_NAME, PHONE_NUMBER);
+        final var saved = Customer.createNew(
+                customerId,
+                profile,
+                EMAIL,
+                PASSWORD,
+                Instant.parse("2026-03-10T12:00:00Z")
+        );
+
+        final var view = new CustomerView(
+                customerId,
+                EMAIL,
+                PHONE_NUMBER,
+                FIRST_NAME,
+                LAST_NAME,
+                CustomerStatus.ACTIVE
+        );
+
+        // when
+        when(ulidGenerator.next()).thenReturn(customerId.value());
+        when(customerMapper.toEntity(any())).thenReturn(mock(CustomerEntity.class));
+        when(customerRepository.save(any())).thenReturn(mock(CustomerEntity.class));
+        when(customerMapper.toDomain(any())).thenReturn(saved);
+
+        final var result = facade.createCustomer(request);
+
+        // then
+        assertThat(result).isEqualTo(view);
+        verify(validator).validate(request);
+        verify(customerRepository).save(any());
+    }
+}

--- a/kartoush/customer/src/test/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidatorTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidatorTest.java
@@ -1,0 +1,100 @@
+package com.kartoush.customer.internal.validation;
+
+
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.platform.validation.RequestValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CreateCustomerRequestValidatorTest {
+
+    private static final String EMAIL = "jack@kartoush.com";
+    private static final String INVALID_EMAIL = "@";
+    private static final String PASSWORD = "password";
+    private static final String PHONE_NUMBER = "3125882300";
+    private static final String INVALID_PHONE_NUMBER = "abc-123";
+    private static final String FIRST_NAME = "Jack";
+    private static final String LAST_NAME = "Kartoush";
+
+    private final CreateCustomerRequestValidator validator = new CreateCustomerRequestValidator();
+
+    @Test
+    @DisplayName("Should reject null request")
+    void shouldRejectNullRequest() {
+        // then
+        assertThatThrownBy(() -> validator.validate(null))
+                .isInstanceOf(RequestValidationException.class);
+    }
+
+    @Test
+    @DisplayName("Should allow a blank phone number")
+    void shouldAllowBlankPhoneNumber() {
+        // given
+        final var request = new CreateCustomerRequest(
+                EMAIL,
+                PASSWORD,
+                " ",
+                FIRST_NAME,
+                LAST_NAME);
+
+        // then
+        assertThatCode(() ->
+                validator.validate(request))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Should reject an invalid phone number")
+    void shouldRejectInvalidPhoneNumberWhenPresent() {
+
+        // given
+        final var request = new CreateCustomerRequest(
+                EMAIL,
+                PASSWORD,
+                INVALID_PHONE_NUMBER,
+                FIRST_NAME,
+                LAST_NAME);
+
+        // then
+        assertThatThrownBy(() ->
+                validator.validate(request))
+                .isInstanceOf(RequestValidationException.class);
+    }
+
+    @Test
+    @DisplayName("Should reject invalid email")
+    void shouldRejectInvalidEmailWhenPresent() {
+
+        // given
+        final var request = new CreateCustomerRequest(
+                INVALID_EMAIL,
+                PASSWORD,
+                PHONE_NUMBER,
+                FIRST_NAME,
+                LAST_NAME);
+
+        // then
+        assertThatThrownBy(() ->
+                validator.validate(request))
+                .isInstanceOf(RequestValidationException.class);
+    }
+
+    @Test
+    @DisplayName("Should reject missing first and last name")
+    void shouldRejectMissingFirstAndLastName() {
+        // given
+        final var request = new CreateCustomerRequest(
+                EMAIL,
+                PASSWORD,
+                PHONE_NUMBER,
+                "",
+                "");
+
+        // then
+        assertThatThrownBy(() -> validator.validate(request))
+                .isInstanceOf(RequestValidationException.class);
+    }
+}

--- a/kartoush/gradle/libs.versions.toml
+++ b/kartoush/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ springDependencyManagement = { id = "io.spring.dependency-management", version.r
 [libraries]
 springBootBom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBootVersion" }
 
+springBootValidation = { module = "org.springframework.boot:spring-boot-starter-validation", version.ref = "springBootVersion" }
+
 springBootStarterTest = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBootVersion" }
 springBootStarterDataJpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBootVersion" }
 springBootStarterFlyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }

--- a/kartoush/platform-types/src/main/java/com/kartoush/platform/types/AddressId.java
+++ b/kartoush/platform-types/src/main/java/com/kartoush/platform/types/AddressId.java
@@ -25,4 +25,16 @@ public final class AddressId {
     public String value() {
         return value;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressId addressId = (AddressId) o;
+        return Objects.equals(value, addressId.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
 }

--- a/kartoush/platform-types/src/main/java/com/kartoush/platform/validation/RequestValidationException.java
+++ b/kartoush/platform-types/src/main/java/com/kartoush/platform/validation/RequestValidationException.java
@@ -1,0 +1,17 @@
+package com.kartoush.platform.validation;
+
+import java.util.List;
+
+public class RequestValidationException extends RuntimeException {
+
+    private final List<ValidationError> errors;
+
+    public RequestValidationException(final String message, final List<ValidationError> errors) {
+        super(message);
+        this.errors = List.copyOf(errors);
+    }
+
+    public List<ValidationError> getErrors() {
+        return errors;
+    }
+}

--- a/kartoush/platform-types/src/main/java/com/kartoush/platform/validation/ValidationError.java
+++ b/kartoush/platform-types/src/main/java/com/kartoush/platform/validation/ValidationError.java
@@ -1,0 +1,6 @@
+package com.kartoush.platform.validation;
+
+public record ValidationError(
+        String field,
+        String message) {
+}


### PR DESCRIPTION
## Summary

Publishes the initial customer module facade contract and implementation.

This PR introduces a public customer facade boundary with request and view models, request validation, and unit tests. It also refines the customer domain model to better support the facade and shared validation handling.

## Changes

### Customer facade
- add `CustomerFacade`
- add `CreateCustomerRequest`
- add `CustomerView`
- add `DefaultCustomerFacade`

### Validation
- add `CreateCustomerRequestValidator`
- add shared platform validation types:
  - `ValidationError`
  - `RequestValidationException`

### Domain updates
- update `Customer`
- update `CustomerAddress`
- update `CustomerProfile`

### Tests
- add `DefaultCustomerFacadeTest`
- add `CreateCustomerRequestValidatorTest`

## Notes

- `CustomerView` mapping remains inside the facade rather than the persistence mapper to keep persistence mapping and facade contract mapping separate
- `passwordHash` remains temporarily in the customer domain with a placeholder value for now
- credential management and real password hashing will move to the future authentication module

## Why

This establishes the first public module boundary for the customer module and keeps the next API work focused on the web layer instead of mixing module contract design with controller concerns.

## Tracking

Closes #79  
Part of #75  
Refs #86