### PR TITLE
feat(customer): clarify PUT update semantics

### DIFF
--- a/docs/architecture/decisions/0021-branch-naming-convention.md
+++ b/docs/architecture/decisions/0021-branch-naming-convention.md
@@ -1,0 +1,80 @@
+# 0021 - Branch Naming Convention
+
+## Status
+
+Accepted
+
+## Context
+
+Consistent branch naming improves collaboration, readability, and traceability across the codebase.
+
+The project currently has inconsistent naming patterns such as:
+
+- feat/...
+- feature/...
+
+Additionally, some branches use nested path structures (e.g., feat/customer/...) while others use flat naming.
+
+A standard convention is needed to:
+
+- align with commit message conventions
+- improve clarity in Git tools (GitHub, GitKraken)
+- reduce cognitive overhead when scanning branches
+- establish a consistent workflow for contributors
+
+## Decision
+
+Branch names will follow this format:
+
+`<type>/<scope>-<short-description>`
+
+### Rules
+
+- Use lowercase kebab-case for all parts
+- Use a single "/" separator between type and the rest of the branch name
+- Do not use nested path structures (no additional "/")
+- Keep names concise but descriptive
+- Do not include issue numbers in branch names
+
+### Allowed Types
+
+- feat — new functionality
+- fix — bug fixes
+- chore — maintenance, build, or tooling changes
+- docs — documentation updates
+- refactor — code changes without behavior changes
+- test — test-related changes
+
+### Examples
+
+- feat/customer-update-semantics
+- feat/customer-email-update-endpoint
+- fix/customer-soft-delete-bug
+- chore/gradle-version-catalog-cleanup
+- docs/customer-lifecycle-api
+- refactor/customer-service-cleanup
+- test/customer-controller-webmvc
+
+## Rationale
+
+- Aligns with Conventional Commits (feat(...), fix(...), etc.)
+- Avoids unnecessary hierarchy and complexity in branch names
+- Improves readability in tooling and pull request workflows
+- Keeps naming predictable and easy to follow
+
+## Consequences
+
+### Positive
+
+- Consistent and predictable branch naming
+- Easier navigation and filtering in Git tools
+- Reduced ambiguity for contributors
+
+### Negative
+
+- Existing branches may not follow this convention
+- Minor overhead to enforce consistency going forward
+
+## Notes
+
+This convention applies to all new branches. Existing branches do not need to be renamed retroactively.

--- a/kartoush/app/src/main/java/com/kartoush/api/customer/CustomerController.java
+++ b/kartoush/app/src/main/java/com/kartoush/api/customer/CustomerController.java
@@ -4,6 +4,9 @@ import com.kartoush.customer.facade.CustomerFacade;
 import com.kartoush.customer.facade.model.CreateCustomerRequest;
 import com.kartoush.customer.facade.model.CustomerView;
 import com.kartoush.customer.facade.model.UpdateCustomerRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,51 +28,61 @@ import java.util.List;
 public class CustomerController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CustomerController.class);
+
     private final CustomerFacade customerFacade;
 
