### PR TITLE
docs: simplify task issue template based on usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -10,30 +10,9 @@ body:
       label: Summary
       description: What needs to be done?
       placeholder: |
-        Implement validation for customer status transitions in the domain layer.
+        Add Swagger/OpenAPI annotations to all CustomerController endpoints to clearly document request/response models, status codes, and behavior.
     validations:
       required: true
-
-  - type: input
-    id: parent
-    attributes:
-      label: Parent
-      description: Link the related Epic or issue (use GitHub sub-issues as the source of truth)
-      placeholder: "#123"
-
-  - type: textarea
-    id: context
-    attributes:
-      label: Context
-      description: Relevant background, decisions, or links
-      placeholder: |
-        Architecture Decision:
-        docs/architecture/decisions/xxxx-some-decision.md
-
-        Persistence Decision:
-        docs/persistence/decisions/xxxx-some-decision.md
-
-        This task implements behavior defined in the decision record.
 
   - type: textarea
     id: scope
@@ -41,9 +20,10 @@ body:
       label: Scope
       description: What is included in this task?
       placeholder: |
-        - add validation to the domain model
-        - enforce allowed transitions
-        - throw appropriate exceptions
+        - add @Operation descriptions for all endpoints
+        - add @ApiResponses for success and error cases
+        - document request and response models
+        - align descriptions with actual API behavior
     validations:
       required: true
 
@@ -53,26 +33,17 @@ body:
       label: Acceptance Criteria
       description: What defines completion?
       placeholder: |
-        - valid transitions succeed
-        - invalid transitions fail with expected exceptions
-        - unit tests cover both scenarios
+        - all relevant endpoints are documented in Swagger UI
+        - request and response models render correctly
+        - status codes are accurate and consistent with implementation
+        - descriptions clearly explain endpoint behavior
     validations:
       required: true
-
-  - type: textarea
-    id: out_of_scope
-    attributes:
-      label: Out of Scope
-      description: What is not included?
-      placeholder: |
-        - API changes
-        - persistence changes
-        - unrelated refactoring
 
   - type: textarea
     id: notes
     attributes:
       label: Notes
-      description: Additional implementation notes or follow-ups
+      description: Additional implementation notes, references, or follow-ups
       placeholder: |
-        Any edge cases, follow-ups, or considerations.
+        Optional.


### PR DESCRIPTION
## Summary

Simplify the Task issue template based on initial usage to better align with how tasks are actually being created.

## Why

After creating the first tasks using the template, several fields (Parent, Context, Out of Scope) were consistently left empty and did not add meaningful value.

Keeping these fields introduces unnecessary friction and noise when creating issues.

## Changes

- remove Parent field (GitHub sub-issues are now the source of truth)
- remove Context field (can be included in Notes when needed)
- remove Out of Scope field (not needed for most tasks)
- keep:
  - Summary
  - Scope
  - Acceptance Criteria
  - Notes (optional)

## Notes

- aligns the template with actual workflow instead of forcing unused structure
- keeps issue creation fast and focused
- maintains clarity without over-engineering