### PR TITLE
test(customer): add WebMvc coverage and align customer view ordering

### DIFF
--- a/kartoush/app/build.gradle
+++ b/kartoush/app/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation project(':platform-types')
     testImplementation project(":test-support")
 
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation (libs.springBootStarterWeb)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation(libs.springdoc.openapi.webmvc.ui)

--- a/kartoush/app/src/test/java/com/kartoush/api/customer/CustomerControllerWebMvcTest.java
+++ b/kartoush/app/src/test/java/com/kartoush/api/customer/CustomerControllerWebMvcTest.java
@@ -1,0 +1,144 @@
+package com.kartoush.api.customer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.api.error.ApiProblemFactory;
+import com.kartoush.customer.facade.CustomerFacade;
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.facade.model.CustomerView;
+import com.kartoush.customer.facade.model.UpdateCustomerRequest;
+import com.kartoush.platform.types.CustomerStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CustomerController.class)
+class CustomerControllerWebMvcTest
+{
+    private static final String BASE_URL = "/api/customers";
+    private static final String CUSTOMER_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+
+    private static final String FIRST_NAME = "Jack";
+    private static final String LAST_NAME = "Kartoush";
+    private static final String EMAIL = "jack@kartoush.com";
+    private static final String PHONE = "+16305551234";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private ApiProblemFactory apiProblemFactory;
+
+    @MockitoBean
+    private CustomerFacade customerFacade;
+
+    @Test
+    void shouldGetCustomers() throws Exception
+    {
+        when(customerFacade.getCustomers()).thenReturn(List.of());
+
+        mockMvc.perform(get(BASE_URL))
+            .andExpect(status().isOk());
+
+        verify(customerFacade).getCustomers();
+    }
+
+    @Test
+    void shouldGetCustomerById() throws Exception
+    {
+        when(customerFacade.getCustomer(eq(CUSTOMER_ID)))
+            .thenReturn(mockCustomerView());
+
+        mockMvc.perform(get(BASE_URL + "/{customerId}", CUSTOMER_ID))
+            .andExpect(status().isOk());
+
+        verify(customerFacade).getCustomer(eq(CUSTOMER_ID));
+    }
+
+    @Test
+    void shouldCreateCustomer() throws Exception
+    {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            EMAIL,
+            PHONE
+        );
+
+        when(customerFacade.createCustomer(any()))
+            .thenReturn(mockCustomerView());
+
+        mockMvc.perform(post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", BASE_URL + "/" + CUSTOMER_ID))
+            .andExpect(jsonPath("$.customerId").value(CUSTOMER_ID))
+            .andExpect(jsonPath("$.email").value(EMAIL))
+            .andExpect(jsonPath("$.firstName").value(FIRST_NAME))
+            .andExpect(jsonPath("$.lastName").value(LAST_NAME));;
+
+        verify(customerFacade).createCustomer(any());
+    }
+
+    @Test
+    void shouldUpdateCustomer() throws Exception
+    {
+        final UpdateCustomerRequest request = new UpdateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            PHONE
+        );
+
+        when(customerFacade.updateCustomer(eq(CUSTOMER_ID), any(UpdateCustomerRequest.class)))
+            .thenReturn(mockCustomerView());
+
+        mockMvc.perform(put(BASE_URL + "/{customerId}", CUSTOMER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+
+        verify(customerFacade).updateCustomer(eq(CUSTOMER_ID), any(UpdateCustomerRequest.class));
+    }
+
+    @Test
+    void shouldDeleteCustomer() throws Exception
+    {
+        mockMvc.perform(delete(BASE_URL + "/{customerId}", CUSTOMER_ID))
+            .andExpect(status().isNoContent());
+
+        verify(customerFacade).deleteCustomer(eq(CUSTOMER_ID));
+    }
+
+    private CustomerView mockCustomerView()
+    {
+        return new CustomerView(
+                                            CUSTOMER_ID,
+                                            FIRST_NAME,
+                                            LAST_NAME,
+                                            EMAIL,
+                                            PHONE,
+                                            CustomerStatus.ACTIVE);
+    }
+}

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CustomerView.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CustomerView.java
@@ -5,10 +5,10 @@ import com.kartoush.platform.types.CustomerStatus;
 
 public record CustomerView(
         String customerId,
-        String email,
-        String phoneNumber,
         String firstName,
         String lastName,
+        String email,
+        String phoneNumber,
         CustomerStatus status
 ) {
     public boolean isActive () {

--- a/kartoush/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/kartoush/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -83,11 +83,11 @@ class DefaultCustomerFacadeTest {
 
     private CustomerView buildCustomerView(){
         return new CustomerView(
-                CUSTOMER_ID,
-                EMAIL,
-                PHONE_NUMBER,
-                FIRST_NAME,
-                LAST_NAME,
-                CustomerStatus.PENDING);
+                                CUSTOMER_ID,
+                                FIRST_NAME,
+                                LAST_NAME,
+                                EMAIL,
+                                PHONE_NUMBER,
+                                CustomerStatus.PENDING);
     }
 }

--- a/kartoush/gradle/libs.versions.toml
+++ b/kartoush/gradle/libs.versions.toml
@@ -14,10 +14,10 @@ springDependencyManagement = { id = "io.spring.dependency-management", version.r
 [libraries]
 springBootBom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBootVersion" }
 
-springBootValidation = { module = "org.springframework.boot:spring-boot-starter-validation", version.ref = "springBootVersion" }
 springdoc-openapi-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
 springBootStarterTest = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBootVersion" }
 springBootStarterDataJpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBootVersion" }
+springBootStarterWeb = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springBootVersion"}
 springBootStarterFlyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 springBootTest = { module = "org.springframework.boot:spring-boot-test", version.ref = "springBootVersion" }
 springBootTestAutoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure", version.ref = "springBootVersion" }


### PR DESCRIPTION
## Summary

Adds WebMvc coverage for `CustomerController` and aligns `CustomerView` ordering with the intended response shape.

## Changes

- added `CustomerControllerWebMvcTest`
- updated `CustomerView` field ordering
- updated related customer facade tests
- included required build configuration updates for the test setup

## Why

- adds controller-level coverage for core customer endpoints
- makes the customer response payload more intuitive and consistently ordered
- keeps related tests aligned with the response contract

## Testing

- added WebMvc tests for `CustomerController`
- updated related customer facade tests

Closes #95