### PR TITLE
feat(customer): mutate email on soft delete to allow reuse

### DIFF
--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
@@ -75,7 +75,12 @@ public final class Customer {
     }
 
     public void softDelete() {
-        transitionTo(CustomerStatus.DELETED);
+        if (this.status == CustomerStatus.DELETED) {
+            return;
+        }
+
+        this.email = this.email.updateForDeletion(this.id);
+        this.status = CustomerStatus.DELETED;
     }
 
     public void activate() {

--- a/kartoush/customer/src/test/java/com/kartoush/customer/domain/CustomerTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/domain/CustomerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,6 +66,8 @@ class CustomerTest {
     private static final String ADDRESSES_NULL_MESSAGE = "Addresses must not be null";
 
     private static final String ADDRESS_NOT_FOUND_PREFIX = "Address not found for id: ";
+
+    private static final String DELETED_SUFFIX = "|deleted|";
 
     private static final CustomerId CUSTOMER_ID = CustomerId.of(CUSTOMER_ID_VALUE);
 
@@ -198,18 +201,6 @@ class CustomerTest {
             new Email(BLANK_EMAIL)))
             .isInstanceOf(InvalidEmailException.class)
             .hasMessage(EMAIL_BLANK_MESSAGE);
-    }
-
-    @Test
-    void shouldKeepDeletedCustomerDeletedWhenSoftDeleted() {
-        // given
-        final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
-
-        // when
-        customer.softDelete();
-
-        // then
-        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
     }
 
     @Test
@@ -540,6 +531,34 @@ class CustomerTest {
         assertThat(customer.getStatus()).isEqualTo(CustomerStatus.INACTIVE);
     }
 
+    @Test
+    void shouldMutateEmailWhenSoftDeletingCustomer() {
+        final Customer customer = createCustomerWithStatus(CustomerStatus.ACTIVE);
+
+        customer.softDelete();
+
+        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
+        assertThat(customer.getEmail().value())
+            .isEqualTo(expectedDeletedEmail());
+    }
+
+    @Test
+    void shouldKeepDeletedCustomerDeletedWhenSoftDeletedAgain() {
+        // given
+        final Customer customer = createCustomerWithStatus(CustomerStatus.ACTIVE);
+
+        customer.softDelete();
+
+        final Email deletedEmail = customer.getEmail();
+
+        // when
+        customer.softDelete();
+
+        // then
+        assertThat(customer.getStatus()).isEqualTo(CustomerStatus.DELETED);
+        assertThat(customer.getEmail()).isEqualTo(deletedEmail);
+    }
+
     @ParameterizedTest
     @EnumSource(value = CustomerStatus.class, names = {"PENDING", "ACTIVE", "DELETED"})
     void shouldRejectReactivateWhenStatusIsNotInactive(final CustomerStatus currentStatus) {
@@ -624,5 +643,12 @@ class CustomerTest {
             ADDRESS_COUNTRY_CODE,
             defaultShipping,
             defaultBilling);
+    }
+
+    private String expectedDeletedEmail() {
+        return (CustomerTest.EMAIL.value()
+            + DELETED_SUFFIX
+            + CustomerTest.CUSTOMER_ID.value())
+            .toLowerCase(Locale.ROOT);
     }
 }

--- a/kartoush/customer/src/test/java/com/kartoush/customer/persistence/CustomerEntityRepositoryTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/persistence/CustomerEntityRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.kartoush.customer.persistence;
 
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.domain.CustomerProfile;
 import com.kartoush.customer.persistence.entity.CustomerEntity;
 import com.kartoush.customer.persistence.entity.CustomerProfileEntity;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
@@ -7,6 +9,7 @@ import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.customer.test.CustomerTestApplication;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
+import com.kartoush.platform.types.Email;
 import com.kartoush.platform.ulid.UlidGenerator;
 import com.kartoush.testsupport.IntegrationTest;
 import com.kartoush.testsupport.PostgresSpringIntegrationTest;
