### PR TITLE
docs: add GitHub issue templates aligned with ADR structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Architecture Decisions
+    url: https://github.com/jbolous/kartoush/tree/main/docs/architecture/decisions
+    about: Review architecture decisions before creating issues.
+
+  - name: Persistence Decisions
+    url: https://github.com/jbolous/kartoush/tree/main/docs/persistence/decisions
+    about: Review persistence-related decisions before creating issues.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,90 @@
+name: Epic
+description: High-level initiative that groups related tasks
+title: "[Epic]: "
+labels:
+  - epic
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What is the intended outcome of this epic?
+      placeholder: |
+        Harden the customer lifecycle and ensure consistent, production-grade API behavior across controller, facade, and service layers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why is this work needed?
+      placeholder: |
+        While the initial vertical slice is complete, this work focuses on correctness, consistency, and clarity of behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What areas of work are included?
+      placeholder: |
+        Lifecycle correctness
+        - define allowed customer status transitions
+        - enforce transition rules in the domain/service layer
+        - prevent invalid operations
+
+        API consistency
+        - clarify update semantics
+        - ensure consistent request validation rules
+        - standardize API responses
+
+        Error handling
+        - introduce global exception handling
+        - map domain exceptions to consistent API responses
+        - align with RFC-7807 / Problem Details
+
+        Testing
+        - add WebMvc tests for create, get, update, and delete
+        - validate error scenarios at the API level
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What defines completion of this epic?
+      placeholder: |
+        - lifecycle rules are clearly defined and enforced
+        - invalid customer operations fail predictably
+        - API behavior is consistent across endpoints
+        - exception handling is standardized
+        - API-level tests cover both happy paths and error scenarios
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related Work
+      description: Link ADRs, issues, or PRs
+      placeholder: |
+        Architecture Decisions:
+        - docs/architecture/decisions/xxxx-some-decision.md
+
+        Persistence Decisions:
+        - docs/persistence/decisions/xxxx-some-decision.md
+
+        Related Issues:
+        - #123
+
+        Related PRs:
+        - #456
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Additional context or follow-ups

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,78 @@
+name: Task
+description: A focused unit of work that contributes to an epic or project goal
+title: "[Task]: "
+labels:
+  - task
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to be done?
+      placeholder: |
+        Implement validation for customer status transitions in the domain layer.
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent
+      description: Link the related Epic or issue (use GitHub sub-issues as the source of truth)
+      placeholder: "#123"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Relevant background, decisions, or links
+      placeholder: |
+        Architecture Decision:
+        docs/architecture/decisions/xxxx-some-decision.md
+
+        Persistence Decision:
+        docs/persistence/decisions/xxxx-some-decision.md
+
+        This task implements behavior defined in the decision record.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included in this task?
+      placeholder: |
+        - add validation to the domain model
+        - enforce allowed transitions
+        - throw appropriate exceptions
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What defines completion?
+      placeholder: |
+        - valid transitions succeed
+        - invalid transitions fail with expected exceptions
+        - unit tests cover both scenarios
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: What is not included?
+      placeholder: |
+        - API changes
+        - persistence changes
+        - unrelated refactoring
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Additional implementation notes or follow-ups
+      placeholder: |
+        Any edge cases, follow-ups, or considerations.


### PR DESCRIPTION
## Summary

Add GitHub issue templates for Epics and Tasks aligned with Kartoush workflow and ADR structure.

## Why

Kartoush now has separate architecture and persistence decision directories. Issue templates should reflect this and guide consistent issue creation.

## Changes

- add epic issue template using goal-driven structure
- add task issue template for execution-focused work
- remove manual child task tracking in favor of GitHub sub-issues
- add references to:
  - docs/architecture/decisions
  - docs/persistence/decisions
- disable blank issues

## Notes

- templates align with current project workflow
- sub-issues are now the source of truth for task breakdown
- additional templates (bug, spike) can be added later if needed