### PR TITLE
feat(customer): enforce lifecycle transitions and add inactive status

### DIFF
--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
@@ -1,6 +1,7 @@
 package com.kartoush.customer.domain;
 
 import com.kartoush.customer.exception.CustomerAddressNotFoundException;
+import com.kartoush.customer.exception.InvalidCustomerStatusTransitionException;
 import com.kartoush.platform.types.AddressId;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
@@ -46,6 +47,23 @@ public final class Customer {
                 CustomerStatus.PENDING);
     }
 
+    public static Customer fromPersistence(
+        CustomerId id,
+        CustomerProfile profile,
+        Email email,
+        String passwordHash,
+        CustomerStatus status,
+        List<CustomerAddress> addresses) {
+        final Customer customer = new Customer(
+            id,
+            profile,
+            email,
+            passwordHash,
+            status);
+        customer.addresses.addAll(Objects.requireNonNull(addresses, "Addresses must not be null"));
+        return customer;
+    }
+
     public void updateDetails(final CustomerProfile newProfile, final Email newEmail) {
         assertNotDeleted();
         this.profile = Objects.requireNonNull(newProfile, "Profile must not be null");
@@ -60,23 +78,6 @@ public final class Customer {
         this.status = CustomerStatus.DELETED;
     }
 
-    public static Customer fromPersistence(
-            CustomerId id,
-            CustomerProfile profile,
-            Email email,
-            String passwordHash,
-            CustomerStatus status,
-            List<CustomerAddress> addresses) {
-        final Customer customer = new Customer(
-                id,
-                profile,
-                email,
-                passwordHash,
-                status);
-        customer.addresses.addAll(Objects.requireNonNull(addresses, "Addresses must not be null"));
-        return customer;
-    }
-
     public void activate() {
         if(status == CustomerStatus.PENDING) {
             status = CustomerStatus.ACTIVE;
@@ -87,30 +88,6 @@ public final class Customer {
         if (status == CustomerStatus.DELETED) {
             status = CustomerStatus.ACTIVE;
         }
-    }
-
-    public CustomerId getId() {
-        return id;
-    }
-
-    public CustomerProfile getProfile() {
-        return profile;
-    }
-
-    public Email getEmail() {
-        return email;
-    }
-
-    public String getPasswordHash() {
-        return passwordHash;
-    }
-
-    public CustomerStatus getStatus() {
-        return status;
-    }
-
-    public List<CustomerAddress> getAddresses() {
-        return List.copyOf(addresses);
     }
 
     public void addAddress(final CustomerAddress address) {
@@ -151,6 +128,54 @@ public final class Customer {
         if (!removed) {
             throw new CustomerAddressNotFoundException(addressId.value());
         }
+    }
+
+    public void transitionTo(final CustomerStatus targetStatus)
+    {
+        if (!isValidTransition(this.status, targetStatus)) {
+            throw new InvalidCustomerStatusTransitionException(this.status, targetStatus);
+        }
+
+        this.status = targetStatus;
+    }
+
+    public CustomerId getId() {
+        return id;
+    }
+
+    public CustomerProfile getProfile() {
+        return profile;
+    }
+
+    public Email getEmail() {
+        return email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public CustomerStatus getStatus() {
+        return status;
+    }
+
+    public List<CustomerAddress> getAddresses() {
+        return List.copyOf(addresses);
+    }
+
+    private boolean isValidTransition(final CustomerStatus currentStatus,
+                                      final CustomerStatus targetStatus)
+    {
+        return switch (currentStatus) {
+            case PENDING -> targetStatus == CustomerStatus.ACTIVE
+                || targetStatus == CustomerStatus.INACTIVE
+                || targetStatus == CustomerStatus.DELETED;
+            case ACTIVE -> targetStatus == CustomerStatus.INACTIVE
+                || targetStatus == CustomerStatus.DELETED;
+            case INACTIVE -> targetStatus == CustomerStatus.ACTIVE
+                || targetStatus == CustomerStatus.DELETED;
+            case DELETED -> false;
+        };
     }
 
     private void clearDefaultShipping() {

--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
@@ -14,37 +14,41 @@ import java.util.Objects;
 public final class Customer {
 
     private final CustomerId id;
+
     private CustomerProfile profile;
+
     private Email email;
+
     private final String passwordHash;
+
     private CustomerStatus status;
 
     private final List<CustomerAddress> addresses = new ArrayList<>();
 
     private Customer(
-            CustomerId id,
-            CustomerProfile profile,
-            Email email,
-            String passwordHash,
-            CustomerStatus status) {
+        CustomerId id,
+        CustomerProfile profile,
+        Email email,
+        String passwordHash,
+        CustomerStatus status) {
         this.id = Objects.requireNonNull(id, "ID must not be null");
-        this.profile = Objects.requireNonNull(profile,  "Profile must not be null");
+        this.profile = Objects.requireNonNull(profile, "Profile must not be null");
         this.email = Objects.requireNonNull(email, "Email must not be null");
         this.passwordHash = Objects.requireNonNull(passwordHash, "passwordHash must not be null");
         this.status = Objects.requireNonNull(status, "Status must not be null");
     }
 
     public static Customer createNew(
-            CustomerId id,
-            CustomerProfile profile,
-            Email email,
-            String passwordHash) {
+        CustomerId id,
+        CustomerProfile profile,
+        Email email,
+        String passwordHash) {
         return new Customer(
-                id,
-                profile,
-                email,
-                passwordHash,
-                CustomerStatus.PENDING);
+            id,
+            profile,
+            email,
+            passwordHash,
+            CustomerStatus.PENDING);
     }
 
     public static Customer fromPersistence(
@@ -70,24 +74,24 @@ public final class Customer {
         this.email = newEmail;
     }
 
-    public void markDeleted() {
-        if(this.status == CustomerStatus.DELETED) {
-            return;
-        }
-
-        this.status = CustomerStatus.DELETED;
+    public void softDelete() {
+        transitionTo(CustomerStatus.DELETED);
     }
 
     public void activate() {
-        if(status == CustomerStatus.PENDING) {
-            status = CustomerStatus.ACTIVE;
-        }
+        transitionTo(CustomerStatus.ACTIVE);
+    }
+
+    public void inactivate() {
+        transitionTo(CustomerStatus.INACTIVE);
     }
 
     public void reactivate() {
-        if (status == CustomerStatus.DELETED) {
-            status = CustomerStatus.ACTIVE;
+        if (this.status != CustomerStatus.INACTIVE) {
+            throw new InvalidCustomerStatusTransitionException(this.status, CustomerStatus.ACTIVE);
         }
+
+        transitionTo(CustomerStatus.ACTIVE);
     }
 
     public void addAddress(final CustomerAddress address) {
@@ -130,8 +134,11 @@ public final class Customer {
         }
     }
 
-    public void transitionTo(final CustomerStatus targetStatus)
-    {
+    public void transitionTo(final CustomerStatus targetStatus) throws InvalidCustomerStatusTransitionException {
+        if (this.status == targetStatus) {
+            return;
+        }
+
         if (!isValidTransition(this.status, targetStatus)) {
             throw new InvalidCustomerStatusTransitionException(this.status, targetStatus);
         }
@@ -164,8 +171,7 @@ public final class Customer {
     }
 
     private boolean isValidTransition(final CustomerStatus currentStatus,
-                                      final CustomerStatus targetStatus)
-    {
+                                      final CustomerStatus targetStatus) {
         return switch (currentStatus) {
             case PENDING -> targetStatus == CustomerStatus.ACTIVE
                 || targetStatus == CustomerStatus.INACTIVE
@@ -196,9 +202,9 @@ public final class Customer {
 
     private CustomerAddress findAddress(final AddressId addressId) {
         return addresses.stream()
-                .filter(address -> address.getId().equals(addressId))
-                .findFirst()
-                .orElseThrow(() -> new CustomerAddressNotFoundException(addressId.value()));
+            .filter(address -> address.getId().equals(addressId))
+            .findFirst()
+            .orElseThrow(() -> new CustomerAddressNotFoundException(addressId.value()));
     }
 
     private void assertNotDeleted() {

--- a/kartoush/customer/src/main/java/com/kartoush/customer/exception/InvalidCustomerStatusTransitionException.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/exception/InvalidCustomerStatusTransitionException.java
@@ -1,0 +1,11 @@
+package com.kartoush.customer.exception;
+
+import com.kartoush.platform.types.CustomerStatus;
+
+public class InvalidCustomerStatusTransitionException extends RuntimeException
+{
+    public InvalidCustomerStatusTransitionException(final CustomerStatus currentStatus,
+                                                    final CustomerStatus targetStatus) {
+        super("Invalid customer status transition from %s to %s".formatted(currentStatus, targetStatus));
+    }
+}

--- a/kartoush/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
@@ -112,7 +112,7 @@ public class DefaultCustomerService implements CustomerService
 
         final Customer customer = customerMapper.toDomain(customerEntity);
 
-        customer.markDeleted();
+        customer.softDelete();
 
         customerMapper.updateEntity(customer, customerEntity);
 

--- a/kartoush/customer/src/main/resources/db/migration/V6__update_customer_status_constraint.sql
+++ b/kartoush/customer/src/main/resources/db/migration/V6__update_customer_status_constraint.sql
@@ -1,0 +1,6 @@
+ALTER TABLE customer
+    DROP CONSTRAINT chk_customer_status;
+
+ALTER TABLE customer
+    ADD CONSTRAINT chk_customer_status
+        CHECK (status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'DELETED'));

--- a/kartoush/customer/src/test/java/com/kartoush/customer/domain/CustomerTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/domain/CustomerTest.java
@@ -1,79 +1,109 @@
 package com.kartoush.customer.domain;
 
 import com.kartoush.customer.exception.CustomerAddressNotFoundException;
+import com.kartoush.customer.exception.InvalidCustomerStatusTransitionException;
 import com.kartoush.platform.types.AddressId;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
 import com.kartoush.platform.types.exception.InvalidEmailException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class CustomerTest
-{
+class CustomerTest {
     private static final String CUSTOMER_ID_VALUE = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+
     private static final String ADDRESS_ID_VALUE_ONE = "01BX5ZZKBKACTAV9WEVGEMMVRZ";
+
     private static final String ADDRESS_ID_VALUE_TWO = "01BX5ZZKBKACTAV9WEVGEMMVS0";
+
     private static final String UNKNOWN_ADDRESS_ID_VALUE = "01BX5ZZKBKACTAV9WEVGEMMVS1";
 
     private static final Email EMAIL = new Email("jack@kartoush.test");
+
     private static final String EMAIL_WITH_MIXED_CASE_AND_SPACES = "  Jack@Kartoush.Test  ";
+
     private static final Email NORMALIZED_EMAIL = new Email("jack@kartoush.test");
+
     private static final Email UPDATED_EMAIL = new Email("updated@kartoush.test");
+
     private static final String BLANK_EMAIL = "   ";
 
     private static final String PASSWORD_HASH = "hashed-password";
+
     private static final String FIRST_NAME = "Jack";
+
     private static final String LAST_NAME = "Kartoush";
+
     private static final String PHONE_NUMBER = "3125550100";
 
     private static final String UPDATED_FIRST_NAME = "John";
+
     private static final String UPDATED_LAST_NAME = "Customer";
+
     private static final String UPDATED_PHONE_NUMBER = "6305550100";
 
     private static final String CUSTOMER_DELETED_MESSAGE = "customer is deleted";
+
     private static final String EMAIL_BLANK_MESSAGE = "Email must not be blank";
+
     private static final String EMAIL_NULL_MESSAGE = "Email must not be null";
+
     private static final String PROFILE_NULL_MESSAGE = "Profile must not be null";
+
     private static final String PASSWORD_HASH_NULL_MESSAGE = "passwordHash must not be null";
+
     private static final String ADDRESSES_NULL_MESSAGE = "Addresses must not be null";
+
     private static final String ADDRESS_NOT_FOUND_PREFIX = "Address not found for id: ";
 
     private static final CustomerId CUSTOMER_ID = CustomerId.of(CUSTOMER_ID_VALUE);
+
     private static final AddressId ADDRESS_ID_ONE = AddressId.of(ADDRESS_ID_VALUE_ONE);
+
     private static final AddressId ADDRESS_ID_TWO = AddressId.of(ADDRESS_ID_VALUE_TWO);
+
     private static final AddressId UNKNOWN_ADDRESS_ID = AddressId.of(UNKNOWN_ADDRESS_ID_VALUE);
 
     private static final String ADDRESS_LABEL = "Home";
+
     private static final String ADDRESS_LINE1 = "123 Test Street";
+
     private static final String ADDRESS_LINE2 = "Unit 4B";
+
     private static final String ADDRESS_CITY = "Chicago";
+
     private static final String ADDRESS_STATE = "IL";
+
     private static final String ADDRESS_POSTAL_CODE = "60601";
+
     private static final String ADDRESS_COUNTRY_CODE = "US";
 
+    private static final String INVALID_CUSTOMER_STATE_TRANSITION_MESSAGE = "Invalid customer status transition from %s to %s";
+
     private static final CustomerProfile PROFILE = new CustomerProfile(
-            FIRST_NAME,
-            LAST_NAME,
-            PHONE_NUMBER);
+        FIRST_NAME,
+        LAST_NAME,
+        PHONE_NUMBER);
 
     private static final CustomerProfile UPDATED_PROFILE = new CustomerProfile(
-            UPDATED_FIRST_NAME,
-            UPDATED_LAST_NAME,
-            UPDATED_PHONE_NUMBER);
+        UPDATED_FIRST_NAME,
+        UPDATED_LAST_NAME,
+        UPDATED_PHONE_NUMBER);
 
     @Test
     void shouldCreateNewCustomer() {
         // when
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createNewCustomer();
 
         // then
         assertThat(customer.getId()).isEqualTo(CUSTOMER_ID);
@@ -88,10 +118,10 @@ class CustomerTest
     void shouldNormalizeEmailWhenCreatingCustomer() {
         // when
         final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                new Email(EMAIL_WITH_MIXED_CASE_AND_SPACES),
-                PASSWORD_HASH);
+            CUSTOMER_ID,
+            PROFILE,
+            new Email(EMAIL_WITH_MIXED_CASE_AND_SPACES),
+            PASSWORD_HASH);
 
         // then
         assertThat(customer.getEmail()).isEqualTo(NORMALIZED_EMAIL);
@@ -100,33 +130,29 @@ class CustomerTest
     @Test
     void shouldThrowWhenCreatingCustomerWithBlankEmail() {
         assertThatThrownBy(() -> Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                new Email(BLANK_EMAIL),
-                PASSWORD_HASH))
-                .isInstanceOf(InvalidEmailException.class)
-                .hasMessage(EMAIL_BLANK_MESSAGE);
+            CUSTOMER_ID,
+            PROFILE,
+            new Email(BLANK_EMAIL),
+            PASSWORD_HASH))
+            .isInstanceOf(InvalidEmailException.class)
+            .hasMessage(EMAIL_BLANK_MESSAGE);
     }
 
     @Test
     void shouldThrowWhenCreatingCustomerWithNullPasswordHash() {
         assertThatThrownBy(() -> Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                null))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage(PASSWORD_HASH_NULL_MESSAGE);
+            CUSTOMER_ID,
+            PROFILE,
+            EMAIL,
+            null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(PASSWORD_HASH_NULL_MESSAGE);
     }
 
     @Test
     void shouldUpdateDetails() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createNewCustomer();
 
         // when
         customer.updateDetails(UPDATED_PROFILE, UPDATED_EMAIL);
@@ -139,11 +165,7 @@ class CustomerTest
     @Test
     void shouldNormalizeEmailWhenUpdatingDetails() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createNewCustomer();
 
         // when
         customer.updateDetails(UPDATED_PROFILE, new Email("  Updated@Kartoush.Test  "));
@@ -155,78 +177,36 @@ class CustomerTest
     @Test
     void shouldThrowWhenUpdatingDetailsWithNullProfile() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createNewCustomer();
 
         // when / then
-        assertThatThrownBy(() -> customer.updateDetails(null, UPDATED_EMAIL))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage(PROFILE_NULL_MESSAGE);
+        assertThatThrownBy(() -> customer.updateDetails(
+            null,
+            UPDATED_EMAIL))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(PROFILE_NULL_MESSAGE);
     }
 
     @Test
     void shouldThrowWhenUpdatingDetailsWithBlankEmail() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createNewCustomer();
 
         // when / then
-        assertThatThrownBy(() -> customer.updateDetails(UPDATED_PROFILE, new Email(BLANK_EMAIL)))
-                .isInstanceOf(InvalidEmailException.class)
-                .hasMessage(EMAIL_BLANK_MESSAGE);
+        assertThatThrownBy(() -> customer.updateDetails(
+            UPDATED_PROFILE,
+            new Email(BLANK_EMAIL)))
+            .isInstanceOf(InvalidEmailException.class)
+            .hasMessage(EMAIL_BLANK_MESSAGE);
     }
 
     @Test
-    void shouldUpdateStatus() {
+    void shouldKeepDeletedCustomerDeletedWhenSoftDeleted() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when
-        customer.markDeleted();
-
-        // then
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
-    }
-
-    @Test
-    void shouldMarkCustomerDeleted() {
-        // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
-
-        // when
-        customer.markDeleted();
-
-        // then
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
-    }
-
-    @Test
-    void shouldKeepDeletedCustomerDeletedWhenMarkedDeletedAgain() {
-        // given
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.DELETED,
-                List.of());
-
-        // when
-        customer.markDeleted();
+        customer.softDelete();
 
         // then
         assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
@@ -235,37 +215,34 @@ class CustomerTest
     @Test
     void shouldThrowWhenUpdatingDetailsForDeletedCustomer() {
         // given
-        final Customer customer = deletedCustomer();
+        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when / then
         assertThatThrownBy(() -> customer.updateDetails(UPDATED_PROFILE, UPDATED_EMAIL))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(CUSTOMER_DELETED_MESSAGE);
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(CUSTOMER_DELETED_MESSAGE);
     }
 
     @Test
     void shouldThrowWhenCreatingCustomerWithNullEmail() {
         assertThatThrownBy(() -> Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                null,
-                PASSWORD_HASH))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage(EMAIL_NULL_MESSAGE);
+            CUSTOMER_ID,
+            PROFILE,
+            null,
+            PASSWORD_HASH))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(EMAIL_NULL_MESSAGE);
     }
 
     @Test
     void shouldAddAddress() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
-        final CustomerAddress address = address(
-                ADDRESS_ID_ONE,
-                false,
-                false);
+        final Customer customer = createNewCustomer();
+
+        final CustomerAddress address = createAddress(
+            ADDRESS_ID_ONE,
+            false,
+            false);
 
         // when
         customer.addAddress(address);
@@ -277,41 +254,32 @@ class CustomerTest
     @Test
     void shouldThrowWhenAddingNullAddress() {
         // given
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
+        final Customer customer = createNewCustomer();
 
         // when / then
         assertThatThrownBy(() -> customer.addAddress(null))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage(ADDRESSES_NULL_MESSAGE);
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(ADDRESSES_NULL_MESSAGE);
     }
 
     @Test
     void shouldThrowWhenAddingAddressToDeletedCustomer() {
         // given
-        final Customer customer = deletedCustomer();
+        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when / then
-        assertThatThrownBy(() -> customer.addAddress(address(ADDRESS_ID_ONE, false, false)))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(CUSTOMER_DELETED_MESSAGE);
+        assertThatThrownBy(() -> customer.addAddress(
+            createAddress(ADDRESS_ID_ONE, false, false)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(CUSTOMER_DELETED_MESSAGE);
     }
 
     @Test
     void shouldClearExistingDefaultShippingWhenAddingNewDefaultShippingAddress() {
         // given
-        final CustomerAddress firstAddress = address(ADDRESS_ID_ONE, true, false);
-        final CustomerAddress secondAddress = address(ADDRESS_ID_TWO, true, false);
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(firstAddress));
+        final CustomerAddress firstAddress = createAddress(ADDRESS_ID_ONE, true, false);
+        final CustomerAddress secondAddress = createAddress(ADDRESS_ID_TWO, true, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(firstAddress));
 
         // when
         customer.addAddress(secondAddress);
@@ -325,15 +293,9 @@ class CustomerTest
     @Test
     void shouldClearExistingDefaultBillingWhenAddingNewDefaultBillingAddress() {
         // given
-        final CustomerAddress firstAddress = address(ADDRESS_ID_ONE, false, true);
-        final CustomerAddress secondAddress = address(ADDRESS_ID_TWO, false, true);
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(firstAddress));
+        CustomerAddress firstAddress = createAddress(ADDRESS_ID_ONE, false, true);
+        CustomerAddress secondAddress = createAddress(ADDRESS_ID_TWO, false, true);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(firstAddress));
 
         // when
         customer.addAddress(secondAddress);
@@ -347,15 +309,9 @@ class CustomerTest
     @Test
     void shouldSetDefaultShippingAddress() {
         // given
-        final CustomerAddress firstAddress = address(ADDRESS_ID_ONE, true, false);
-        final CustomerAddress secondAddress = address(ADDRESS_ID_TWO, false, false);
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(firstAddress, secondAddress));
+        final CustomerAddress firstAddress = createAddress(ADDRESS_ID_ONE, true, false);
+        final CustomerAddress secondAddress = createAddress(ADDRESS_ID_TWO, false, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(firstAddress, secondAddress));
 
         // when
         customer.setDefaultShippingAddress(ADDRESS_ID_TWO);
@@ -368,43 +324,32 @@ class CustomerTest
     @Test
     void shouldThrowWhenSettingDefaultShippingAddressThatDoesNotExist() {
         // given
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(address(ADDRESS_ID_ONE, false, false)));
+        final CustomerAddress address = createAddress(ADDRESS_ID_ONE, true, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(address));
 
         // when / then
         assertThatThrownBy(() -> customer.setDefaultShippingAddress(UNKNOWN_ADDRESS_ID))
-                .isInstanceOf(CustomerAddressNotFoundException.class)
-                .hasMessage(ADDRESS_NOT_FOUND_PREFIX + UNKNOWN_ADDRESS_ID_VALUE);
+            .isInstanceOf(CustomerAddressNotFoundException.class)
+            .hasMessage(ADDRESS_NOT_FOUND_PREFIX + UNKNOWN_ADDRESS_ID_VALUE);
     }
 
     @Test
     void shouldThrowWhenSettingDefaultShippingAddressForDeletedCustomer() {
         // given
-        final Customer customer = deletedCustomer();
+        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when / then
         assertThatThrownBy(() -> customer.setDefaultShippingAddress(ADDRESS_ID_ONE))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(CUSTOMER_DELETED_MESSAGE);
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(CUSTOMER_DELETED_MESSAGE);
     }
 
     @Test
     void shouldSetDefaultBillingAddress() {
         // given
-        final CustomerAddress firstAddress = address(ADDRESS_ID_ONE, false, true);
-        final CustomerAddress secondAddress = address(ADDRESS_ID_TWO, false, false);
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(firstAddress, secondAddress));
+        final CustomerAddress firstAddress = createAddress(ADDRESS_ID_ONE, false, true);
+        final CustomerAddress secondAddress = createAddress(ADDRESS_ID_TWO, false, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(firstAddress, secondAddress));
 
         // when
         customer.setDefaultBillingAddress(ADDRESS_ID_TWO);
@@ -417,43 +362,32 @@ class CustomerTest
     @Test
     void shouldThrowWhenSettingDefaultBillingAddressThatDoesNotExist() {
         // given
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(address(ADDRESS_ID_ONE, false, false)));
+        final CustomerAddress address = createAddress(ADDRESS_ID_ONE, false, true);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(address));
 
         // when / then
         assertThatThrownBy(() -> customer.setDefaultBillingAddress(UNKNOWN_ADDRESS_ID))
-                .isInstanceOf(CustomerAddressNotFoundException.class)
-                .hasMessage(ADDRESS_NOT_FOUND_PREFIX + UNKNOWN_ADDRESS_ID_VALUE);
+            .isInstanceOf(CustomerAddressNotFoundException.class)
+            .hasMessage(ADDRESS_NOT_FOUND_PREFIX + UNKNOWN_ADDRESS_ID_VALUE);
     }
 
     @Test
     void shouldThrowWhenSettingDefaultBillingAddressForDeletedCustomer() {
         // given
-        final Customer customer = deletedCustomer();
+        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when / then
         assertThatThrownBy(() -> customer.setDefaultBillingAddress(ADDRESS_ID_ONE))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(CUSTOMER_DELETED_MESSAGE);
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(CUSTOMER_DELETED_MESSAGE);
     }
 
     @Test
     void shouldRemoveAddress() {
         // given
-        final CustomerAddress firstAddress = address(ADDRESS_ID_ONE, false, false);
-        final CustomerAddress secondAddress = address(ADDRESS_ID_TWO, false, false);
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(firstAddress, secondAddress));
+        final CustomerAddress firstAddress = createAddress(ADDRESS_ID_ONE, false, false);
+        final CustomerAddress secondAddress = createAddress(ADDRESS_ID_TWO, false, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(firstAddress, secondAddress));
 
         // when
         customer.removeAddress(ADDRESS_ID_ONE);
@@ -465,167 +399,230 @@ class CustomerTest
     @Test
     void shouldThrowWhenRemovingAddressThatDoesNotExist() {
         // given
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(address(ADDRESS_ID_ONE, false, false)));
+        final CustomerAddress address = createAddress(ADDRESS_ID_ONE, false, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(address));
 
         // when / then
         assertThatThrownBy(() -> customer.removeAddress(UNKNOWN_ADDRESS_ID))
-                .isInstanceOf(CustomerAddressNotFoundException.class)
-                .hasMessage(ADDRESS_NOT_FOUND_PREFIX + UNKNOWN_ADDRESS_ID_VALUE);
+            .isInstanceOf(CustomerAddressNotFoundException.class)
+            .hasMessage(ADDRESS_NOT_FOUND_PREFIX + UNKNOWN_ADDRESS_ID_VALUE);
     }
 
     @Test
     void shouldThrowWhenRemovingAddressForDeletedCustomer() {
         // given
-        final Customer customer = deletedCustomer();
+        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when / then
         assertThatThrownBy(() -> customer.removeAddress(ADDRESS_ID_ONE))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(CUSTOMER_DELETED_MESSAGE);
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(CUSTOMER_DELETED_MESSAGE);
     }
 
     @Test
     void shouldReturnUnmodifiableCopyOfAddresses() {
         // given
-        final CustomerAddress address = address(ADDRESS_ID_ONE, false, false);
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                List.of(address));
+        final CustomerAddress address = createAddress(ADDRESS_ID_ONE, false, false);
+        final Customer customer = createActiveCustomerWithAddresses(List.of(address));
 
-        // when
-        final List<CustomerAddress> addresses = customer.getAddresses();
-
-        // then
-        assertThatThrownBy(() -> {
-            addresses.add(address(ADDRESS_ID_TWO, false, false));
-        })
-                .isInstanceOf(UnsupportedOperationException.class);
+        // when / then
+        assertThat(customer.getAddresses()).isUnmodifiable();
     }
 
     @Test
     void shouldCreateCustomerFromPersistence() {
         // given
-        final CustomerAddress address = address(ADDRESS_ID_ONE, true, true);
-
-        // when
+        CustomerAddress address = createAddress(ADDRESS_ID_ONE, true, true);
         final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.DELETED,
-                List.of(address));
+            CustomerId.of(CUSTOMER_ID_VALUE),
+            PROFILE,
+            EMAIL,
+            PASSWORD_HASH,
+            CustomerStatus.PENDING,
+            List.of(address));
 
         // then
         assertThat(customer.getId()).isEqualTo(CUSTOMER_ID);
         assertThat(customer.getProfile()).isEqualTo(PROFILE);
         assertThat(customer.getEmail()).isEqualTo(EMAIL);
         assertThat(customer.getPasswordHash()).isEqualTo(PASSWORD_HASH);
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
+        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.PENDING);
         assertThat(customer.getAddresses()).containsExactly(address);
     }
 
     @Test
     void shouldThrowWhenCreatingCustomerFromPersistenceWithNullAddresses() {
         assertThatThrownBy(() -> Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.ACTIVE,
-                null))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage(ADDRESSES_NULL_MESSAGE);
-    }
-
-    private static Customer deletedCustomer() {
-        return Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.DELETED,
-                List.of());
-    }
-
-    private static CustomerAddress address(
-            final AddressId addressId,
-            final boolean defaultShipping,
-            final boolean defaultBilling) {
-
-        return CustomerAddress.fromPersistence(
-                addressId,
-                ADDRESS_LABEL,
-                ADDRESS_LINE1,
-                ADDRESS_LINE2,
-                ADDRESS_CITY,
-                ADDRESS_STATE,
-                ADDRESS_POSTAL_CODE,
-                ADDRESS_COUNTRY_CODE,
-                defaultShipping,
-                defaultBilling);
-    }
-    @Test
-    void shouldReactivateDeletedCustomer() {
-        final Customer customer = Customer.fromPersistence(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH,
-                CustomerStatus.DELETED,
-                List.of());
-
-        customer.reactivate();
-
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.ACTIVE);
-    }
-
-    @Test
-    void shouldKeepActiveCustomerPendingWhenReactivated() {
-        final Customer customer = Customer.createNew(
-                CUSTOMER_ID,
-                PROFILE,
-                EMAIL,
-                PASSWORD_HASH);
-
-        customer.reactivate();
-
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.PENDING);
-    }
-
-    @Test
-    void shouldActivateCustomerWhenActivated() {
-        final Customer customer = Customer.createNew(
             CUSTOMER_ID,
             PROFILE,
             EMAIL,
-            PASSWORD_HASH);
+            PASSWORD_HASH,
+            CustomerStatus.ACTIVE,
+            null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(ADDRESSES_NULL_MESSAGE);
+    }
 
