### PR TITLE
Implement activation token creation and hashing

### DIFF
--- a/customer/src/main/java/com/kartoush/customer/domain/ActivationToken.java
+++ b/customer/src/main/java/com/kartoush/customer/domain/ActivationToken.java
@@ -46,6 +46,24 @@ public class ActivationToken {
         );
     }
 
+    public static ActivationToken of(
+        final ActivationTokenId id,
+        final CustomerId customerId,
+        final String tokenHash,
+        final Instant expiresAt,
+        final Instant consumedAt,
+        final Instant createdAt
+    ) {
+        return new ActivationToken(
+            id,
+            customerId,
+            tokenHash,
+            expiresAt,
+            consumedAt,
+            createdAt
+        );
+    }
+
 
     public ActivationTokenId getId() {
         return id;

--- a/customer/src/main/java/com/kartoush/customer/infrastructure/config/TimeConfiguration.java
+++ b/customer/src/main/java/com/kartoush/customer/infrastructure/config/TimeConfiguration.java
@@ -1,0 +1,14 @@
+package com.kartoush.customer.infrastructure.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfiguration {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationTokenGenerator.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationTokenGenerator.java
@@ -1,0 +1,6 @@
+package com.kartoush.customer.service;
+
+public interface ActivationTokenGenerator {
+
+    String generate();
+}

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationTokenHasher.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationTokenHasher.java
@@ -1,0 +1,6 @@
+package com.kartoush.customer.service;
+
+public interface ActivationTokenHasher {
+
+    String hash(String rawToken);
+}

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationTokenService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationTokenService.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.service;
+
+import com.kartoush.customer.domain.ActivationToken;
+import com.kartoush.platform.types.CustomerId;
+
+public interface ActivationTokenService {
+    ActivationToken createFor(CustomerId customerId);
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenGenerator.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenGenerator.java
@@ -1,0 +1,25 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.service.ActivationTokenGenerator;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class DefaultActivationTokenGenerator implements ActivationTokenGenerator {
+
+    private static final int TOKEN_BYTE_LENGTH = 32;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public String generate() {
+        byte[] tokenBytes = new byte[TOKEN_BYTE_LENGTH];
+        secureRandom.nextBytes(tokenBytes);
+
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(tokenBytes);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenHasher.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenHasher.java
@@ -1,0 +1,26 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.service.ActivationTokenHasher;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultActivationTokenHasher implements ActivationTokenHasher {
+
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    @Override
+    public String hash(String rawToken) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(HASH_ALGORITHM);
+            byte[] hashedBytes = messageDigest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+
+            return HexFormat.of().formatHex(hashedBytes);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("Unable to hash activation token", exception);
+        }
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenService.java
@@ -1,0 +1,76 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.domain.ActivationToken;
+import com.kartoush.customer.exception.CustomerNotFoundException;
+import com.kartoush.customer.persistence.entity.ActivationTokenEntity;
+import com.kartoush.customer.persistence.mapper.ActivationTokenMapper;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
+import com.kartoush.customer.persistence.repository.CustomerRepository;
+import com.kartoush.customer.service.ActivationTokenGenerator;
+import com.kartoush.customer.service.ActivationTokenHasher;
+import com.kartoush.customer.service.ActivationTokenService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.ulid.UlidGenerator;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultActivationTokenService implements ActivationTokenService {
+
+    private static final Duration ACTIVATION_TOKEN_TTL = Duration.ofHours(24);
+
+    private final ActivationTokenRepository activationTokenRepository;
+    private final CustomerRepository customerRepository;
+    private final ActivationTokenGenerator activationTokenGenerator;
+    private final ActivationTokenHasher activationTokenHasher;
+    private final ActivationTokenMapper activationTokenMapper;
+    private final UlidGenerator ulidGenerator;
+    private final Clock clock;
+
+    public DefaultActivationTokenService(
+        ActivationTokenRepository activationTokenRepository,
+        CustomerRepository customerRepository,
+        ActivationTokenGenerator activationTokenGenerator,
+        ActivationTokenHasher activationTokenHasher,
+        ActivationTokenMapper activationTokenMapper,
+        UlidGenerator ulidGenerator,
+        Clock clock) {
+        this.activationTokenRepository = activationTokenRepository;
+        this.customerRepository = customerRepository;
+        this.activationTokenGenerator = activationTokenGenerator;
+        this.activationTokenHasher = activationTokenHasher;
+        this.activationTokenMapper = activationTokenMapper;
+        this.ulidGenerator = ulidGenerator;
+        this.clock = clock;
+    }
+
+    @Override
+    public ActivationToken createFor(CustomerId customerId) {
+        if (!customerRepository.existsById(CustomerIdEmbeddable.from(customerId))) {
+            throw new CustomerNotFoundException(customerId.value());
+        }
+
+        Instant createdAt = Instant.now(clock);
+        Instant expiresAt = createdAt.plus(ACTIVATION_TOKEN_TTL);
+
+        String rawToken = activationTokenGenerator.generate();
+        String tokenHash = activationTokenHasher.hash(rawToken);
+
+        ActivationToken activationToken = ActivationToken.of(
+            ActivationTokenId.newId(ulidGenerator),
+            customerId,
+            tokenHash,
+            expiresAt,
+            null,
+            createdAt);
+
+        ActivationTokenEntity activationTokenEntity = activationTokenMapper.toEntity(activationToken);
+
+        return activationTokenMapper.toDomain(activationTokenRepository.save(activationTokenEntity));
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenGeneratorTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenGeneratorTest.java
@@ -1,0 +1,53 @@
+package com.kartoush.customer.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kartoush.customer.service.ActivationTokenGenerator;
+import org.junit.jupiter.api.Test;
+
+class DefaultActivationTokenGeneratorTest {
+
+    private static final String URL_SAFE_BASE64_PATTERN = "^[A-Za-z0-9_-]+$";
+
+    private final ActivationTokenGenerator activationTokenGenerator =
+        new DefaultActivationTokenGenerator();
+
+    @Test
+    void shouldGenerateNonBlankToken() {
+        // given/when
+        String token = activationTokenGenerator.generate();
+
+        // then
+        assertThat(token).isNotBlank();
+    }
+
+    @Test
+    void shouldGenerateDifferentTokensAcrossCalls() {
+        // given/when
+        String firstToken = activationTokenGenerator.generate();
+        String secondToken = activationTokenGenerator.generate();
+
+        // then
+        assertThat(firstToken).isNotEqualTo(secondToken);
+    }
+
+    @Test
+    void shouldGenerateUrlSafeTokenWithoutPadding() {
+        // given/when
+        String token = activationTokenGenerator.generate();
+
+        // then
+        assertThat(token)
+            .matches(URL_SAFE_BASE64_PATTERN)
+            .doesNotContain("=");
+    }
+
+    @Test
+    void shouldGenerateExpectedTokenLength() {
+        // given / when
+        String token = activationTokenGenerator.generate();
+
+        // then
+        assertThat(token).hasSize(43);
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenHasherTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenHasherTest.java
@@ -1,0 +1,69 @@
+package com.kartoush.customer.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kartoush.customer.service.ActivationTokenHasher;
+import org.junit.jupiter.api.Test;
+
+class DefaultActivationTokenHasherTest {
+
+    private static final String HEX_PATTERN = "^[0-9a-f]+$";
+    private static final String SAMPLE_ACTIVATION_TOKEN = "sample-activation-token";
+    private static final String HASHED_SAMPLE_ACTIVATION_TOKEN = "ca288cabaeeb1144926c4d530e0cae0b5e4ae5d0b299fe104d0f385516191874";
+    private static final String FIRST_TOKEN = "first-token";
+    private static final String SECOND_TOKEN = "second-token";
+
+    private final ActivationTokenHasher activationTokenHasher =
+        new DefaultActivationTokenHasher();
+
+    @Test
+    void shouldReturnConsistentHashForSameToken() {
+        // given
+        String token = SAMPLE_ACTIVATION_TOKEN;
+
+        // when
+        String firstHash = activationTokenHasher.hash(token);
+        String secondHash = activationTokenHasher.hash(token);
+
+        // then
+        assertThat(firstHash).isEqualTo(secondHash);
+    }
+
+    @Test
+    void shouldReturnDifferentHashForDifferentTokens() {
+        // given/when
+        String firstHash = activationTokenHasher.hash(FIRST_TOKEN);
+        String secondHash = activationTokenHasher.hash(SECOND_TOKEN);
+
+        // then
+        assertThat(firstHash).isNotEqualTo(secondHash);
+    }
+
+    @Test
+    void shouldReturnLowercaseHexHash() {
+        // given/when
+        String hash = activationTokenHasher.hash(SAMPLE_ACTIVATION_TOKEN);
+
+        // then
+        assertThat(hash).matches(HEX_PATTERN);
+    }
+
+    @Test
+    void shouldReturnHashWithExpectedLength() {
+        // given/when
+        String hash = activationTokenHasher.hash(SAMPLE_ACTIVATION_TOKEN);
+
+        // then
+        assertThat(hash).hasSize(64);
+    }
+
+    @Test
+    void shouldReturnKnownHashForToken() {
+        // given/when
+        String hash = activationTokenHasher.hash(SAMPLE_ACTIVATION_TOKEN);
+
+        // then
+        assertThat(hash)
+            .isEqualTo(HASHED_SAMPLE_ACTIVATION_TOKEN);
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenServiceTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenServiceTest.java
@@ -1,0 +1,279 @@
+package com.kartoush.customer.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kartoush.customer.domain.ActivationToken;
+import com.kartoush.customer.exception.CustomerNotFoundException;
+import com.kartoush.customer.persistence.entity.ActivationTokenEntity;
+import com.kartoush.customer.persistence.mapper.ActivationTokenMapper;
+import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
+import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
+import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
+import com.kartoush.customer.persistence.repository.CustomerRepository;
+import com.kartoush.customer.service.ActivationTokenGenerator;
+import com.kartoush.customer.service.ActivationTokenHasher;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import com.kartoush.platform.types.ActivationTokenId;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.ulid.UlidGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultActivationTokenServiceTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-04-06T15:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+    private static final String RAW_TOKEN = "generated-raw-token";
+    private static final String TOKEN_HASH = "generated-token-hash";
+    private static final String CUSTOMER_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    private static final String ACTIVATION_TOKEN_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    private static final long TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60;
+
+    @Mock
+    private ActivationTokenRepository activationTokenRepository;
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @Mock
+    private ActivationTokenGenerator activationTokenGenerator;
+
+    @Mock
+    private ActivationTokenHasher activationTokenHasher;
+
+    @Mock
+    private ActivationTokenMapper activationTokenMapper;
+
+    @Mock
+    private UlidGenerator ulidGenerator;
+
+    @Captor
+    private ArgumentCaptor<ActivationTokenEntity> activationTokenEntityCaptor;
+
+    @Test
+    void shouldCreateActivationTokenForCustomer() {
+        // given
+        CustomerId customerId = CustomerId.of(CUSTOMER_ID);
+
+        DefaultActivationTokenService activationTokenService =
+            new DefaultActivationTokenService(
+                activationTokenRepository,
+                customerRepository,
+                activationTokenGenerator,
+                activationTokenHasher,
+                activationTokenMapper,
+                ulidGenerator,
+                FIXED_CLOCK);
+
+        stubExistingCustomer(customerId);
+        when(activationTokenGenerator.generate()).thenReturn(RAW_TOKEN);
+        when(activationTokenHasher.hash(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        stubGeneratedActivationTokenId();
+        stubMapperToEntity();
+        stubMapperToDomain();
+        when(activationTokenRepository.save(activationTokenEntityCaptor.capture()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ActivationToken activationToken = activationTokenService.createFor(customerId);
+
+        // then
+        verify(activationTokenGenerator).generate();
+        verify(activationTokenHasher).hash(RAW_TOKEN);
+        verify(activationTokenRepository).save(activationTokenEntityCaptor.getValue());
+
+        ActivationTokenEntity savedActivationTokenEntity = activationTokenEntityCaptor.getValue();
+
+        assertThat(savedActivationTokenEntity.getCustomerId()).isEqualTo(CustomerIdEmbeddable.from(customerId));
+        assertThat(savedActivationTokenEntity.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(savedActivationTokenEntity.getCreatedAt()).isEqualTo(FIXED_INSTANT);
+        assertThat(savedActivationTokenEntity.getExpiresAt()).isEqualTo(FIXED_INSTANT.plusSeconds(TWENTY_FOUR_HOURS_IN_SECONDS));
+        assertThat(savedActivationTokenEntity.getConsumedAt()).isNull();
+        assertThat(savedActivationTokenEntity.getId()).isNotNull();
+
+        assertThat(activationToken.getId()).isEqualTo(ActivationTokenId.of(ACTIVATION_TOKEN_ID));
+        assertThat(activationToken.getCustomerId()).isEqualTo(customerId);
+        assertThat(activationToken.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(activationToken.getCreatedAt()).isEqualTo(FIXED_INSTANT);
+        assertThat(activationToken.getExpiresAt()).isEqualTo(FIXED_INSTANT.plusSeconds(TWENTY_FOUR_HOURS_IN_SECONDS));
+        assertThat(activationToken.getConsumedAt()).isNull();
+    }
+
+    @Test
+    void shouldSetExpirationToTwentyFourHoursAfterCreation() {
+        // given
+        CustomerId customerId = CustomerId.of(CUSTOMER_ID);
+
+        DefaultActivationTokenService activationTokenService =
+            new DefaultActivationTokenService(
+                activationTokenRepository,
+                customerRepository,
+                activationTokenGenerator,
+                activationTokenHasher,
+                activationTokenMapper,
+                ulidGenerator,
+                FIXED_CLOCK);
+
+        stubExistingCustomer(customerId);
+        when(activationTokenGenerator.generate()).thenReturn(RAW_TOKEN);
+        when(activationTokenHasher.hash(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        stubGeneratedActivationTokenId();
+        stubMapperToEntity();
+        when(activationTokenRepository.save(activationTokenEntityCaptor.capture()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        activationTokenService.createFor(customerId);
+
+        // then
+        ActivationTokenEntity savedActivationToken = activationTokenEntityCaptor.getValue();
+        assertThat(savedActivationToken.getExpiresAt())
+            .isEqualTo(savedActivationToken.getCreatedAt().plusSeconds(TWENTY_FOUR_HOURS_IN_SECONDS));
+    }
+
+    @Test
+    void shouldHashGeneratedRawTokenBeforeSaving() {
+        // given
+        CustomerId customerId = CustomerId.of(CUSTOMER_ID);
+
+        DefaultActivationTokenService activationTokenService =
+            new DefaultActivationTokenService(
+                activationTokenRepository,
+                customerRepository,
+                activationTokenGenerator,
+                activationTokenHasher,
+                activationTokenMapper,
+                ulidGenerator,
+                FIXED_CLOCK);
+
+        stubExistingCustomer(customerId);
+        when(activationTokenGenerator.generate()).thenReturn(RAW_TOKEN);
+        when(activationTokenHasher.hash(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        stubGeneratedActivationTokenId();
+        stubMapperToEntity();
+        when(activationTokenRepository.save(activationTokenEntityCaptor.capture()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        activationTokenService.createFor(customerId);
+
+        // then
+        verify(activationTokenHasher).hash(RAW_TOKEN);
+
+        ActivationTokenEntity savedActivationToken = activationTokenEntityCaptor.getValue();
+        assertThat(savedActivationToken.getTokenHash()).isEqualTo(TOKEN_HASH);
+    }
+
+    @Test
+    void shouldGenerateHashAndSaveOnlyOnce() {
+        // given
+        CustomerId customerId = CustomerId.of(CUSTOMER_ID);
+
+        DefaultActivationTokenService activationTokenService =
+            new DefaultActivationTokenService(
+                activationTokenRepository,
+                customerRepository,
+                activationTokenGenerator,
+                activationTokenHasher,
+                activationTokenMapper,
+                ulidGenerator,
+                FIXED_CLOCK);
+
+        stubExistingCustomer(customerId);
+        when(activationTokenGenerator.generate()).thenReturn(RAW_TOKEN);
+        when(activationTokenHasher.hash(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        stubGeneratedActivationTokenId();
+        stubMapperToEntity();
+        when(activationTokenRepository.save(activationTokenEntityCaptor.capture()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        activationTokenService.createFor(customerId);
+
+        // then
+        verify(activationTokenGenerator, times(1)).generate();
+        verify(activationTokenHasher, times(1)).hash(RAW_TOKEN);
+        verify(activationTokenRepository, times(1)).save(activationTokenEntityCaptor.getValue());
+    }
+
+    @Test
+    void shouldThrowWhenCustomerDoesNotExist() {
+        // given
+        CustomerId customerId = CustomerId.of(CUSTOMER_ID);
+
+        DefaultActivationTokenService activationTokenService =
+            new DefaultActivationTokenService(
+                activationTokenRepository,
+                customerRepository,
+                activationTokenGenerator,
+                activationTokenHasher,
+                activationTokenMapper,
+                ulidGenerator,
+                FIXED_CLOCK);
+
+        when(customerRepository.existsById(CustomerIdEmbeddable.from(customerId))).thenReturn(false);
+
+        // when/then
+        assertThatThrownBy(() -> activationTokenService.createFor(customerId))
+            .isInstanceOf(CustomerNotFoundException.class)
+            .hasMessage("Customer not found for id: " + customerId.value());
+
+        verify(activationTokenGenerator, never()).generate();
+        verify(activationTokenHasher, never()).hash(any());
+        verify(activationTokenRepository, never()).save(any());
+    }
+
+    private void stubExistingCustomer(CustomerId customerId) {
+        when(customerRepository.existsById(CustomerIdEmbeddable.from(customerId))).thenReturn(true);
+    }
+
+    private void stubGeneratedActivationTokenId() {
+        when(ulidGenerator.next()).thenReturn(ACTIVATION_TOKEN_ID);
+    }
+
+    private void stubMapperToEntity() {
+        when(activationTokenMapper.toEntity(any(ActivationToken.class)))
+            .thenAnswer(invocation -> {
+                ActivationToken activationToken = invocation.getArgument(0);
+
+                return ActivationTokenEntity.of(
+                    ActivationTokenIdEmbeddable.from(activationToken.getId()),
+                    CustomerIdEmbeddable.from(activationToken.getCustomerId()),
+                    activationToken.getTokenHash(),
+                    activationToken.getExpiresAt(),
+                    activationToken.getConsumedAt(),
+                    activationToken.getCreatedAt()
+                );
+            });
+    }
+
+    private void stubMapperToDomain() {
+        when(activationTokenMapper.toDomain(any(ActivationTokenEntity.class)))
+            .thenAnswer(invocation -> {
+                ActivationTokenEntity entity = invocation.getArgument(0);
+
+                return ActivationToken.fromPersistence(
+                    entity.getId().toActivationTokenId(),
+                    entity.getCustomerId().toCustomerId(),
+                    entity.getTokenHash(),
+                    entity.getExpiresAt(),
+                    entity.getConsumedAt(),
+                    entity.getCreatedAt()
+                );
+            });
+    }
+}


### PR DESCRIPTION
## Summary
Implements activation token generation and hashing in the customer
module, adds service-level token creation with customer existence
validation, and introduces focused tests for the new behavior.

## Scope
- add `ActivationTokenGenerator` contract and default implementation
- add `ActivationTokenHasher` contract and default implementation
- add `ActivationTokenService` contract and default implementation
- introduce `TimeConfiguration` with a shared UTC `Clock` bean
- generate activation tokens as URL-safe Base64 values without padding
- hash activation tokens with SHA-256 before persistence
- create activation tokens with generated id, `createdAt`, and 24-hour expiration
- validate customer existence before saving an activation token
- add unit tests for token generator output shape and length
- add unit tests for token hasher consistency, format, and known output
- add service tests for activation token creation, expiration, hashing, and missing-customer behavior

## Notes
Activation token creation now fails fast with `CustomerNotFoundException`
when the supplied customer does not exist, instead of relying on a
database-level foreign key failure.

This task intentionally stores and returns only the hashed activation
token. Raw token delivery will be handled in a subsequent task when the
customer notification flow is implemented.

## Testing
- unit tests cover activation token generator behavior
- unit tests cover activation token hasher behavior
- service tests cover token creation and missing-customer handling
- validated with `./gradlew :customer:test --tests '*DefaultActivationToken*'`