### PR TITLE
Add issue import workflow and retry handling scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -68,3 +68,11 @@ indent_size = 4
 
 [*.properties]
 indent_size = 2
+
+[*.sh]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/issue-import/.gitignore
+++ b/.github/issue-import/.gitignore
@@ -1,0 +1,9 @@
+*
+!.gitkeep
+!README.md
+!pending/
+!pending/.gitkeep
+!imported/
+!imported/.gitkeep
+!failed/
+!failed/.gitkeep

--- a/.github/issue-import/README.md
+++ b/.github/issue-import/README.md
@@ -1,0 +1,520 @@
+# Issue Import Workflow
+
+This directory supports a small GitHub issue import workflow for Kartoush.
+It is designed for importing pre-written issue definitions from markdown files,
+creating the issues in GitHub, linking sub-issues to parent issues, and keeping
+the file lifecycle visible in the repository.
+
+## Directory Layout
+
+- `pending/`
+  Contains markdown files waiting to be imported.
+- `imported/`
+  Contains files that were successfully imported and annotated with GitHub issue
+  metadata.
+- `failed/`
+  Contains files that could not be fully processed and were annotated with
+  failure details.
+
+The `.gitignore` in this directory keeps these folders in the repository while
+allowing imported artifacts to be ignored by default, except for `.gitkeep` and
+this README.
+
+## File Format
+
+Each issue definition must be a markdown file in `pending/` with a small
+metadata header followed by a blank line and then the issue body.
+
+Use a numeric filename prefix to make import order explicit, for example:
+
+- `00-epic-import-and-workflow-tooling.md`
+- `01-task-validate-sub-issue-linking.md`
+
+The import script creates all issues in pass 1 and links parent-child
+relationships in pass 2, so linking does not happen immediately after each
+issue is created. Even so, parent titles are resolved against issues that were
+recorded earlier in the same run, so epics should still appear before their
+children in `pending/`. In practice this also matches how the work is usually
+numbered, with the epic using a lower prefix than its tasks.
+
+Required metadata:
+
+- `Title:`
+
+Optional metadata:
+
+- `Parent:`
+
+Rules:
+
+- metadata must appear at the top of the file
+- metadata must be one key per line
+- metadata parsing stops at the first blank line
+- any non-empty, non-metadata line before the first blank line is treated as an
+  error
+- `Title:` is required
+- `Parent:` is optional
+
+Example epic:
+
+```md
+Title: Epic: Issue Import and Workflow Tooling
+
+### Goal
+
+Validate that the import script correctly creates an epic and assigns child
+issues as sub-issues.
+
+### Why
+
+- verify parent-child relationships are created automatically
+- confirm metadata parsing works correctly
+- ensure sub-issue API integration behaves as expected
+```
+
+Example child task:
+
+```md
+Title: Task: Validate sub-issue linking during import
+Parent: Epic: Issue Import and Workflow Tooling
+
+### Summary
+
+Ensure that a task is properly linked as a sub-issue to the epic created during
+the same import run.
+
+### Scope
+
+- create a task via import script
+- link it to the epic using metadata
+- verify linkage in GitHub UI
+```
+
+## Parent Resolution
+
+`Parent:` can be defined in one of two ways:
+
+- by title, for example:
+  `Parent: Epic: Issue Import and Workflow Tooling`
+- by explicit GitHub issue number, for example:
+  `Parent: #153`
+
+When a parent title is used, the import script resolves it against issues
+created earlier in the same import run. This is what allows an epic and its
+children to be imported together from `pending/`.
+
+If the parent cannot be resolved, the child issue may already exist in GitHub,
+but the file will be moved to `failed/` and marked for manual follow-up.
+
+## Import Script
+
+The main import entrypoint is:
+
+```bash
+.github/scripts/import-issues.sh
+```
+
+Optional flag:
+
+- `--dry-run`
+- `--verbose`
+
+Environment variables supported by the script:
+
+- `REPO`
+  Defaults to `jbolous/kartoush`
+- `IMPORT_ROOT`
+  Defaults to `.github/issue-import`
+- `PENDING_DIR`
+  Defaults to `$IMPORT_ROOT/pending`
+- `IMPORTED_DIR`
+  Defaults to `$IMPORT_ROOT/imported`
+- `FAILED_DIR`
+  Defaults to `$IMPORT_ROOT/failed`
+
+### What the script does
+
+The import runs in two passes.
+
+Before either pass begins, the script runs import preflight checks.
+
+Pass 1: create issues
+
+- reads each `pending/*.md` file
+- parses `Title:` and optional `Parent:`
+- appends this footer to the GitHub issue body:
+
+  ```html
+  ---
+
+  <sub>Created via Kartoush issue import workflow</sub>
+  ```
+
+- creates the issue with `gh issue create`
+- records the created issue number, URL, and internal GitHub issue id for use in
+  pass 2
+
+Pass 2: link sub-issues and move files
+
+- resolves each `Parent:` value
+- links child issues using the GitHub sub-issues API
+- moves successfully processed files to `imported/`
+- moves failed files to `failed/`
+
+### Example usage
+
+Dry run:
+
+```bash
+.github/scripts/import-issues.sh --dry-run
+```
+
+Dry run with verbose logging:
+
+```bash
+.github/scripts/import-issues.sh --dry-run --verbose
+```
+
+Import into the default repository:
+
+```bash
+.github/scripts/import-issues.sh
+```
+
+Import with verbose logging:
+
+```bash
+.github/scripts/import-issues.sh --verbose
+```
+
+Import into a different repository:
+
+```bash
+REPO=your-org/your-repo .github/scripts/import-issues.sh
+```
+
+### Quick Start
+
+1. Create an epic file in `pending/`, for example:
+
+   ```md
+   Title: Epic: Example Import Epic
+
+   ### Goal
+
+   Create an example epic for issue import testing.
+   ```
+
+2. Create a child task file in `pending/`, for example:
+
+   ```md
+   Title: Task: Example Child Task
+   Parent: Epic: Example Import Epic
+
+   ### Summary
+
+   Create a child task linked to the example epic.
+   ```
+
+3. Run a dry run:
+
+   ```bash
+   .github/scripts/import-issues.sh --dry-run
+   ```
+
+4. Review the dry-run output to confirm the files, titles, and parent
+   relationships look correct.
+
+5. Run the real import:
+
+   ```bash
+   .github/scripts/import-issues.sh
+   ```
+
+6. Verify the created issues and sub-issue relationship in GitHub
+
+### Optional: create symbolic links for easier execution
+
+If you run these scripts often, you can create symbolic links with shorter
+names.
+
+From the repository root:
+
+```bash
+ln -s .github/scripts/import-issues.sh import-issues
+ln -s .github/scripts/requeue-failed-imports.sh requeue-failed-imports
+```
+
+You can then run:
+
+```bash
+./import-issues --dry-run
+./requeue-failed-imports
+```
+
+If you prefer to run them from anywhere, create links in a directory that is on
+your `PATH`, for example:
+
+```bash
+ln -s /absolute/path/to/kartoush/.github/scripts/import-issues.sh /usr/local/bin/import-issues
+ln -s /absolute/path/to/kartoush/.github/scripts/requeue-failed-imports.sh /usr/local/bin/requeue-failed-imports
+```
+
+After that, you can run:
+
+```bash
+import-issues --dry-run
+requeue-failed-imports
+```
+
+## Failure Handling
+
+If something goes wrong, the script moves the source file into `failed/` and
+adds a trailing HTML comment block with metadata about the failure.
+
+That metadata can include:
+
+- import status
+- timestamp
+- whether a GitHub issue was already created
+- issue number
+- issue URL
+- retry count
+- error summary
+
+Typical failure cases:
+
+- missing `Title:` metadata
+- invalid metadata before the blank-line separator
+- GitHub issue creation failure
+- unresolved `Parent:`
+- sub-issue linking failure
+
+There are two important failure modes:
+
+1. No issue was created
+
+- the file can usually be fixed and safely requeued
+
+2. The issue was created, but linking or later processing failed
+
+- the file is still moved to `failed/`
+- the failure metadata records `IssueCreated: true`
+- the failure metadata records and increments `RetryCount`
+- manual cleanup or manual parent linking may be required
+
+## Requeue Script
+
+The requeue entrypoint is:
+
+```bash
+.github/scripts/requeue-failed-imports.sh
+```
+
+This script moves safe-to-retry files from `failed/` back into `pending/`.
+
+Optional flag:
+
+- `--verbose`
+
+Optional positional arguments:
+
+- one or more GitHub issue numbers to restore from `failed/`
+
+Before processing files, the script runs a lighter preflight check for the
+local shell and repository environment.
+
+### Requeue behavior
+
+- failed files are restored from `failed/` back to `pending/`
+- files with `IssueCreated: true` keep their metadata comment so the existing
+  issue can be reused on the next import run
+- files without a created issue have the trailing failed metadata block stripped
+- the timestamp prefix added in `failed/` is removed
+
+When issue numbers are passed to the requeue script:
+
+- matching failed files are restored from `failed/` back to `pending/`
+- the failed metadata comment is preserved when `IssueCreated: true`
+- the original issue is intended to be reused rather than recreated
+
+For normal failed-file requeue:
+
+- files with `RetryCount` 3 or greater are skipped
+- this prevents the same file from being requeued indefinitely after repeated failures
+
+When issue numbers are passed explicitly:
+
+- the matching failed file can still be requeued even if it has reached the
+  normal retry limit
+- this provides an operator override path without requiring manual file edits
+
+Example:
+
+```bash
+.github/scripts/requeue-failed-imports.sh
+```
+
+Verbose example:
+
+```bash
+.github/scripts/requeue-failed-imports.sh --verbose
+```
+
+Restore specific failed issues back to `pending/`:
+
+```bash
+.github/scripts/requeue-failed-imports.sh 159 160 161
+```
+
+Comma-separated input is also accepted:
+
+```bash
+.github/scripts/requeue-failed-imports.sh 159, 160, 161
+```
+
+If a failed file is skipped because an issue was already created, inspect the
+failure metadata and retry count to determine whether manual cleanup is needed.
+
+If a failed file is requeued by issue number and it retains issue metadata, the
+import script can detect the existing GitHub issue and skip issue creation on
+the next run.
+
+## Prerequisites
+
+Before running the import:
+
+- `gh` must be installed
+- `bash` 4 or newer must be available
+- the authenticated user must have permission to create issues in the target
+  repository
+- for sub-issue linking, the repository and token permissions must support the
+  GitHub sub-issues API
+
+For real imports, `gh` must be authenticated against GitHub.
+
+For `--dry-run`, `gh` must still be installed, but GitHub authentication is not
+required.
+
+### Install GitHub CLI
+
+macOS with Homebrew:
+
+```bash
+brew install gh
+```
+
+Windows with `winget`:
+
+```powershell
+winget install --id GitHub.cli
+```
+
+After installation, authenticate with:
+
+```bash
+gh auth login
+```
+
+You can verify authentication with:
+
+```bash
+gh auth status
+```
+
+### Install Bash 4+ on macOS
+
+The import scripts use Bash features that are not supported by the older Bash
+version shipped with macOS by default. On macOS, install a newer Bash with
+Homebrew:
+
+```bash
+brew install bash
+```
+
+You can verify your Bash version with:
+
+```bash
+bash --version
+```
+
+If needed, invoke the scripts with the Homebrew-installed Bash explicitly.
+
+### Script permissions
+
+If your environment does not preserve executable bits, make the scripts
+executable before running them:
+
+```bash
+chmod +x .github/scripts/import-issues.sh
+chmod +x .github/scripts/requeue-failed-imports.sh
+```
+
+The shared helper file `.github/scripts/issue-import-common.sh` is sourced by
+the scripts and does not need to be executable.
+
+### Preflight checks
+
+Before processing files, the scripts run preflight checks.
+
+The import script checks:
+
+- Bash is available
+- Bash 4 or newer is being used
+- GitHub CLI (`gh`) is installed
+- GitHub CLI is authenticated for real imports
+- the current working directory is inside a git repository
+
+In `--dry-run` mode, the GitHub authentication check is skipped.
+
+The requeue script checks only the local environment it needs:
+
+- Bash is available
+- Bash 4 or newer is being used
+- the current working directory is inside a git repository
+
+### Windows Support
+
+This workflow requires a Bash-compatible environment.
+
+Recommended options:
+
+- Git Bash, which is included with Git for Windows
+- Windows Subsystem for Linux (WSL)
+- another shell with Bash 4 or newer
+
+The scripts are not supported in native Windows Command Prompt or PowerShell
+without a Bash environment.
+
+If you are working on Windows:
+
+- run the scripts from Git Bash, WSL, or another Bash-compatible shell
+- use `gh auth login` and `gh auth status` from that same shell environment
+- if symbolic link creation is restricted, run the scripts directly instead of
+  creating symlink shortcuts
+- depending on your Windows configuration, symlink creation may require
+  Developer Mode or elevated permissions
+
+## Recommended Workflow
+
+1. Create one or more issue definition files in `pending/`
+2. Run the import script with `--dry-run` to validate intent
+3. Run the import script without `--dry-run`
+4. Confirm created issues and parent-child relationships in GitHub
+5. If anything fails, inspect the file in `failed/`
+6. Fix and requeue only when no GitHub issue was already created
+
+## Notes
+
+- this workflow creates issues through the GitHub CLI, so the normal GitHub web
+  issue template selection flow is bypassed
+- imported issue files should still follow the same structure and conventions as
+  the repository's issue templates
+- shared script helpers live in `.github/scripts/issue-import-common.sh`
+- files in `imported/` and `failed/` act as a lightweight audit trail
+- pending files that retain imported metadata will reuse the existing GitHub
+  issue on the next import run instead of creating a duplicate
+- parent titles are resolved only within the current import run, not by querying
+  GitHub for title matches
+- parent-title linking depends on import order, while `Parent: #123` does not
+- if you need to link to an already-existing GitHub issue, prefer `Parent: #123`

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERBOSE="false"
+DRY_RUN="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --verbose)
+      VERBOSE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+  SCRIPT_PATH="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$SCRIPT_PATH/$SOURCE"
+done
+
+SCRIPT_PATH="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_PATH/issue-import-common.sh"
+
+setup_repo_paths
+preflight_import
+
+print_verbose "REPO=$REPO"
+print_verbose "REPO_ROOT=$REPO_ROOT"
+print_verbose "IMPORT_ROOT=$IMPORT_ROOT"
+print_verbose "PENDING_DIR=$PENDING_DIR"
+print_verbose "IMPORTED_DIR=$IMPORTED_DIR"
+print_verbose "FAILED_DIR=$FAILED_DIR"
+print_verbose "DRY_RUN=$DRY_RUN"
+
+declare -A FILE_PARENT
+declare -A FILE_ISSUE_NUMBER
+declare -A FILE_ISSUE_ID
+declare -A FILE_ISSUE_URL
+declare -A TITLE_TO_ISSUE_NUMBER
+
+created_count=0
+linked_count=0
+failed_count=0
+
+parse_metadata() {
+  local file="$1"
+  local title=""
+  local parent=""
+  local body_file
+  local in_metadata="true"
+
+  body_file="$(mktemp)"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_metadata" == "true" ]]; then
+      if [[ -z "$line" ]]; then
+        in_metadata="false"
+        continue
+      elif [[ "$line" == Title:* ]]; then
+        title="$(trim "${line#Title:}")"
+      elif [[ "$line" == Parent:* ]]; then
+        parent="$(trim "${line#Parent:}")"
+      else
+        print_verbose "Invalid metadata line in $(basename "$file"): $line"
+        rm -f "$body_file"
+        return 1
+      fi
+    else
+      printf '%s\n' "$line" >> "$body_file"
+    fi
+  done < "$file"
+
+  if [[ -z "$title" ]]; then
+    print_verbose "Missing required Title metadata in $(basename "$file")"
+    rm -f "$body_file"
+    return 1
+  fi
+
+  PARSED_TITLE="$title"
+  PARSED_PARENT="$parent"
+  PARSED_BODY_FILE="$body_file"
+}
+
+parse_existing_issue_metadata() {
+  local file="$1"
+  parse_trailing_metadata "$file"
+  EXISTING_ISSUE_NUMBER="$META_ISSUE_NUMBER"
+  EXISTING_ISSUE_URL="$META_URL"
+}
+
+append_footer() {
+  local body_file="$1"
+  printf '\n\n---\n\n<sub>Created via Kartoush issue import workflow</sub>\n' >> "$body_file"
+}
+
+lookup_issue_rest_id() {
+  local issue_number="$1"
+  local issue_id
+  local gh_exit_code
+
+  set +e
+  issue_id="$(
+    gh api \
+      "/repos/$REPO/issues/$issue_number" \
+      --jq '.id' 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "gh api issue lookup failed: $issue_id"
+    return 1
+  fi
+
+  LOOKED_UP_ISSUE_ID="$issue_id"
+}
+
+lookup_issue_number_by_title_in_dir() {
+  local dir="$1"
+  local title="$2"
+  local matches file
+
+  mapfile -t matches < <(grep -l "^Title: $title\$" "$dir"/*.md 2>/dev/null || true)
+
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    return 1
+  fi
+
+  if [[ ${#matches[@]} -gt 1 ]]; then
+    print_verbose "Multiple files matched title '$title' in $dir"
+    return 1
+  fi
+
+  file="${matches[0]}"
+  parse_trailing_metadata "$file"
+
+  if [[ -z "$META_ISSUE_NUMBER" ]]; then
+    print_verbose "Matched title '$title' in $file but no issue number was present"
+    return 1
+  fi
+
+  LOOKED_UP_PARENT_ISSUE_NUMBER="$META_ISSUE_NUMBER"
+}
+
+lookup_existing_parent_issue_number() {
+  local parent_title="$1"
+
+  if lookup_issue_number_by_title_in_dir "$IMPORTED_DIR" "$parent_title"; then
+    print_verbose "Resolved parent by imported metadata: '$parent_title' -> #$LOOKED_UP_PARENT_ISSUE_NUMBER"
+    return 0
+  fi
+
+  if lookup_issue_number_by_title_in_dir "$FAILED_DIR" "$parent_title"; then
+    print_verbose "Resolved parent by failed metadata: '$parent_title' -> #$LOOKED_UP_PARENT_ISSUE_NUMBER"
+    return 0
+  fi
+
+  return 1
+}
+
+move_to_failed() {
+  local file="$1"
+  local error_message="$2"
+  local issue_created="${3:-false}"
+  local issue_number="${4:-}"
+  local issue_url="${5:-}"
+  local base_name
+  local failed_at
+  local filename_ts
+  local failed_file
+  local retry_count=1
+
+  base_name="$(basename "$file")"
+  failed_count=$((failed_count + 1))
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    print_warning "  [DRY RUN] Move to failed"
+    printf '    Error: %s\n' "$error_message"
+    return
+  fi
+
+  failed_at="$(timestamp_for_metadata)"
+  filename_ts="$(timestamp_for_filename)"
+  failed_file="$FAILED_DIR/${filename_ts}-${base_name}"
+
+  parse_trailing_metadata "$file"
+  if [[ -n "$META_RETRY_COUNT" ]]; then
+    retry_count=$((META_RETRY_COUNT + 1))
+  fi
+
+  strip_trailing_metadata_comment "$file"
+
+  {
+    cat "$file"
+    printf '\n\n<!--\n'
+    printf 'Imported: FAILED\n'
+    printf 'Timestamp: %s\n' "$failed_at"
+    printf 'IssueCreated: %s\n' "$issue_created"
+    if [[ -n "$issue_number" ]]; then
+      printf 'Issue: #%s\n' "$issue_number"
+    fi
+    if [[ -n "$issue_url" ]]; then
+      printf 'URL: %s\n' "$issue_url"
+    fi
+    printf 'RetryCount: %s\n' "$retry_count"
+    printf 'Error: %s\n' "$error_message"
+    printf '%s\n' '-->'
+  } > "$failed_file"
+
+  rm -f "$file"
+  print_warning "  Failed"
+}
+
+move_to_imported() {
+  local file="$1"
+  local issue_number="$2"
+  local issue_url="$3"
+  local base_name
+
+  base_name="$(basename "$file")"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    print_info "  [DRY RUN] Move to imported"
+    return
+  fi
+
+  local imported_at filename_ts imported_file
+  imported_at="$(timestamp_for_metadata)"
+  filename_ts="$(timestamp_for_filename)"
+  imported_file="$IMPORTED_DIR/${filename_ts}-issue-${issue_number}-${base_name}"
+
+  strip_trailing_metadata_comment "$file"
+
+  {
+    cat "$file"
+    printf '\n\n<!--\n'
+    printf 'Imported: %s\n' "$imported_at"
+    printf 'Issue: #%s\n' "$issue_number"
+    printf 'URL: %s\n' "$issue_url"
+    printf '%s\n' '-->'
+  } > "$imported_file"
+
+  rm -f "$file"
+  print_success "  Imported (#$issue_number)"
+}
+
+create_issue() {
+  local file="$1"
+  local title="$2"
+  local body_file="$3"
+
+  append_footer "$body_file"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    local key
+    local dry_run_issue_number
+    key="$(basename "$file" .md)"
+    dry_run_issue_number=$((1000 + created_count))
+    print_info "  [DRY RUN] Create issue"
+    printf '    Title: %s\n' "$title"
+    CREATED_ISSUE_URL="dry-run://$key"
+    CREATED_ISSUE_NUMBER="$dry_run_issue_number"
+    CREATED_ISSUE_ID="DRY-ID-$dry_run_issue_number"
+    created_count=$((created_count + 1))
+    return 0
+  fi
+
+  local gh_output issue_url issue_number
+
+  print_verbose "Executing: gh issue create --repo $REPO --title \"$title\" --body-file $body_file"
+  set +e
+  gh_output="$(gh issue create --repo "$REPO" --title "$title" --body-file "$body_file" 2>&1)"
+  local gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "gh issue create failed: $gh_output"
+    return 1
+  fi
+
+  issue_url="$(printf '%s\n' "$gh_output" | tail -n 1 | tr -d '\r')"
+  issue_number="$(echo "$issue_url" | sed -E 's#.*/issues/([0-9]+)$#\1#')"
+
+  if ! lookup_issue_rest_id "$issue_number"; then
+    return 1
+  fi
+
+  CREATED_ISSUE_URL="$issue_url"
+  CREATED_ISSUE_NUMBER="$issue_number"
+  CREATED_ISSUE_ID="$LOOKED_UP_ISSUE_ID"
+
+  created_count=$((created_count + 1))
+  print_success "  Created (#$issue_number)"
+  printf '    URL: %s\n' "$issue_url"
+  print_verbose "Issue ID: $LOOKED_UP_ISSUE_ID"
+}
+
+resolve_parent_issue_number() {
+  local parent_raw="$1"
+
+  if [[ "$parent_raw" =~ ^#([0-9]+)$ ]]; then
+    RESOLVED_PARENT_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+    print_verbose "Resolved parent directly from issue number: #$RESOLVED_PARENT_ISSUE_NUMBER"
+    return 0
+  fi
+
+  if [[ -n "${TITLE_TO_ISSUE_NUMBER[$parent_raw]:-}" ]]; then
+    RESOLVED_PARENT_ISSUE_NUMBER="${TITLE_TO_ISSUE_NUMBER[$parent_raw]}"
+    print_verbose "Resolved parent by title match: '$parent_raw' -> #$RESOLVED_PARENT_ISSUE_NUMBER"
+    return 0
+  fi
+
+  if lookup_existing_parent_issue_number "$parent_raw"; then
+    RESOLVED_PARENT_ISSUE_NUMBER="$LOOKED_UP_PARENT_ISSUE_NUMBER"
+    return 0
+  fi
+
+  print_verbose "Could not resolve parent: $parent_raw"
+  return 1
+}
+
+link_sub_issue() {
+  local parent="$1"
+  local child_id="$2"
+  local gh_output
+  local gh_exit_code
+
+  printf '  Linking sub-issue\n'
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf '    [DRY RUN] Parent: #%s\n' "$parent"
+    printf '    [DRY RUN] Child ID: %s\n' "$child_id"
+    linked_count=$((linked_count + 1))
+    return
+  fi
+
+  print_verbose "Executing: gh api --method POST /repos/$REPO/issues/$parent/sub_issues -F sub_issue_id=$child_id"
+
+  set +e
+  gh_output="$(
+    gh api \
+      --method POST \
+      -H "Accept: application/vnd.github+json" \
+      "/repos/$REPO/issues/$parent/sub_issues" \
+      -F sub_issue_id="$child_id" 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "gh api sub-issue link failed: $gh_output"
+    return 1
+  fi
+
+  linked_count=$((linked_count + 1))
+  print_success "    Linked"
+}
+
+files=( "$PENDING_DIR"/*.md )
+[[ -e "${files[0]}" ]] || {
+  print_warning "No pending markdown files found in $PENDING_DIR"
+  exit 0
+}
+
+print_header "Pass 1: Creating issues"
+printf '%s\n\n' "-----------------------"
+
+for file in "${files[@]}"; do
+  base="$(basename "$file")"
+  printf '%s\n' "$base"
+
+  if ! parse_metadata "$file"; then
+    move_to_failed "$file" "Metadata error"
+    printf '\n'
+    continue
+  fi
+
+  print_verbose "Parsed title: $PARSED_TITLE"
+  if [[ -n "$PARSED_PARENT" ]]; then
+    print_verbose "Parsed parent: $PARSED_PARENT"
+  else
+    print_verbose "Parsed parent: <none>"
+  fi
+
+  FILE_PARENT["$file"]="$PARSED_PARENT"
+
+  parse_existing_issue_metadata "$file"
+
+  if [[ -n "$EXISTING_ISSUE_NUMBER" ]]; then
+    print_info "  Reusing existing issue #$EXISTING_ISSUE_NUMBER"
+
+    if ! lookup_issue_rest_id "$EXISTING_ISSUE_NUMBER"; then
+      rm -f "$PARSED_BODY_FILE"
+      move_to_failed "$file" "Existing issue lookup failed" "true" "$EXISTING_ISSUE_NUMBER" "$EXISTING_ISSUE_URL"
+      printf '\n'
+      continue
+    fi
+
+    FILE_ISSUE_NUMBER["$file"]="$EXISTING_ISSUE_NUMBER"
+    FILE_ISSUE_ID["$file"]="$LOOKED_UP_ISSUE_ID"
+    FILE_ISSUE_URL["$file"]="$EXISTING_ISSUE_URL"
+    TITLE_TO_ISSUE_NUMBER["$PARSED_TITLE"]="$EXISTING_ISSUE_NUMBER"
+
+    rm -f "$PARSED_BODY_FILE"
+    printf '\n'
+    continue
+  fi
+
+  if ! create_issue "$file" "$PARSED_TITLE" "$PARSED_BODY_FILE"; then
+    rm -f "$PARSED_BODY_FILE"
+    move_to_failed "$file" "Create failed"
+    printf '\n'
+    continue
+  fi
+
+  FILE_ISSUE_NUMBER["$file"]="$CREATED_ISSUE_NUMBER"
+  FILE_ISSUE_ID["$file"]="$CREATED_ISSUE_ID"
+  FILE_ISSUE_URL["$file"]="$CREATED_ISSUE_URL"
+  TITLE_TO_ISSUE_NUMBER["$PARSED_TITLE"]="$CREATED_ISSUE_NUMBER"
+
+  rm -f "$PARSED_BODY_FILE"
+  printf '\n'
+done
+
+printf '%s\n' "Pass 2: Linking sub-issues and moving files"
+printf '%s\n\n' "-------------------------------------------"
+
+for file in "${files[@]}"; do
+  [[ -n "${FILE_ISSUE_NUMBER[$file]:-}" ]] || continue
+
+  base="$(basename "$file")"
+  printf '%s\n' "$base"
+
+  parent="${FILE_PARENT[$file]}"
+  num="${FILE_ISSUE_NUMBER[$file]}"
+  id="${FILE_ISSUE_ID[$file]}"
+  url="${FILE_ISSUE_URL[$file]}"
+
+  if [[ -n "$parent" ]]; then
+    if resolve_parent_issue_number "$parent"; then
+      if ! link_sub_issue "$RESOLVED_PARENT_ISSUE_NUMBER" "$id"; then
+        move_to_failed "$file" "Sub-issue linking failed" "true" "$num" "$url"
+        print_warning "  Issue #$num was created but sub-issue linkage failed"
+        printf '\n'
+        continue
+      fi
+    else
+      move_to_failed "$file" "Parent resolution failed" "true" "$num" "$url"
+      print_warning "  Issue #$num was created but parent resolution failed"
+      printf '\n'
+      continue
+    fi
+  fi
+
+  move_to_imported "$file" "$num" "$url"
+  printf '\n'
+done
+
+printf '%sSummary%s\n' "$COLOR_BOLD" "$COLOR_RESET"
+printf '%s\n' "-------"
+printf '%sCreated:%s %s\n' "$COLOR_BOLD" "$COLOR_RESET" "$created_count"
+printf '%sLinked:%s  %s\n' "$COLOR_BOLD" "$COLOR_RESET" "$linked_count"
+if (( failed_count > 0 )); then
+  print_error "${COLOR_BOLD}Failed:${COLOR_RESET}  $failed_count"
+else
+  print_info "${COLOR_BOLD}Failed:${COLOR_RESET}  $failed_count"
+fi

--- a/.github/scripts/issue-import-common.sh
+++ b/.github/scripts/issue-import-common.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+if [[ -t 1 ]]; then
+  COLOR_RED=$'\033[0;31m'
+  COLOR_GREEN=$'\033[0;32m'
+  COLOR_YELLOW=$'\033[1;33m'
+  COLOR_BLUE=$'\033[1;36m'
+  COLOR_BOLD=$'\033[1m'
+  COLOR_RESET=$'\033[0m'
+else
+  COLOR_RED=""
+  COLOR_GREEN=""
+  COLOR_YELLOW=""
+  COLOR_BLUE=""
+  COLOR_BOLD=""
+  COLOR_RESET=""
+fi
+
+print_info() {
+  printf '%s%s%s\n' "$COLOR_BLUE" "$1" "$COLOR_RESET"
+}
+
+print_success() {
+  printf '%s%s%s\n' "$COLOR_GREEN" "$1" "$COLOR_RESET"
+}
+
+print_warning() {
+  printf '%s%s%s\n' "$COLOR_YELLOW" "$1" "$COLOR_RESET"
+}
+
+print_error() {
+  printf '%s%s%s\n' "$COLOR_RED" "$1" "$COLOR_RESET" >&2
+}
+
+print_header() {
+  printf '\n%s%s%s\n' "$COLOR_BOLD" "$1" "$COLOR_RESET"
+}
+
+print_verbose() {
+  if [[ "${VERBOSE:-false}" == "true" ]]; then
+    printf '%s[VERBOSE]%s %s\n' "$COLOR_YELLOW" "$COLOR_RESET" "$1"
+  fi
+}
+
+resolve_script_source() {
+  local source="$1"
+
+  while [[ -L "$source" ]]; do
+    local script_dir
+    script_dir="$(cd -P "$(dirname "$source")" && pwd)"
+    source="$(readlink "$source")"
+    [[ "$source" != /* ]] && source="$script_dir/$source"
+  done
+
+  printf '%s\n' "$source"
+}
+
+setup_repo_paths() {
+  local source
+  source="$(resolve_script_source "${BASH_SOURCE[1]}")"
+
+  SCRIPT_DIR="$(cd -P "$(dirname "$source")" && pwd)"
+  REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+  REPO="${REPO:-jbolous/kartoush}"
+  IMPORT_ROOT="${IMPORT_ROOT:-$REPO_ROOT/.github/issue-import}"
+  PENDING_DIR="${PENDING_DIR:-$IMPORT_ROOT/pending}"
+  IMPORTED_DIR="${IMPORTED_DIR:-$IMPORT_ROOT/imported}"
+  FAILED_DIR="${FAILED_DIR:-$IMPORT_ROOT/failed}"
+
+  mkdir -p "$PENDING_DIR" "$IMPORTED_DIR" "$FAILED_DIR"
+}
+
+preflight_common() {
+  if [[ -z "${BASH_VERSION:-}" ]]; then
+    print_error "✗ This script must be run with bash"
+    exit 1
+  fi
+
+  print_success "✓ Bash detected ($BASH_VERSION)"
+
+  if (( BASH_VERSINFO[0] < 4 )); then
+    print_error "✗ Bash 4+ is required (associative arrays are used)"
+    exit 1
+  fi
+
+  if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    print_error "✗ Not inside a git repository"
+    exit 1
+  fi
+
+  print_success "✓ Git repository detected"
+}
+
+preflight_import() {
+  print_header "Running preflight checks..."
+  printf '%s\n' "---------------------------"
+
+  preflight_common
+
+  if ! command -v gh >/dev/null 2>&1; then
+    print_error "✗ GitHub CLI (gh) is not installed"
+    print_info "  Install with: brew install gh"
+    exit 1
+  fi
+
+  print_success "✓ GitHub CLI found"
+
+  if [[ "${DRY_RUN:-false}" == "true" ]]; then
+    print_info "• Skipping GitHub authentication check in dry-run mode"
+  elif ! gh auth status >/dev/null 2>&1; then
+    print_error "✗ GitHub CLI is not authenticated"
+    print_info "  Run: gh auth login"
+    exit 1
+  else
+    print_success "✓ GitHub CLI authenticated"
+  fi
+
+  printf '\n'
+}
+
+preflight_requeue() {
+  print_header "Running preflight checks..."
+  printf '%s\n' "---------------------------"
+
+  preflight_common
+}
+
+timestamp_for_filename() {
+  date +"%Y-%m-%dT%H-%M-%S"
+}
+
+timestamp_for_metadata() {
+  date +"%Y-%m-%dT%H:%M:%S%z"
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+strip_trailing_metadata_comment() {
+  local file="$1"
+  local temp_file
+
+  temp_file="$(mktemp)"
+  perl -0pe 's/(?:\n\s*)*<!--\n(?:.*?\n)*?-->[\r\n\s]*$//s' "$file" > "$temp_file"
+  mv "$temp_file" "$file"
+}
+
+parse_trailing_metadata() {
+  local file="$1"
+  local line
+
+  META_IMPORTED=""
+  META_TIMESTAMP=""
+  META_ISSUE_CREATED=""
+  META_ISSUE_NUMBER=""
+  META_URL=""
+  META_ERROR=""
+  META_RETRY_COUNT=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^Imported:\ (.+)$ ]]; then
+      META_IMPORTED="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^Timestamp:\ (.+)$ ]]; then
+      META_TIMESTAMP="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^IssueCreated:\ (.+)$ ]]; then
+      META_ISSUE_CREATED="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^Issue:\ #([0-9]+)$ ]]; then
+      META_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^URL:\ (.+)$ ]]; then
+      META_URL="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^Error:\ (.+)$ ]]; then
+      META_ERROR="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^RetryCount:\ ([0-9]+)$ ]]; then
+      META_RETRY_COUNT="${BASH_REMATCH[1]}"
+    fi
+  done < "$file"
+}

--- a/.github/scripts/requeue-failed-imports.sh
+++ b/.github/scripts/requeue-failed-imports.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERBOSE="false"
+DRY_RUN="false"
+declare -a ISSUE_NUMBERS=()
+MAX_RETRY_COUNT=3
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --verbose)
+      VERBOSE="true"
+      shift
+      ;;
+    --*)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+    *)
+      ISSUE_NUMBERS+=( "${1//,/}" )
+      shift
+      ;;
+  esac
+done
+
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+  SCRIPT_PATH="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$SCRIPT_PATH/$SOURCE"
+done
+
+SCRIPT_PATH="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_PATH/issue-import-common.sh"
+
+setup_repo_paths
+preflight_requeue
+
+print_verbose "REPO_ROOT=$REPO_ROOT"
+print_verbose "FAILED_DIR=$FAILED_DIR"
+print_verbose "PENDING_DIR=$PENDING_DIR"
+print_verbose "IMPORTED_DIR=$IMPORTED_DIR"
+print_verbose "DRY_RUN=$DRY_RUN"
+
+moved=0
+skipped=0
+not_found=0
+
+restore_failed_file() {
+  local file="$1"
+  local base_name original_name target_file
+
+  base_name="$(basename "$file")"
+  printf '%s\n' "$base_name"
+
+  parse_trailing_metadata "$file"
+
+  if [[ -n "$META_RETRY_COUNT" ]] && (( META_RETRY_COUNT >= MAX_RETRY_COUNT )); then
+    print_warning "  Skipping because retry limit was reached (RetryCount=$META_RETRY_COUNT)"
+    skipped=$((skipped + 1))
+    printf '\n'
+    return
+  fi
+
+  original_name="$(printf '%s\n' "$base_name" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}-(issue-[0-9]+-)?//')"
+  target_file="$PENDING_DIR/$original_name"
+
+  print_verbose "Restoring file as $target_file"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ "$META_ISSUE_CREATED" == "true" ]]; then
+      print_info "  [DRY RUN] Requeue existing issue as $original_name"
+    else
+      print_info "  [DRY RUN] Requeue as $original_name"
+    fi
+    moved=$((moved + 1))
+    printf '\n'
+    return
+  fi
+
+  if [[ "$META_ISSUE_CREATED" == "true" ]]; then
+    cp "$file" "$target_file"
+  else
+    sed '/^<!--$/,/^-->$/d' "$file" > "$target_file"
+  fi
+  rm -f "$file"
+
+  if [[ "$META_ISSUE_CREATED" == "true" ]]; then
+    print_success "  Requeued existing issue as $original_name"
+  else
+    print_success "  Requeued as $original_name"
+  fi
+  moved=$((moved + 1))
+  printf '\n'
+}
+
+restore_issue_by_number() {
+  local issue_number="$1"
+  local matches file base_name original_name target_file
+
+  mapfile -t matches < <(grep -l "^Issue: #$issue_number\$" "$FAILED_DIR"/*.md 2>/dev/null || true)
+
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    print_warning "Issue #$issue_number not found in failed/"
+    not_found=$((not_found + 1))
+    return
+  fi
+
+  if [[ ${#matches[@]} -gt 1 ]]; then
+    print_warning "Multiple failed files matched issue #$issue_number"
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  file="${matches[0]}"
+  base_name="$(basename "$file")"
+  printf '%s\n' "$base_name"
+
+  original_name="$(printf '%s\n' "$base_name" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}-(issue-[0-9]+-)?//')"
+  target_file="$PENDING_DIR/$original_name"
+
+  print_verbose "Restoring failed issue #$issue_number as $target_file"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    print_info "  [DRY RUN] Requeue existing issue as $original_name"
+    moved=$((moved + 1))
+    printf '\n'
+    return
+  fi
+
+  cp "$file" "$target_file"
+  rm -f "$file"
+
+  print_success "  Requeued existing issue as $original_name"
+  moved=$((moved + 1))
+  printf '\n'
+}
+
+files=( "$FAILED_DIR"/*.md )
+
+print_header "Requeueing failed imports"
+printf '%s\n\n' "-------------------------"
+
+if [[ ${#ISSUE_NUMBERS[@]} -gt 0 ]]; then
+  for issue_number in "${ISSUE_NUMBERS[@]}"; do
+    restore_issue_by_number "$issue_number"
+  done
+else
+  [[ -e "${files[0]}" ]] || {
+    print_warning "No failed files to requeue"
+    exit 0
+  }
+
+  for file in "${files[@]}"; do
+    restore_failed_file "$file"
+  done
+fi
+
+print_header "Summary"
+printf '%s\n' "-------"
+printf 'Moved:   %s\n' "$moved"
+printf 'Skipped: %s\n' "$skipped"
+if [[ ${#ISSUE_NUMBERS[@]} -gt 0 ]]; then
+  printf 'Missing: %s\n' "$not_found"
+fi


### PR DESCRIPTION
## Summary
Adds a local GitHub issue import workflow under `.github/` with support for
queued issue definitions, issue creation, sub-issue linking, retry handling,
and contributor-facing documentation for operating the workflow.

## Scope
- add `import-issues.sh` to create issues from markdown files in `pending/`
- add `requeue-failed-imports.sh` to restore failed issue files back to `pending/`
- add `issue-import-common.sh` for shared path resolution, preflight checks,
  metadata parsing, and console output helpers
- add `.github/issue-import/.gitignore` to preserve the workflow directories
  while ignoring transient import artifacts
- add `.github/issue-import/README.md` documenting the issue import workflow,
  file format, failure handling, retry behavior, and platform setup notes
- add support for dry-run mode in import and requeue flows
- add support for verbose logging in import and requeue flows
- support symlink-safe script execution by resolving the real script path before
  sourcing shared helpers
- implement two-pass import behavior: create issues first, then resolve and link
  sub-issues
- support parent resolution by explicit issue number, titles created in the
  current run, and existing local imported or failed metadata
- reuse existing issue metadata on re-import to avoid creating duplicate issues
- add targeted requeue by issue number for failed items with existing GitHub
  issues
- track `RetryCount` in failed metadata and skip normal requeue at the retry
  limit
- rewrite failed and imported metadata blocks cleanly so stale error metadata
  does not accumulate
- add shell-specific `.editorconfig` settings for `.sh` files

## Notes
The workflow intentionally treats `failed/` as the retry source of truth and
`imported/` as completed history. Existing issue reuse is driven by preserved
metadata comments when a failed file with `IssueCreated: true` is requeued.

When issue numbers are passed explicitly to the requeue script, that acts as an
operator override path and can restore a failed file even if it has reached the
normal retry limit.

This workflow creates issues through the GitHub CLI, so the normal GitHub web
issue-template selection flow is bypassed. Imported issue files should still
follow the same structure and conventions as the repository’s issue templates.

## Testing
- validated shell syntax with `bash -n` for:
  - `.github/scripts/import-issues.sh`
  - `.github/scripts/requeue-failed-imports.sh`
  - `.github/scripts/issue-import-common.sh`
- exercised dry-run behavior for import and requeue flows
- verified recovery scenarios for:
  - existing issues reused during re-import
  - failed files requeued with preserved metadata
  - retry-limit skip behavior
  - parent resolution from local imported metadata

Closes #159  
Closes #160  
Closes #161  
Closes #162  
Closes #158