@@ -17,6 +20,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -108,5 +112,59 @@ class CustomerEntityRepositoryTest extends PostgresSpringIntegrationTest {
 
         // then
         assertThat(saved.getId()).isEqualTo(id.getValue());
+    }
+
+    @Test
+    void shouldAllowReusingOriginalEmailAfterSoftDelete()
+    {
+        // given
+        final String originalEmail = "jack@kartoush.test";
+        final CustomerIdEmbeddable customerId1 = CustomerIdEmbeddable.from(CustomerId.newId(ulidGenerator));
+        final CustomerProfileEntity profile = new CustomerProfileEntity(FIRST_NAME, LAST_NAME, PHONE_NUMBER);
+
+        final CustomerEntity first = CustomerEntity.newCustomer(
+            customerId1,
+            profile,
+            originalEmail,
+            PASSWORD_HASH,
+            CustomerStatus.PENDING);
+
+        // persist original
+        customerRepository.saveAndFlush(first);
+
+        // simulate soft delete
+        first.setEmail(originalEmail + "|deleted|" + customerId1.getValue().toLowerCase(Locale.ROOT));
+        first.setCustomerStatus(CustomerStatus.DELETED);
+
+        customerRepository.saveAndFlush(first);
+
+        final CustomerIdEmbeddable customerId2 = CustomerIdEmbeddable.from(CustomerId.newId(ulidGenerator));
+        final CustomerProfileEntity profile2 = new CustomerProfileEntity(FIRST_NAME, LAST_NAME, PHONE_NUMBER);
+
+        final CustomerEntity second = CustomerEntity.newCustomer(
+            customerId2,
+            profile2,
+            originalEmail,
+            PASSWORD_HASH,
+            CustomerStatus.PENDING
+        );
+
+        // create new customer with same email
+        customerRepository.saveAndFlush(second);
+
+        // then
+        final List<CustomerEntity> customers = customerRepository.findAll();
+
+        assertThat(customers).hasSize(2);
+
+        final CustomerEntity deleted = customerRepository.findById(customerId1).orElseThrow();
+        final CustomerEntity active = customerRepository.findById(customerId2).orElseThrow();
+
+        assertThat(deleted.getCustomerStatus()).isEqualTo(CustomerStatus.DELETED);
+        assertThat(deleted.getEmail())
+            .isEqualTo(originalEmail + "|deleted|" + customerId1.getValue().toLowerCase(Locale.ROOT));
+
+        assertThat(active.getCustomerStatus()).isEqualTo(CustomerStatus.PENDING);
+        assertThat(active.getEmail()).isEqualTo(originalEmail);
     }
 }

--- a/kartoush/platform-types/src/main/java/com/kartoush/platform/types/Email.java
+++ b/kartoush/platform-types/src/main/java/com/kartoush/platform/types/Email.java
@@ -9,7 +9,9 @@ import java.util.regex.Pattern;
 public record Email(String value) {
 
     private static final Pattern EMAIL_PATTERN =
-            Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+        Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+
+    private static final String DELETED_SUFFIX = "|deleted|";
 
     public Email {
         if (value == null) {
@@ -24,6 +26,16 @@ public record Email(String value) {
         if (!EMAIL_PATTERN.matcher(value).matches()) {
             throw new InvalidEmailException("Email must be a valid email address");
         }
+    }
+
+    public Email updateForDeletion(final CustomerId customerId) {
+        final String suffix = DELETED_SUFFIX + customerId.value();
+
+        if (this.value.endsWith(suffix)) {
+            return this;
+        }
+
+        return new Email(this.value + suffix);
     }
 
     private static String normalize(final String email) {


### PR DESCRIPTION
## Summary

Updates customer soft delete behavior so deleted customers free up their original email address for reuse.

## Changes

### Domain
- update `softDelete()` to mutate the customer email before marking the customer as deleted
- keep repeated soft delete calls idempotent

### Email value object
- add `updateForDeletion(...)` to `Email`
- centralize deleted email suffix handling with a constant
- preserve normalized email storage through the existing `Email` constructor behavior

### Tests
- add unit tests for soft delete email mutation
- add unit tests for repeated soft delete behavior
- add persistence test to verify the original email can be reused after a customer is soft deleted

## Soft Delete Email Rule

When a customer is soft deleted, the email is mutated using the existing customer id:

`<originalEmail>|deleted|<customerId>`

This frees the original email for reuse while preserving uniqueness for the deleted record.

##Notes
- repeated softDelete() calls are treated as a no-op
- the persistence test uses saveAndFlush(...) to ensure the deleted email update is flushed before inserting a new customer with the original email

## Issues

Closes #98