### PR TITLE
docs(customer): add Swagger/OpenAPI documentation for CustomerController

### DIFF
--- a/docs/architecture/decisions/0023-testing-strategy-and-conventions.md
+++ b/docs/architecture/decisions/0023-testing-strategy-and-conventions.md
@@ -1,0 +1,147 @@
+# ADR 0023: Testing Strategy and Conventions
+
+## Status
+
+Accepted
+
+## Context
+
+Kartoush needs a clear and lightweight testing strategy so contributors can make consistent choices about what to test, how to structure tests, and which test style to use for each layer of the system.
+
+As the codebase grows, unclear testing boundaries increase the risk of duplicated coverage, fragile tests, inconsistent naming, and confusion about when to use mocks versus real infrastructure. Recent work on customer lifecycle behavior, exception handling, and persistence testing highlighted the need for a shared standard.
+
+Kartoush already uses a mix of unit tests, web tests, and persistence integration tests. This ADR defines the intended purpose of each testing layer and establishes conventions for readability and consistency.
+
+## Decision
+
+Kartoush will use a layered testing strategy with explicit responsibilities for each test type.
+
+### Unit tests
+
+Unit tests verify isolated logic without requiring Spring application context startup unless there is a strong justification.
+
+Unit tests should be the default choice for:
+- domain behavior
+- validation logic
+- mapping logic
+- lifecycle rules
+- exception behavior
+- small utility classes
+
+Unit tests should prefer direct object construction over framework bootstrapping. Mocks may be used when collaborating dependencies are required and isolation provides meaningful value.
+
+### Persistence tests
+
+Persistence tests verify JPA mappings, repository behavior, entity lifecycle callbacks, and behavior that depends on a real database.
+
+Persistence tests should use:
+- `@DataJpaTest`
+- Testcontainers
+- `@ServiceConnection`
+
+Persistence tests should prefer a real PostgreSQL database over mocks or in-memory database substitutes when testing persistence behavior.
+
+### Web/API tests
+
+Web tests verify controller contracts and HTTP behavior, including:
+- request binding
+- validation errors
+- response codes
+- response payloads
+- exception-to-response mapping
+
+Web tests should use focused MVC test slices rather than full application startup unless there is a strong reason to test broader wiring.
+
+### Integration tests
+
+Integration tests verify behavior across collaborating components where wiring, transactions, module boundaries, or infrastructure interaction are part of the behavior under test.
+
+Integration tests may use Spring context startup and real infrastructure when the goal is to verify module integration rather than isolated logic.
+
+Integration tests should be used selectively because they are slower and more expensive than unit tests.
+
+## Test structure conventions
+
+Tests should use clear method names in the following format:
+
+`should<ExpectedBehavior>When<Condition>`
+
+Examples:
+- `shouldCreateCustomerWhenValidInputProvided`
+- `shouldThrowExceptionWhenCustomerIdIsMissing`
+- `shouldNotReactivateCustomerWhenStatusIsPending`
+
+Tests should use `given`, `when`, and `then` comments when doing so improves readability.
+
+Example:
+
+    @Test
+    void shouldNormalizeEmailWhenCreatingCustomer() {
+        // given
+        CustomerEntity entity = ...
+
+        // when
+        entity.onCreate();
+
+        // then
+        assertThat(entity.getEmail()).isEqualTo(...);
+    }
+
+For exception tests, combining `when / then` is acceptable when that is clearer.
+
+`@DisplayName` is not part of the standard Kartoush approach. Clear test method names are preferred instead.
+
+## Mocking guidance
+
+Mocks are appropriate when:
+- isolating a unit of logic
+- simulating collaboration failures
+- avoiding unrelated infrastructure in unit tests
+
+Mocks should not replace real infrastructure in persistence tests.
+
+Where test confidence depends on actual database behavior, actual Spring wiring, or real HTTP request handling, mocks should not be used as a substitute for the behavior under test.
+
+## Consequences
+
+### Positive
+
+This decision:
+- makes testing expectations clearer
+- reduces inconsistency in naming and structure
+- encourages fast unit tests for isolated logic
+- preserves real database confidence for persistence behavior
+- improves readability in reviews and maintenance
+
+### Negative
+
+This decision:
+- adds some upfront discipline to test writing
+- may require incremental cleanup of older tests over time
+- does not automatically enforce conventions without future tooling or review discipline
+
+## Scope and adoption
+
+This ADR applies to new tests and to existing tests that are modified as part of normal feature work.
+
+This ADR does not require immediate retrofitting of the entire existing test suite.
+
+## Alternatives considered
+
+### Ad hoc testing decisions
+
+Continue allowing contributors to choose test style and structure case by case without a documented standard.
+
+This was rejected because it leads to inconsistent naming, unclear boundaries, and more review churn.
+
+### Heavy enforcement through tooling first
+
+Introduce automated enforcement for naming and structure before documenting expectations.
+
+This was rejected for now because the immediate need is clarity and shared guidance, not process overhead. Tooling can be added later if needed.
+
+## Related Decisions
+
+- ADR 0002: Architecture Style
+- ADR 0003: Data Ownership
+- ADR 0011: Layering and Facade Contracts