+    @Test
+    void shouldActivateCustomerWhenPending() {
+        // given
+        final Customer customer = createNewCustomer();
+
+        // when
         customer.activate();
 
+        // then
         assertThat(customer.getStatus()).isEqualTo(CustomerStatus.ACTIVE);
     }
 
     @Test
     void shouldDeleteCustomerWhenActive() {
-        final Customer customer = Customer.createNew(
+        // given
+        final Customer customer = createCustomerWithStatus(CustomerStatus.ACTIVE);
+
+        // when
+        customer.softDelete();
+
+        // then
+        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTransitions")
+    void shouldAllowValidTransitions(final CustomerStatus currentStatus,
+                                     final CustomerStatus targetStatus) {
+        // given
+        final Customer customer = createCustomerWithStatus(currentStatus);
+
+        // when
+        customer.transitionTo(targetStatus);
+
+        // then
+        assertThat(customer.getStatus()).isEqualTo(targetStatus);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidTransitions")
+    void shouldRejectInvalidStatusTransitions(final CustomerStatus currentStatus,
+                                              final CustomerStatus targetStatus) {
+
+        // given
+        final Customer customer = createCustomerWithStatus(currentStatus);
+
+        // when / then
+        assertThatThrownBy(() -> customer.transitionTo(targetStatus))
+            .isInstanceOf(InvalidCustomerStatusTransitionException.class)
+            .hasMessage(INVALID_CUSTOMER_STATE_TRANSITION_MESSAGE
+                .formatted(currentStatus, targetStatus));
+    }
+
+    @Test
+    void shouldReactivateCustomerWhenInactive() {
+        // given
+        final Customer customer = createCustomerWithStatus(CustomerStatus.INACTIVE);
+
+        // when
+        customer.reactivate();
+
+        // then
+        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.ACTIVE);
+    }
+
+    @Test
+    void shouldInactivateCustomerWhenActive() {
+        // given
+        final Customer customer = createCustomerWithStatus(CustomerStatus.ACTIVE);
+
+        // when
+        customer.inactivate();
+
+        // then
+        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.INACTIVE);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CustomerStatus.class, names = {"PENDING", "ACTIVE", "DELETED"})
+    void shouldRejectReactivateWhenStatusIsNotInactive(final CustomerStatus currentStatus) {
+        final Customer customer = createCustomerWithStatus(currentStatus);
+
+        assertThatThrownBy(customer::reactivate)
+            .isInstanceOf(InvalidCustomerStatusTransitionException.class)
+            .hasMessage(INVALID_CUSTOMER_STATE_TRANSITION_MESSAGE
+                .formatted(currentStatus, CustomerStatus.ACTIVE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(CustomerStatus.class)
+    void shouldIgnoreTransitionToSameStatus(final CustomerStatus status) {
+        // given
+        final Customer customer = createCustomerWithStatus(status);
+
+        // when
+        customer.transitionTo(status);
+
+        // then
+        assertThat(customer.getStatus()).isEqualTo(status);
+    }
+
+    private static Stream<Arguments> invalidTransitions() {
+        return Stream.of(
+            Arguments.of(CustomerStatus.ACTIVE, CustomerStatus.PENDING),
+            Arguments.of(CustomerStatus.INACTIVE, CustomerStatus.PENDING),
+            Arguments.of(CustomerStatus.DELETED, CustomerStatus.PENDING),
+            Arguments.of(CustomerStatus.DELETED, CustomerStatus.ACTIVE),
+            Arguments.of(CustomerStatus.DELETED, CustomerStatus.INACTIVE));
+    }
+
+    private static Stream<Arguments> validTransitions() {
+        return Stream.of(
+            Arguments.of(CustomerStatus.PENDING, CustomerStatus.ACTIVE),
+            Arguments.of(CustomerStatus.PENDING, CustomerStatus.INACTIVE),
+            Arguments.of(CustomerStatus.PENDING, CustomerStatus.DELETED),
+            Arguments.of(CustomerStatus.ACTIVE, CustomerStatus.INACTIVE),
+            Arguments.of(CustomerStatus.ACTIVE, CustomerStatus.DELETED),
+            Arguments.of(CustomerStatus.INACTIVE, CustomerStatus.ACTIVE),
+            Arguments.of(CustomerStatus.INACTIVE, CustomerStatus.DELETED));
+    }
+
+    private Customer createCustomerWithStatus(final CustomerStatus status) {
+        return Customer.fromPersistence(
+            CustomerId.of(CUSTOMER_ID_VALUE),
+            PROFILE,
+            EMAIL,
+            PASSWORD_HASH,
+            status,
+            List.of());
+    }
+
+    private Customer createNewCustomer() {
+        return Customer.createNew(
             CUSTOMER_ID,
             PROFILE,
             EMAIL,
             PASSWORD_HASH);
+    }
 
-        customer.activate();
-        customer.markDeleted();
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
+    private Customer createActiveCustomerWithAddresses(List<CustomerAddress> addresses) {
+        Customer customer = createCustomerWithStatus(CustomerStatus.ACTIVE);
+        addresses.forEach(customer::addAddress);
+        return customer;
+    }
+
+    private static CustomerAddress createAddress(
+        final AddressId addressId,
+        final boolean defaultShipping,
+        final boolean defaultBilling) {
+
+        return CustomerAddress.fromPersistence(
+            addressId,
+            ADDRESS_LABEL,
+            ADDRESS_LINE1,
+            ADDRESS_LINE2,
+            ADDRESS_CITY,
+            ADDRESS_STATE,
+            ADDRESS_POSTAL_CODE,
+            ADDRESS_COUNTRY_CODE,
+            defaultShipping,
+            defaultBilling);
     }
 }

--- a/kartoush/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
@@ -189,7 +189,7 @@ class DefaultCustomerServiceTest
         // then
         verify(customerRepository).findById(CUSTOMER_ID_EMBEDDABLE);
         verify(customerMapper).toDomain(customerEntity);
-        verify(customer).markDeleted();
+        verify(customer).softDelete();
         verify(customerMapper).updateEntity(customer, customerEntity);
         verify(customerRepository).save(customerEntity);
     }

--- a/kartoush/platform-types/src/main/java/com/kartoush/platform/types/CustomerStatus.java
+++ b/kartoush/platform-types/src/main/java/com/kartoush/platform/types/CustomerStatus.java
@@ -3,5 +3,6 @@ package com.kartoush.platform.types;
 public enum CustomerStatus {
     PENDING,
     ACTIVE,
+    INACTIVE,
     DELETED
 }


### PR DESCRIPTION
## Summary

Defines and enforces customer lifecycle transitions in the domain layer and introduces the `INACTIVE` status.

## Changes

### Domain
- add `INACTIVE` to `CustomerStatus`
- implement `transitionTo(...)` with centralized validation
- enforce valid lifecycle transitions within the `Customer` aggregate
- introduce `InvalidCustomerStatusTransitionException`
- add domain methods:
  - `activate()`
  - `inactivate()`
  - `reactivate()`
  - `softDelete()`
- enforce no-op behavior for same-state transitions

### Persistence
- add Flyway migration to update customer status constraint to include `INACTIVE`

### Tests
- add parameterized tests for:
  - valid transitions
  - invalid transitions
  - no-op transitions
  - invalid `reactivate()` scenarios
- add tests for `inactivate()` behavior
- fix test helpers to avoid mutating unmodifiable collections
- remove duplicate and redundant tests

## Lifecycle Rules
PENDING -> ACTIVE
PENDING -> INACTIVE
PENDING -> DELETED
ACTIVE -> INACTIVE
ACTIVE -> DELETED
INACTIVE -> ACTIVE
INACTIVE -> DELETED
DELETED -> (no transitions)


## Notes

- Same-state transitions are treated as no-ops for idempotency
- Business intent methods (e.g. `reactivate`) enforce stricter rules than `transitionTo`

## Issues

Closes #91  
Partially addresses #92

## Follow-ups

- #98 Enhance customer soft delete behavior (email mutation)
- #97 Document lifecycle and API behavior