### PR TITLE
Add testing strategy summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ Integration tests use Testcontainers and will:
 
 ---
 
+## Testing Strategy
+
+Kartoush follows a layered testing approach designed to balance fast feedback with real-world validation.
+
+- **Unit tests** provide fast, isolated validation of business logic  
+- **Integration tests** validate behavior against a real PostgreSQL database using Testcontainers  
+- **verifyAll** runs the full test suite and is the recommended pre-commit verification step  
+
+Integration tests are treated as first-class and are designed to catch issues that only appear in real environments, such as persistence behavior, transaction boundaries, and database constraints.
+
+For detailed testing conventions and design decisions, see:
+
+- `docs/architecture/decisions/0023-testing-strategy-and-conventions.md`
+
+---
+
 ## API Documentation
 
 Swagger UI is available when the application is running:


### PR DESCRIPTION
## Summary

Adds a high-level testing strategy section to the README to clarify how quality and validation are handled in Kartoush.

## Scope

- document unit and integration testing approach
- explain role of Testcontainers in integration tests
- highlight `verifyAll` as the primary verification command
- link to ADR 0023 for detailed testing conventions

## Notes

This section is intentionally high-level to keep the README concise while pointing to deeper architectural documentation.

## Testing

- not applicable (documentation only)

Closes #121