### PR TITLE
feat(customer): add activation token domain and persistence model

### DIFF
--- a/customer/src/main/java/com/kartoush/customer/domain/ActivationToken.java
+++ b/customer/src/main/java/com/kartoush/customer/domain/ActivationToken.java
@@ -1,0 +1,81 @@
+package com.kartoush.customer.domain;
+
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+
+import java.time.Instant;
+
+public class ActivationToken {
+
+    private final ActivationTokenId id;
+    private final CustomerId customerId;
+    private final String tokenHash;
+    private final Instant expiresAt;
+    private final Instant consumedAt;
+    private final Instant createdAt;
+
+    protected ActivationToken(
+        final ActivationTokenId id,
+        final CustomerId customerId,
+        final String tokenHash,
+        final Instant expiresAt,
+        final Instant consumedAt,
+        final Instant createdAt) {
+        this.id = id;
+        this.customerId = customerId;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.consumedAt = consumedAt;
+        this.createdAt = createdAt;
+    }
+
+    public static ActivationToken fromPersistence(
+        final ActivationTokenId id,
+        final CustomerId customerId,
+        final String tokenHash,
+        final Instant expiresAt,
+        final Instant consumedAt,
+        final Instant createdAt) {
+        return new ActivationToken(
+            id,
+            customerId,
+            tokenHash,
+            expiresAt,
+            consumedAt,
+            createdAt
+        );
+    }
+
+
+    public ActivationTokenId getId() {
+        return id;
+    }
+
+    public CustomerId getCustomerId() {
+        return customerId;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public Instant getConsumedAt() {
+        return consumedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public boolean isConsumed() {
+        return consumedAt != null;
+    }
+
+    public boolean isExpired(final Instant now) {
+        return !expiresAt.isAfter(now);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/entity/ActivationTokenEntity.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/entity/ActivationTokenEntity.java
@@ -1,0 +1,118 @@
+package com.kartoush.customer.persistence.entity;
+
+import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "activation_token")
+public class ActivationTokenEntity {
+
+    @EmbeddedId
+    private ActivationTokenIdEmbeddable id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "customer_id", nullable = false))
+    private CustomerIdEmbeddable customerId;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 128)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "consumed_at")
+    private Instant consumedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected ActivationTokenEntity() {
+    }
+
+    protected ActivationTokenEntity(
+        final ActivationTokenIdEmbeddable id,
+        final CustomerIdEmbeddable customerId,
+        final String tokenHash,
+        final Instant expiresAt,
+        final Instant consumedAt,
+        final Instant createdAt) {
+        this.id = id;
+        this.customerId = customerId;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.consumedAt = consumedAt;
+        this.createdAt = createdAt;
+    }
+
+    public static ActivationTokenEntity of(
+        final ActivationTokenIdEmbeddable id,
+        final CustomerIdEmbeddable customerId,
+        final String tokenHash,
+        final Instant expiresAt,
+        final Instant consumedAt,
+        final Instant createdAt) {
+        return new ActivationTokenEntity(
+            id,
+            customerId,
+            tokenHash,
+            expiresAt,
+            consumedAt,
+            createdAt);
+    }
+
+    public ActivationTokenIdEmbeddable getId() {
+        return id;
+    }
+
+    public void setId(ActivationTokenIdEmbeddable id) {
+        this.id = id;
+    }
+
+    public CustomerIdEmbeddable getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(CustomerIdEmbeddable customerId) {
+        this.customerId = customerId;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public void setTokenHash(String tokenHash) {
+        this.tokenHash = tokenHash;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public Instant getConsumedAt() {
+        return consumedAt;
+    }
+
+    public void setConsumedAt(Instant consumedAt) {
+        this.consumedAt = consumedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/mapper/ActivationTokenMapper.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/mapper/ActivationTokenMapper.java
@@ -1,0 +1,58 @@
+package com.kartoush.customer.persistence.mapper;
+
+import com.kartoush.customer.domain.ActivationToken;
+import com.kartoush.customer.persistence.entity.ActivationTokenEntity;
+import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ActivationTokenMapper {
+
+    default ActivationToken toDomain(ActivationTokenEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return ActivationToken.fromPersistence(
+            entity.getId().toActivationTokenId(),
+            entity.getCustomerId().toCustomerId(),
+            entity.getTokenHash(),
+            entity.getExpiresAt(),
+            entity.getConsumedAt(),
+            entity.getCreatedAt()
+        );
+    }
+
+    default ActivationTokenEntity toEntity(ActivationToken domain) {
+        if (domain == null) {
+            return null;
+        }
+
+        return ActivationTokenEntity.of(
+            toEmbeddableId(domain.getId()),
+            toEmbeddableId(domain.getCustomerId()),
+            domain.getTokenHash(),
+            domain.getExpiresAt(),
+            domain.getConsumedAt(),
+            domain.getCreatedAt());
+    }
+
+    default ActivationTokenIdEmbeddable toEmbeddableId(ActivationTokenId activationTokenId) {
+        if (activationTokenId == null) {
+            return null;
+        }
+
+        return ActivationTokenIdEmbeddable.from(activationTokenId);
+    }
+
+    default CustomerIdEmbeddable toEmbeddableId(CustomerId customerId) {
+        if (customerId == null) {
+            return null;
+        }
+
+        return CustomerIdEmbeddable.from(customerId);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/model/ActivationTokenIdEmbeddable.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/model/ActivationTokenIdEmbeddable.java
@@ -1,0 +1,49 @@
+package com.kartoush.customer.persistence.model;
+
+import com.kartoush.platform.types.ActivationTokenId;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class ActivationTokenIdEmbeddable implements Serializable {
+
+    @Column(name = "id", nullable = false, updatable = false, length = 26)
+    private String value;
+
+    protected ActivationTokenIdEmbeddable() {}
+
+    private ActivationTokenIdEmbeddable(final String value) {
+        this.value = Objects.requireNonNull(value, "value");
+    }
+
+    public static ActivationTokenIdEmbeddable from(ActivationTokenId id) {
+        return new ActivationTokenIdEmbeddable(id.value());
+    }
+
+    public ActivationTokenId toActivationTokenId() {
+        return ActivationTokenId.of(this.value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ActivationTokenIdEmbeddable that = (ActivationTokenIdEmbeddable) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/repository/ActivationTokenRepository.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/repository/ActivationTokenRepository.java
@@ -1,0 +1,15 @@
+package com.kartoush.customer.persistence.repository;
+
+import com.kartoush.customer.persistence.entity.ActivationTokenEntity;
+import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ActivationTokenRepository extends JpaRepository<ActivationTokenEntity, ActivationTokenIdEmbeddable> {
+
+    Optional<ActivationTokenEntity> findByCustomerIdAndTokenHash(
+        CustomerIdEmbeddable customerId,
+        String tokenHash);
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/repository/CustomerRepository.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/repository/CustomerRepository.java
@@ -3,7 +3,6 @@ package com.kartoush.customer.persistence.repository;
 import com.kartoush.customer.persistence.entity.CustomerEntity;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import com.kartoush.platform.types.CustomerStatus;
-import com.kartoush.platform.types.Email;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/customer/src/main/resources/db/migration/V7___create_activation_token_table.sql
+++ b/customer/src/main/resources/db/migration/V7___create_activation_token_table.sql
@@ -1,0 +1,14 @@
+create table activation_token
+(
+    id          varchar(26) primary key,
+    customer_id varchar(26)  not null,
+    token_hash  varchar(128) not null unique,
+    expires_at  timestamptz  not null,
+    consumed_at timestamptz  null,
+    created_at  timestamptz  not null,
+    constraint fk_activation_token_customer
+        foreign key (customer_id)
+            references customer (id)
+);
+
+create index idx_activation_token_customer_id on activation_token (customer_id);

--- a/customer/src/test/java/com/kartoush/customer/domain/ActivationTokenTest.java
+++ b/customer/src/test/java/com/kartoush/customer/domain/ActivationTokenTest.java
@@ -1,0 +1,119 @@
+package com.kartoush.customer.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.ulid.DefaultUlidGenerator;
+import com.kartoush.platform.ulid.UlidGenerator;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ActivationTokenTest {
+
+    private static final String TOKEN_HASH = "hashed-token-value";
+
+    private static final Instant CREATED_AT = Instant.parse("2026-04-01T18:00:00Z");
+    private static final Instant EXPIRES_AT = Instant.parse("2026-04-02T18:00:00Z");
+    private static final Instant BEFORE_EXPIRATION = Instant.parse("2026-04-02T17:59:59Z");
+    private static final Instant AT_EXPIRATION = Instant.parse("2026-04-02T18:00:00Z");
+    private static final Instant AFTER_EXPIRATION = Instant.parse("2026-04-02T18:00:01Z");
+    private static final Instant CONSUMED_AT = Instant.parse("2026-04-01T19:00:00Z");
+
+    private final UlidGenerator ulidGenerator = new DefaultUlidGenerator();
+
+    @Test
+    void shouldCreateUnconsumedActivationToken() {
+        // given
+        final ActivationToken activationToken = ActivationToken.fromPersistence(
+            ActivationTokenId.newId(ulidGenerator),
+            CustomerId.newId(ulidGenerator),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            null,
+            CREATED_AT);
+
+        // when
+        final boolean consumed = activationToken.isConsumed();
+
+        // then
+        assertThat(consumed).isFalse();
+        assertThat(activationToken.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(activationToken.getExpiresAt()).isEqualTo(EXPIRES_AT);
+        assertThat(activationToken.getConsumedAt()).isNull();
+        assertThat(activationToken.getCreatedAt()).isEqualTo(CREATED_AT);
+    }
+
+    @Test
+    void shouldReturnFalseWhenTokenIsNotExpired() {
+        // given
+        final ActivationToken activationToken = ActivationToken.fromPersistence(
+            ActivationTokenId.newId(ulidGenerator),
+            CustomerId.newId(ulidGenerator),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            null,
+            CREATED_AT);
+
+        // when
+        final boolean expired = activationToken.isExpired(BEFORE_EXPIRATION);
+
+        // then
+        assertThat(expired).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenTokenIsAtExpiration() {
+        // given
+        final ActivationToken activationToken = ActivationToken.fromPersistence(
+            ActivationTokenId.newId(ulidGenerator),
+            CustomerId.newId(ulidGenerator),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            null,
+            CREATED_AT);
+
+        // when
+        final boolean expired = activationToken.isExpired(AT_EXPIRATION);
+
+        // then
+        assertThat(expired).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenTokenIsAfterExpiration() {
+        // given
+        final ActivationToken activationToken = ActivationToken.fromPersistence(
+            ActivationTokenId.newId(ulidGenerator),
+            CustomerId.newId(ulidGenerator),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            null,
+            CREATED_AT);
+
+        // when
+        final boolean expired = activationToken.isExpired(AFTER_EXPIRATION);
+
+        // then
+        assertThat(expired).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenTokenIsConsumed() {
+        // given
+        final ActivationToken activationToken = ActivationToken.fromPersistence(
+            ActivationTokenId.newId(ulidGenerator),
+            CustomerId.newId(ulidGenerator),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            CONSUMED_AT,
+            CREATED_AT);
+
+        // when
+        final boolean consumed = activationToken.isConsumed();
+
+        // then
+        assertThat(consumed).isTrue();
+        assertThat(activationToken.getConsumedAt()).isEqualTo(CONSUMED_AT);
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/persistence/entity/ActivationTokenEntityTest.java
+++ b/customer/src/test/java/com/kartoush/customer/persistence/entity/ActivationTokenEntityTest.java
@@ -1,0 +1,76 @@
+package com.kartoush.customer.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.ulid.DefaultUlidGenerator;
+import com.kartoush.platform.ulid.UlidGenerator;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ActivationTokenEntityTest {
+
+    private static final String TOKEN_HASH = "hashed-token-value";
+    private static final Instant CREATED_AT = Instant.parse("2026-04-01T18:00:00Z");
+    private static final Instant EXPIRES_AT = Instant.parse("2026-04-02T18:00:00Z");
+    private static final Instant CONSUMED_AT = Instant.parse("2026-04-01T19:00:00Z");
+
+    private final UlidGenerator ulidGenerator = new DefaultUlidGenerator();
+
+    @Test
+    void shouldCreateActivationTokenEntityWithNullConsumedAt() {
+        // given
+        final ActivationTokenIdEmbeddable activationTokenId =
+            ActivationTokenIdEmbeddable.from(ActivationTokenId.newId(ulidGenerator));
+        final CustomerIdEmbeddable customerId =
+            CustomerIdEmbeddable.from(CustomerId.newId(ulidGenerator));
+
+        // when
+        final ActivationTokenEntity activationTokenEntity = ActivationTokenEntity.of(
+            activationTokenId,
+            customerId,
+            TOKEN_HASH,
+            EXPIRES_AT,
+            null,
+            CREATED_AT
+        );
+
+        // then
+        assertThat(activationTokenEntity.getId()).isEqualTo(activationTokenId);
+        assertThat(activationTokenEntity.getCustomerId()).isEqualTo(customerId);
+        assertThat(activationTokenEntity.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(activationTokenEntity.getExpiresAt()).isEqualTo(EXPIRES_AT);
+        assertThat(activationTokenEntity.getConsumedAt()).isNull();
+        assertThat(activationTokenEntity.getCreatedAt()).isEqualTo(CREATED_AT);
+    }
+
+    @Test
+    void shouldCreateActivationTokenEntityWithConsumedAt() {
+        // given
+        final ActivationTokenIdEmbeddable activationTokenId =
+            ActivationTokenIdEmbeddable.from(ActivationTokenId.newId(ulidGenerator));
+        final CustomerIdEmbeddable customerId =
+            CustomerIdEmbeddable.from(CustomerId.newId(ulidGenerator));
+
+        // when
+        final ActivationTokenEntity activationTokenEntity = ActivationTokenEntity.of(
+            activationTokenId,
+            customerId,
+            TOKEN_HASH,
+            EXPIRES_AT,
+            CONSUMED_AT,
+            CREATED_AT
+        );
+
+        // then
+        assertThat(activationTokenEntity.getId()).isEqualTo(activationTokenId);
+        assertThat(activationTokenEntity.getCustomerId()).isEqualTo(customerId);
+        assertThat(activationTokenEntity.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(activationTokenEntity.getExpiresAt()).isEqualTo(EXPIRES_AT);
+        assertThat(activationTokenEntity.getConsumedAt()).isEqualTo(CONSUMED_AT);
+        assertThat(activationTokenEntity.getCreatedAt()).isEqualTo(CREATED_AT);
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/persistence/entity/CustomerEntityTest.java
+++ b/customer/src/test/java/com/kartoush/customer/persistence/entity/CustomerEntityTest.java
@@ -1,4 +1,4 @@
-package com.kartoush.customer.persistence;
+package com.kartoush.customer.persistence.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -6,8 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Instant;
 import java.util.Locale;
 
-import com.kartoush.customer.persistence.entity.CustomerEntity;
-import com.kartoush.customer.persistence.entity.CustomerProfileEntity;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;

--- a/customer/src/test/java/com/kartoush/customer/persistence/repository/ActivationTokenRepositoryTest.java
+++ b/customer/src/test/java/com/kartoush/customer/persistence/repository/ActivationTokenRepositoryTest.java
@@ -1,0 +1,188 @@
+package com.kartoush.customer.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kartoush.customer.CustomerTestApplication;
+import com.kartoush.customer.persistence.entity.ActivationTokenEntity;
+import com.kartoush.customer.persistence.entity.CustomerEntity;
+import com.kartoush.customer.persistence.entity.CustomerProfileEntity;
+import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.types.CustomerStatus;
+import com.kartoush.platform.ulid.DefaultUlidGenerator;
+import com.kartoush.platform.ulid.UlidGenerator;
+import com.kartoush.testsupport.IntegrationTest;
+import com.kartoush.testsupport.PostgresDataJpaTest;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.ContextConfiguration;
+
+@IntegrationTest
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(classes = CustomerTestApplication.class)
+class ActivationTokenRepositoryTest extends PostgresDataJpaTest {
+
+    private static final String FIRST_NAME = "Jack";
+    private static final String LAST_NAME = "Kartoush";
+    private static final String PHONE_NUMBER = "555-555-1212";
+    private static final String EMAIL_PREFIX = "jack";
+    private static final String EMAIL_SUFFIX = "@kartoush.com";
+    private static final String PASSWORD_HASH = "ABCXYZ123789";
+
+    private static final String TOKEN_HASH = "hashed-token-value";
+    private static final String UNKNOWN_TOKEN_HASH = "unknown-token-value";
+
+    private static final Instant CREATED_AT = Instant.parse("2026-04-01T18:00:00Z");
+    private static final Instant EXPIRES_AT = Instant.parse("2026-04-02T18:00:00Z");
+    private static final Instant CONSUMED_AT = Instant.parse("2026-04-01T19:00:00Z");
+
+    private final UlidGenerator ulidGenerator = new DefaultUlidGenerator();
+
+    @Autowired
+    private ActivationTokenRepository activationTokenRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void shouldPersistAndLoadActivationToken() {
+        // given
+        final CustomerEntity customer = saveCustomer();
+        final ActivationTokenIdEmbeddable activationTokenId =
+            ActivationTokenIdEmbeddable.from(ActivationTokenId.newId(ulidGenerator));
+
+        final ActivationTokenEntity activationToken = ActivationTokenEntity.of(
+            activationTokenId,
+            customer.getCustomerId(),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            null,
+            CREATED_AT
+        );
+
+        // when
+        final ActivationTokenEntity saved = activationTokenRepository.saveAndFlush(activationToken);
+        final Optional<ActivationTokenEntity> retrieved =
+            activationTokenRepository.findById(saved.getId());
+
+        // then
+        assertThat(saved.getId()).isEqualTo(activationTokenId);
+        assertThat(saved.getCustomerId()).isEqualTo(customer.getCustomerId());
+        assertThat(saved.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(saved.getExpiresAt()).isEqualTo(EXPIRES_AT);
+        assertThat(saved.getConsumedAt()).isNull();
+        assertThat(saved.getCreatedAt()).isEqualTo(CREATED_AT);
+
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get().getId()).isEqualTo(activationTokenId);
+        assertThat(retrieved.get().getCustomerId()).isEqualTo(customer.getCustomerId());
+        assertThat(retrieved.get().getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(retrieved.get().getExpiresAt()).isEqualTo(EXPIRES_AT);
+        assertThat(retrieved.get().getConsumedAt()).isNull();
+        assertThat(retrieved.get().getCreatedAt()).isEqualTo(CREATED_AT);
+    }
+
+    @Test
+    void shouldFindByCustomerIdAndTokenHash() {
+        // given
+        final CustomerEntity customer = saveCustomer();
+        final ActivationTokenEntity activationToken = saveActivationToken(
+            customer.getCustomerId(),
+            TOKEN_HASH,
+            null
+        );
+
+        // when
+        final Optional<ActivationTokenEntity> retrieved =
+            activationTokenRepository.findByCustomerIdAndTokenHash(
+                customer.getCustomerId(),
+                TOKEN_HASH
+            );
+
+        // then
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get().getId()).isEqualTo(activationToken.getId());
+        assertThat(retrieved.get().getCustomerId()).isEqualTo(customer.getCustomerId());
+        assertThat(retrieved.get().getTokenHash()).isEqualTo(TOKEN_HASH);
+    }
+
+    @Test
+    void shouldNotFindByCustomerIdAndTokenHashWhenTokenHashDoesNotMatch() {
+        // given
+        final CustomerEntity customer = saveCustomer();
+        saveActivationToken(customer.getCustomerId(), TOKEN_HASH, null);
+
+        // when
+        final Optional<ActivationTokenEntity> retrieved =
+            activationTokenRepository.findByCustomerIdAndTokenHash(
+                customer.getCustomerId(),
+                UNKNOWN_TOKEN_HASH
+            );
+
+        // then
+        assertThat(retrieved).isEmpty();
+    }
+
+    @Test
+    void shouldPersistConsumedAtForConsumedToken() {
+        // given
+        final CustomerEntity customer = saveCustomer();
+        final ActivationTokenEntity activationToken = ActivationTokenEntity.of(
+            ActivationTokenIdEmbeddable.from(ActivationTokenId.newId(ulidGenerator)),
+            customer.getCustomerId(),
+            TOKEN_HASH,
+            EXPIRES_AT,
+            CONSUMED_AT,
+            CREATED_AT
+        );
+
+        // when
+        final ActivationTokenEntity saved = activationTokenRepository.saveAndFlush(activationToken);
+        final ActivationTokenEntity retrieved = activationTokenRepository.findById(saved.getId()).orElseThrow();
+
+        // then
+        assertThat(retrieved.getConsumedAt()).isEqualTo(CONSUMED_AT);
+    }
+
+    private CustomerEntity saveCustomer() {
+        final CustomerIdEmbeddable customerId = CustomerIdEmbeddable.from(CustomerId.newId(ulidGenerator));
+        final CustomerProfileEntity profile = new CustomerProfileEntity(FIRST_NAME, LAST_NAME, PHONE_NUMBER);
+        final CustomerEntity customer = CustomerEntity.newCustomer(
+            customerId,
+            profile,
+            uniqueEmail(customerId),
+            PASSWORD_HASH,
+            CustomerStatus.PENDING
+        );
+
+        return customerRepository.saveAndFlush(customer);
+    }
+
+    private ActivationTokenEntity saveActivationToken(
+        final CustomerIdEmbeddable customerId,
+        final String tokenHash,
+        final Instant consumedAt
+    ) {
+        final ActivationTokenEntity activationToken = ActivationTokenEntity.of(
+            ActivationTokenIdEmbeddable.from(ActivationTokenId.newId(ulidGenerator)),
+            customerId,
+            tokenHash,
+            EXPIRES_AT,
+            consumedAt,
+            CREATED_AT
+        );
+
+        return activationTokenRepository.saveAndFlush(activationToken);
+    }
+
+    private String uniqueEmail(final CustomerIdEmbeddable customerId) {
+        return EMAIL_PREFIX + customerId.getValue() + EMAIL_SUFFIX;
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/persistence/repository/CustomerEntityRepositoryTest.java
+++ b/customer/src/test/java/com/kartoush/customer/persistence/repository/CustomerEntityRepositoryTest.java
@@ -1,24 +1,20 @@
-package com.kartoush.customer.persistence;
+package com.kartoush.customer.persistence.repository;
 
 import com.kartoush.customer.persistence.entity.CustomerEntity;
 import com.kartoush.customer.persistence.entity.CustomerProfileEntity;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
-import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.customer.CustomerTestApplication;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.ulid.DefaultUlidGenerator;
 import com.kartoush.platform.ulid.UlidGenerator;
 import com.kartoush.testsupport.IntegrationTest;
+import com.kartoush.testsupport.PostgresDataJpaTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.test.context.ContextConfiguration;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.util.List;
 import java.util.Locale;
@@ -27,25 +23,16 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
-@Testcontainers
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = CustomerTestApplication.class)
-class CustomerEntityRepositoryTest {
+class CustomerEntityRepositoryTest extends PostgresDataJpaTest {
 
     private static final String FIRST_NAME = "Jack";
     private static final String LAST_NAME = "Kartoush";
     private static final String PHONE_NUMBER = "555-555-1212";
     private static final String EMAIL = "jack@kartoush.test";
     private static final String PASSWORD_HASH = "ABCXYZ123789";
-
-    @Container
-    @ServiceConnection
-    static PostgreSQLContainer postgres =
-        new PostgreSQLContainer("postgres:16-alpine")
-            .withDatabaseName("kartoush")
-            .withUsername("kartoush")
-            .withPassword("kartoush")
-            .waitingFor(Wait.forListeningPort());
 
     private final UlidGenerator ulidGenerator = new DefaultUlidGenerator();
 
@@ -62,8 +49,7 @@ class CustomerEntityRepositoryTest {
             profile,
             EMAIL,
             PASSWORD_HASH,
-            CustomerStatus.ACTIVE
-        );
+            CustomerStatus.ACTIVE);
 
         CustomerEntity saved = customerRepository.saveAndFlush(customer);
         CustomerProfileEntity savedProfile = saved.getProfile();
@@ -105,8 +91,7 @@ class CustomerEntityRepositoryTest {
             profile,
             EMAIL,
             PASSWORD_HASH,
-            CustomerStatus.ACTIVE
-        );
+            CustomerStatus.ACTIVE);
 
         // when
         CustomerEntity saved = customerRepository.saveAndFlush(customerEntity);
@@ -127,8 +112,7 @@ class CustomerEntityRepositoryTest {
             profile,
             originalEmail,
             PASSWORD_HASH,
-            CustomerStatus.PENDING
-        );
+            CustomerStatus.PENDING);
 
         customerRepository.saveAndFlush(first);
 
@@ -146,8 +130,7 @@ class CustomerEntityRepositoryTest {
             profile2,
             originalEmail,
             PASSWORD_HASH,
-            CustomerStatus.PENDING
-        );
+            CustomerStatus.PENDING);
 
         customerRepository.saveAndFlush(second);
 

--- a/platform/platform-types/src/main/java/com/kartoush/platform/types/ActivationTokenId.java
+++ b/platform/platform-types/src/main/java/com/kartoush/platform/types/ActivationTokenId.java
@@ -1,0 +1,40 @@
+package com.kartoush.platform.types;
+
+import com.kartoush.platform.ulid.UlidGenerator;
+import com.kartoush.platform.ulid.Ulids;
+
+import java.util.Objects;
+
+public class ActivationTokenId {
+    private final String value;
+
+    private ActivationTokenId(String value) {
+        this.value = value;
+    }
+
+    public static ActivationTokenId of(String value) {
+        return new ActivationTokenId(
+            Ulids.requireValid(value, "ActivationTokenId")
+        );
+    }
+
+    public static ActivationTokenId newId(UlidGenerator generator) {
+        return new ActivationTokenId(generator.next());
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ActivationTokenId that = (ActivationTokenId) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+}

--- a/test-support/src/main/java/com/kartoush/testsupport/PostgresDataJpaTest.java
+++ b/test-support/src/main/java/com/kartoush/testsupport/PostgresDataJpaTest.java
@@ -1,0 +1,37 @@
+package com.kartoush.testsupport;
+
+import java.time.Duration;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+public abstract class PostgresDataJpaTest {
+
+    private static final String POSTGRES_DOCKER_IMAGE_NAME = "postgres:16";
+    private static final String DATABASE_NAME = "kartoush";
+    private static final String USERNAME = "kartoush";
+    private static final String PASSWORD = "kartoush";
+
+    private static final String APP_LABEL_KEY = "app";
+    private static final String ENV_LABEL_KEY = "env";
+    private static final String APP_LABEL_VALUE = "kartoush";
+    private static final String ENV_LABEL_VALUE = "test";
+
+    private static final int STARTUP_ATTEMPTS = 3;
+    private static final Duration STARTUP_TIMEOUT_DURATION = Duration.ofSeconds(60);
+
+    @ServiceConnection
+    protected static final PostgreSQLContainer POSTGRES =
+        new PostgreSQLContainer(POSTGRES_DOCKER_IMAGE_NAME)
+            .withDatabaseName(DATABASE_NAME)
+            .withUsername(USERNAME)
+            .withPassword(PASSWORD)
+            .withLabel(APP_LABEL_KEY, APP_LABEL_VALUE)
+            .withLabel(ENV_LABEL_KEY, ENV_LABEL_VALUE)
+            .withStartupAttempts(STARTUP_ATTEMPTS)
+            .withStartupTimeout(STARTUP_TIMEOUT_DURATION);
+
+    static {
+        POSTGRES.start();
+    }
+}


### PR DESCRIPTION
## Summary

Defines the activation token domain and persistence model within the
customer module, establishing the foundation for account activation
flows.

## Scope

- add ActivationToken domain model with derived lifecycle state (expiration, consumption)
- introduce ActivationTokenId and embeddable persistence mapping
- implement ActivationTokenEntity with factory method and JPA mappings
- add ActivationTokenMapper for domain ↔ entity conversion
- add ActivationTokenRepository with customerId and tokenHash lookup
- create Flyway migration for activation_token table with unique token_hash
- add unit tests for domain behavior (expiration, consumption state)
- add entity tests for ActivationTokenEntity factory
- add repository integration tests using shared Postgres container
- introduce PostgresDataJpaTest base class for reusable Testcontainers configuration
- update repository tests to extend PostgresDataJpaTest
- move CustomerEntityTest to repository package for consistency

## Notes

Lifecycle state is derived from timestamps rather than a persisted
status to avoid state drift and ensure consistency between expiration
and consumption logic.

This task establishes structure and invariants only. Token generation,
validation, and activation behavior will be implemented in subsequent
tasks.

## Testing

- unit tests cover ActivationToken domain behavior
- entity tests validate ActivationTokenEntity construction
- integration tests verify persistence and repository queries
- Testcontainers configuration is centralized via PostgresDataJpaTest

Closes #140