--- a/kartoush/app/src/main/java/com/kartoush/api/customer/CustomerController.java
+++ b/kartoush/app/src/main/java/com/kartoush/api/customer/CustomerController.java
@@ -35,21 +35,39 @@ public class CustomerController {
         this.customerFacade = customerFacade;
     }
 
+    @Operation(summary = "Get all customers")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Customers retrieved successfully")
+    })
     @GetMapping
     public ResponseEntity<List<CustomerView>> getCustomers() {
         return ResponseEntity.ok(customerFacade.getCustomers());
     }
 
+    @Operation(summary = "Get customer by id")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Customer retrieved successfully"),
+        @ApiResponse(responseCode = "404", description = "Customer not found")
+    })
     @GetMapping("/{customerId}")
     public ResponseEntity<CustomerView> getCustomer(@PathVariable final String customerId) {
         return ResponseEntity.ok(customerFacade.getCustomer(customerId));
     }
 
+    @Operation(summary = "Create customer")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Customer created successfully"),
+        @ApiResponse(responseCode = "400", description = "Request validation failed"),
+        @ApiResponse(responseCode = "409", description = "Customer already exists or pending activation")
+    })
     @PostMapping
     public ResponseEntity<CustomerView> createCustomer(
         @Valid @RequestBody final CreateCustomerRequest request) {
+
         LOG.info("Received create customer request for email={}", request.email());
+
         final CustomerView createdCustomer = customerFacade.createCustomer(request);
+
         LOG.info("Created customer id={} for email={}", createdCustomer.customerId(), request.email());
 
         return ResponseEntity
@@ -57,30 +75,25 @@ public class CustomerController {
             .body(createdCustomer);
     }
 
-
-    @Operation(
-        summary = "Update customer profile",
-        description = """
-            Replaces the customer profile fields that are updatable through this API.
-
-            This endpoint updates profile data only, such as first name, last name, and phone number.
-            It does not update the customer's email address and does not change customer lifecycle state.
-
-            The operation is idempotent.
-            """
-    )
+    @Operation(summary = "Update customer profile")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Customer profile updated successfully"),
+        @ApiResponse(responseCode = "200", description = "Customer updated successfully"),
         @ApiResponse(responseCode = "400", description = "Request validation failed"),
         @ApiResponse(responseCode = "404", description = "Customer not found")
     })
     @PutMapping("/{customerId}")
     public ResponseEntity<CustomerView> updateCustomer(
         @PathVariable final String customerId,
-        @RequestBody final UpdateCustomerRequest request) {
+        @Valid @RequestBody final UpdateCustomerRequest request) {
+
         return ResponseEntity.ok(customerFacade.updateCustomer(customerId, request));
     }
 