-    public CustomerController(final CustomerFacade customerFacade)
-    {
+    public CustomerController(final CustomerFacade customerFacade) {
         this.customerFacade = customerFacade;
     }
 
     @GetMapping
-    public ResponseEntity<List<CustomerView>> getCustomers()
-    {
+    public ResponseEntity<List<CustomerView>> getCustomers() {
         return ResponseEntity.ok(customerFacade.getCustomers());
     }
 
     @GetMapping("/{customerId}")
-    public ResponseEntity<CustomerView> getCustomer(@PathVariable final String customerId)
-    {
+    public ResponseEntity<CustomerView> getCustomer(@PathVariable final String customerId) {
         return ResponseEntity.ok(customerFacade.getCustomer(customerId));
     }
 
     @PostMapping
     public ResponseEntity<CustomerView> createCustomer(
-            @Valid @RequestBody final CreateCustomerRequest request)
-    {
+        @Valid @RequestBody final CreateCustomerRequest request) {
         LOG.info("Received create customer request for email={}", request.email());
         final CustomerView createdCustomer = customerFacade.createCustomer(request);
         LOG.info("Created customer id={} for email={}", createdCustomer.customerId(), request.email());
 
         return ResponseEntity
-                .created(URI.create("/api/customers/" + createdCustomer.customerId()))
-                .body(createdCustomer);
+            .created(URI.create("/api/customers/" + createdCustomer.customerId()))
+            .body(createdCustomer);
     }
 
 
+    @Operation(
+        summary = "Update customer profile",
+        description = """
+            Replaces the customer profile fields that are updatable through this API.
 
+            This endpoint updates profile data only, such as first name, last name, and phone number.
+            It does not update the customer's email address and does not change customer lifecycle state.
+
+            The operation is idempotent.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Customer profile updated successfully"),
+        @ApiResponse(responseCode = "400", description = "Request validation failed"),
+        @ApiResponse(responseCode = "404", description = "Customer not found")
+    })
     @PutMapping("/{customerId}")
     public ResponseEntity<CustomerView> updateCustomer(
-            @PathVariable final String customerId,
-            @Valid @RequestBody final UpdateCustomerRequest request)
-    {
+        @PathVariable final String customerId,
+        @RequestBody final UpdateCustomerRequest request) {
         return ResponseEntity.ok(customerFacade.updateCustomer(customerId, request));
     }
 
     @DeleteMapping("/{customerId}")
-    public ResponseEntity<Void> deleteCustomer(@PathVariable final String customerId)
-    {
+    public ResponseEntity<Void> deleteCustomer(@PathVariable final String customerId) {
         customerFacade.deleteCustomer(customerId);
         return ResponseEntity.noContent().build();
     }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/domain/Customer.java
@@ -68,10 +68,9 @@ public final class Customer {
         return customer;
     }
 
-    public void updateDetails(final CustomerProfile newProfile, final Email newEmail) {
+    public void updateDetails(final CustomerProfile newProfile) {
         assertNotDeleted();
         this.profile = Objects.requireNonNull(newProfile, "Profile must not be null");
-        this.email = newEmail;
     }
 
     public void softDelete() {
@@ -92,10 +91,6 @@ public final class Customer {
     }
 
     public void reactivate() {
-        if (this.status != CustomerStatus.INACTIVE) {
-            throw new InvalidCustomerStatusTransitionException(this.status, CustomerStatus.ACTIVE);
-        }
-
         transitionTo(CustomerStatus.ACTIVE);
     }
 

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/UpdateCustomerRequest.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/UpdateCustomerRequest.java
@@ -1,8 +1,7 @@
 package com.kartoush.customer.facade.model;
 
 public record UpdateCustomerRequest(
-        String email,
-        String phoneNumber,
         String firstName,
-        String lastName) {
+        String lastName,
+        String phoneNumber) {
 }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -78,8 +78,7 @@ public class DefaultCustomerFacade implements CustomerFacade {
         updateCustomerRequestValidator.validate(request);
 
         CustomerProfile profile = buildCustomerProfile(request);
-        Email email = new Email(request.email());
-        Customer savedCustomer = customerService.updateCustomer(customerId, profile, email);
+        Customer savedCustomer = customerService.updateCustomer(customerId, profile);
 
         return toCustomerView(savedCustomer);
     }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
@@ -14,7 +14,7 @@ public interface CustomerService
 
     Optional<Customer> getCustomerById(String customerId);
 
-    Customer updateCustomer(final String customerId, final CustomerProfile profile, Email email);
+    Customer updateCustomer(final String customerId, final CustomerProfile profile);
 
     Customer createCustomer(final Customer customer);
 

--- a/kartoush/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
@@ -87,13 +87,12 @@ public class DefaultCustomerService implements CustomerService
     @Transactional
     public Customer updateCustomer(
             final String customerId,
-            final CustomerProfile profile,
-            final Email email) {
+            final CustomerProfile profile) {
         final CustomerEntity customerEntity = customerRepository.findById(CustomerIdEmbeddable.from(customerId))
                 .orElseThrow(() -> new CustomerNotFoundException(customerId));
 
         final Customer customer = customerMapper.toDomain(customerEntity);
-        customer.updateDetails(profile, email);
+        customer.updateDetails(profile);
 
         customerMapper.updateEntity(customer, customerEntity);
         final CustomerEntity savedCustomer = customerRepository.save(customerEntity);

--- a/kartoush/customer/src/test/java/com/kartoush/customer/domain/CustomerTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/domain/CustomerTest.java
@@ -158,23 +158,11 @@ class CustomerTest {
         final Customer customer = createNewCustomer();
 
         // when
-        customer.updateDetails(UPDATED_PROFILE, UPDATED_EMAIL);
+        customer.updateDetails(UPDATED_PROFILE);
 
         // then
         assertThat(customer.getProfile()).isEqualTo(UPDATED_PROFILE);
-        assertThat(customer.getEmail()).isEqualTo(UPDATED_EMAIL);
-    }
-
-    @Test
-    void shouldNormalizeEmailWhenUpdatingDetails() {
-        // given
-        final Customer customer = createNewCustomer();
-
-        // when
-        customer.updateDetails(UPDATED_PROFILE, new Email("  Updated@Kartoush.Test  "));
-
-        // then
-        assertThat(customer.getEmail()).isEqualTo(UPDATED_EMAIL);
+        assertThat(customer.getEmail()).isEqualTo(EMAIL);
     }
 
     @Test
@@ -184,23 +172,9 @@ class CustomerTest {
 
         // when / then
         assertThatThrownBy(() -> customer.updateDetails(
-            null,
-            UPDATED_EMAIL))
+            null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage(PROFILE_NULL_MESSAGE);
-    }
-
-    @Test
-    void shouldThrowWhenUpdatingDetailsWithBlankEmail() {
-        // given
-        final Customer customer = createNewCustomer();
-
-        // when / then
-        assertThatThrownBy(() -> customer.updateDetails(
-            UPDATED_PROFILE,
-            new Email(BLANK_EMAIL)))
-            .isInstanceOf(InvalidEmailException.class)
-            .hasMessage(EMAIL_BLANK_MESSAGE);
     }
 
     @Test
@@ -209,7 +183,7 @@ class CustomerTest {
         final Customer customer = createCustomerWithStatus(CustomerStatus.DELETED);
 
         // when / then
-        assertThatThrownBy(() -> customer.updateDetails(UPDATED_PROFILE, UPDATED_EMAIL))
+        assertThatThrownBy(() -> customer.updateDetails(UPDATED_PROFILE))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage(CUSTOMER_DELETED_MESSAGE);
     }

--- a/kartoush/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
@@ -149,7 +149,7 @@ class DefaultCustomerServiceTest
         given(customerMapper.toDomain(any(CustomerEntity.class))).willReturn(mappedCustomer);
 
         // when
-        final Customer result = defaultCustomerService.updateCustomer(CUSTOMER_ID_VALUE, PROFILE, EMAIL);
+        final Customer result = defaultCustomerService.updateCustomer(CUSTOMER_ID_VALUE, PROFILE);
 
         // then
         assertThat(result).isSameAs(mappedCustomer);
@@ -165,7 +165,7 @@ class DefaultCustomerServiceTest
         given(customerRepository.findById(CUSTOMER_ID_EMBEDDABLE)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> defaultCustomerService.updateCustomer(CUSTOMER_ID_VALUE, PROFILE, EMAIL))
+        assertThatThrownBy(() -> defaultCustomerService.updateCustomer(CUSTOMER_ID_VALUE, PROFILE))
                 .isInstanceOf(CustomerNotFoundException.class)
                 .hasMessageContaining(CUSTOMER_ID_VALUE);
 


### PR DESCRIPTION
## Summary

Clarifies the semantics of `PUT /api/customers/{customerId}` by restricting the endpoint to updating customer profile fields only.

## Why

The update endpoint previously included `email` in `UpdateCustomerRequest`, which created ambiguity around whether email should be treated as a standard mutable field or a more sensitive identity attribute.

This change removes that ambiguity and ensures the endpoint has a clear, consistent contract.

## Changes

- removed `email` from `UpdateCustomerRequest`
- updated validation logic to align with the new request contract
- updated domain/service update flow to operate on profile fields only
- clarified Swagger documentation for the update endpoint
- simplified `Customer.reactivate()` by delegating validation to `transitionTo(...)`

## API Behavior

`PUT /api/customers/{customerId}` now:

- updates customer profile fields only:
  - `firstName` (required)
  - `lastName` (required)
  - `phoneNumber` (optional)
- does **not** update email
- does **not** change customer lifecycle state
- is idempotent

## Validation

- `firstName` and `lastName` are required
- `phoneNumber` is optional but must match the expected format if provided

## Responses

- `200 OK` — customer updated successfully
- `400 Bad Request` — validation failed
- `404 Not Found` — customer does not exist

## Scope

- applies only to the update endpoint and related request/validation logic
- no changes to lifecycle endpoints or email behavior

## Testing

- updated existing tests to remove email from update scenarios
- verified update flow continues to function for profile fields
- ensured no remaining usage of `request.email()` in update logic

## Notes

Email updates will be handled by a dedicated endpoint in a future change.

Closes #93