+    @Operation(summary = "Delete customer")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Customer deleted successfully"),
+        @ApiResponse(responseCode = "404", description = "Customer not found")
+    })
     @DeleteMapping("/{customerId}")
     public ResponseEntity<Void> deleteCustomer(@PathVariable final String customerId) {
         customerFacade.deleteCustomer(customerId);

--- a/kartoush/customer/build.gradle
+++ b/kartoush/customer/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation(libs.springBootStarterFlyway)
     implementation(libs.flywayPostgresql)
     implementation(libs.mapstruct)
+    implementation(libs.swaggerAnnotations)
 
     annotationProcessor(libs.mapstructProcessor)
     testAnnotationProcessor(libs.mapstructProcessor)

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
@@ -1,8 +1,36 @@
 package com.kartoush.customer.facade.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CreateCustomerRequest", description = "Request payload for creating a customer")
 public record CreateCustomerRequest(
-        String firstName,
-        String lastName,
-        String email,
-        String phoneNumber) {
+
+    @Schema(
+        description = "Customer first name",
+        example = "Jack",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String firstName,
+
+    @Schema(
+        description = "Customer last name",
+        example = "Kartoush",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String lastName,
+
+    @Schema(
+        description = "Customer email address",
+        example = "jack@kartoush.test",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String email,
+
+    @Schema(
+        description = "Customer phone number",
+        example = "+16305551234",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    String phoneNumber
+) {
 }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CustomerView.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/CustomerView.java
@@ -1,17 +1,42 @@
 package com.kartoush.customer.facade.model;
 
-import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "CustomerView", description = "Customer response payload")
 public record CustomerView(
-        String customerId,
-        String firstName,
-        String lastName,
-        String email,
-        String phoneNumber,
-        CustomerStatus status
+    @Schema(
+        description = "Customer identifier",
+        example = "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+    String customerId,
+
+    @Schema(
+        description = "Customer first name",
+        example = "Jack")
+    String firstName,
+
+    @Schema(
+        description = "Customer last name",
+        example = "Kartoush")
+    String lastName,
+
+    @Schema(
+        description = "Customer email address",
+        example = "jack@kartoush.test")
+    String email,
+
+    @Schema(
+        description = "Customer phone number",
+        example = "+16305551234",
+        nullable = true)
+    String phoneNumber,
+
+    @Schema(
+        description = "Customer lifecycle status",
+        example = "ACTIVE")
+    CustomerStatus status
 ) {
-    public boolean isActive () {
+    public boolean isActive() {
         return status == CustomerStatus.ACTIVE;
     }
 }

--- a/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/UpdateCustomerRequest.java
+++ b/kartoush/customer/src/main/java/com/kartoush/customer/facade/model/UpdateCustomerRequest.java
@@ -1,7 +1,29 @@
 package com.kartoush.customer.facade.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UpdateCustomerRequest", description = "Request payload for updating customer profile fields")
 public record UpdateCustomerRequest(
-        String firstName,
-        String lastName,
-        String phoneNumber) {
+
+    @Schema(
+        description = "Customer first name",
+        example = "Jack",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String firstName,
+
+    @Schema(
+        description = "Customer last name",
+        example = "Kartoush",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String lastName,
+
+    @Schema(
+        description = "Customer phone number",
+        example = "+13125551234",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    String phoneNumber
+) {
 }

--- a/kartoush/gradle/libs.versions.toml
+++ b/kartoush/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ springDependencyManagement = { id = "io.spring.dependency-management", version.r
 springBootBom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBootVersion" }
 
 springdoc-openapi-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
+swaggerAnnotations = { module = "io.swagger.core.v3:swagger-annotations-jakarta", version = "2.2.28" }
 springBootStarterTest = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBootVersion" }
 springBootStarterDataJpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBootVersion" }
 springBootStarterWeb = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springBootVersion"}


### PR DESCRIPTION
## Summary

Add Swagger/OpenAPI documentation for CustomerController endpoints.

## Scope

- add `@Operation` summaries for all endpoints
- add `@ApiResponses` for success and error status codes
- document request and response models via `@Schema` annotations
- align Swagger output with current API behavior

## Notes

- documentation is intentionally lightweight to avoid controller bloat
- error responses are documented by status code only (no explicit error schema yet)
- activation and reactivation endpoints are intentionally not exposed at this time

## Testing

- verified Swagger UI renders all customer endpoints
- verified request and response models display correctly
- verified status codes align with controller behavior

Closes #106