### PR TITLE
Introduce activation email delivery abstraction

### DIFF
--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -9,7 +9,11 @@ import com.kartoush.customer.facade.model.CustomerView;
 import com.kartoush.customer.facade.model.UpdateCustomerRequest;
 import com.kartoush.customer.internal.validation.CreateCustomerRequestValidator;
 import com.kartoush.customer.internal.validation.UpdateCustomerRequestValidator;
+import com.kartoush.customer.service.ActivationEmailDelivery;
+import com.kartoush.customer.service.ActivationEmailService;
+import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.Email;
 import com.kartoush.platform.ulid.UlidGenerator;
@@ -21,21 +25,27 @@ import java.util.List;
 public class DefaultCustomerFacade implements CustomerFacade {
 
     /* TODO(#82): Move credential handling to a dedicated authentication module.
-     * Customer should not own passwordHash long-term as part of proper domain separation. 
+     * Customer should not own passwordHash long-term as part of proper domain separation.
      */
     private static final String TEMPORARY_PASSWORD_HASH = "TEMPORARY_PASSWORD_HASH";
 
     private final CustomerService customerService;
+    private final ActivationEmailService activationEmailService;
+    private final ActivationTokenService activationTokenService;
     private final UlidGenerator ulidGenerator;
     private final CreateCustomerRequestValidator createCustomerRequestValidator;
     private final UpdateCustomerRequestValidator updateCustomerRequestValidator;
 
     public DefaultCustomerFacade(
             final CustomerService customerService,
+            final ActivationEmailService activationEmailService,
+            final ActivationTokenService activationTokenService,
             final UlidGenerator ulidGenerator,
             final CreateCustomerRequestValidator createCustomerRequestValidator,
             final UpdateCustomerRequestValidator updateCustomerRequestValidator) {
         this.customerService = customerService;
+        this.activationEmailService = activationEmailService;
+        this.activationTokenService = activationTokenService;
         this.ulidGenerator = ulidGenerator;
         this.createCustomerRequestValidator = createCustomerRequestValidator;
         this.updateCustomerRequestValidator = updateCustomerRequestValidator;
@@ -62,7 +72,11 @@ public class DefaultCustomerFacade implements CustomerFacade {
                 new Email(request.email()),
                 TEMPORARY_PASSWORD_HASH);
 
-        final var savedCustomer = customerService.createCustomer(customer);
+        final Customer savedCustomer = customerService.createCustomer(customer);
+        final IssuedActivationToken issuedActivationToken = activationTokenService.createFor(savedCustomer.getId());
+
+        activationEmailService.sendActivationToken(savedCustomer.getEmail(), issuedActivationToken.rawToken());
+
         return toCustomerView(savedCustomer);
     }
 
@@ -92,7 +106,8 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     @Override
     public void resendActivationToken(final String customerId) {
-        customerService.resendActivationToken(customerId);
+        final ActivationEmailDelivery activationEmailDelivery = customerService.issueActivationTokenForResend(customerId);
+        activationEmailService.sendActivationToken(activationEmailDelivery.email(), activationEmailDelivery.rawToken());
     }
 
     @Override

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationEmailDelivery.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationEmailDelivery.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.service;
+
+import com.kartoush.platform.types.Email;
+
+public record ActivationEmailDelivery(
+    Email email,
+    String rawToken) {
+}

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationEmailService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationEmailService.java
@@ -1,0 +1,7 @@
+package com.kartoush.customer.service;
+
+import com.kartoush.platform.types.Email;
+
+public interface ActivationEmailService {
+    void sendActivationToken(Email email, String rawToken);
+}

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationTokenService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationTokenService.java
@@ -4,11 +4,11 @@ import com.kartoush.customer.domain.ActivationToken;
 import com.kartoush.platform.types.CustomerId;
 
 public interface ActivationTokenService {
-    ActivationToken createFor(CustomerId customerId);
+    IssuedActivationToken createFor(CustomerId customerId);
 
     ActivationToken validate(CustomerId customerId, String rawToken);
 
     ActivationToken consume(ActivationToken activationToken);
 
-    ActivationToken resendFor(CustomerId customerId);
+    IssuedActivationToken resendFor(CustomerId customerId);
 }

--- a/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
@@ -20,7 +20,7 @@ public interface CustomerService
 
     Customer activateCustomer(final String customerId, final String rawToken);
 
-    void resendActivationToken(final String customerId);
+    ActivationEmailDelivery issueActivationTokenForResend(final String customerId);
 
     Customer reactivateCustomer(final String customerId);
 

--- a/customer/src/main/java/com/kartoush/customer/service/IssuedActivationToken.java
+++ b/customer/src/main/java/com/kartoush/customer/service/IssuedActivationToken.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.service;
+
+import com.kartoush.customer.domain.ActivationToken;
+
+public record IssuedActivationToken(
+    ActivationToken activationToken,
+    String rawToken) {
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenService.java
@@ -13,6 +13,7 @@ import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.customer.service.ActivationTokenGenerator;
 import com.kartoush.customer.service.ActivationTokenHasher;
 import com.kartoush.customer.service.ActivationTokenService;
+import com.kartoush.customer.service.IssuedActivationToken;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -54,7 +55,7 @@ public class DefaultActivationTokenService implements ActivationTokenService {
     }
 
     @Override
-    public ActivationToken createFor(CustomerId customerId) {
+    public IssuedActivationToken createFor(CustomerId customerId) {
         if (!customerRepository.existsById(CustomerIdEmbeddable.from(customerId))) {
             throw new CustomerNotFoundException(customerId.value());
         }
@@ -63,7 +64,7 @@ public class DefaultActivationTokenService implements ActivationTokenService {
     }
 
     @Override
-    public ActivationToken resendFor(CustomerId customerId) {
+    public IssuedActivationToken resendFor(CustomerId customerId) {
         Instant consumedAt = Instant.now(clock);
         List<ActivationTokenEntity> activeTokens = activationTokenRepository.findAllByCustomerIdAndConsumedAtIsNull(
             CustomerIdEmbeddable.from(customerId));
@@ -79,7 +80,7 @@ public class DefaultActivationTokenService implements ActivationTokenService {
         return createFor(customerId);
     }
 
-    private ActivationToken createActivationToken(CustomerId customerId) {
+    private IssuedActivationToken createActivationToken(CustomerId customerId) {
         Instant createdAt = Instant.now(clock);
         Instant expiresAt = createdAt.plus(ACTIVATION_TOKEN_TTL);
 
@@ -96,7 +97,10 @@ public class DefaultActivationTokenService implements ActivationTokenService {
 
         ActivationTokenEntity activationTokenEntity = activationTokenMapper.toEntity(activationToken);
 
-        return activationTokenMapper.toDomain(activationTokenRepository.save(activationTokenEntity));
+        ActivationToken savedActivationToken =
+            activationTokenMapper.toDomain(activationTokenRepository.save(activationTokenEntity));
+
+        return new IssuedActivationToken(savedActivationToken, rawToken);
     }
 
     @Override

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
@@ -13,8 +13,10 @@ import com.kartoush.customer.persistence.entity.CustomerEntity;
 import com.kartoush.customer.persistence.mapper.CustomerMapper;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import com.kartoush.customer.persistence.repository.CustomerRepository;
+import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.IssuedActivationToken;
 
 import java.util.List;
 import java.util.Optional;
@@ -188,7 +190,7 @@ public class DefaultCustomerService implements CustomerService
 
     @Override
     @Transactional
-    public void resendActivationToken(final String customerId) {
+    public ActivationEmailDelivery issueActivationTokenForResend(final String customerId) {
         final CustomerEntity customerEntity = customerRepository
             .findById(CustomerIdEmbeddable.from(customerId))
             .orElseThrow(() -> new CustomerNotFoundException(customerId));
@@ -199,7 +201,8 @@ public class DefaultCustomerService implements CustomerService
             throw new InvalidActivationTokenResendException(customer.getStatus());
         }
 
-        activationTokenService.resendFor(customer.getId());
+        final IssuedActivationToken issuedActivationToken = activationTokenService.resendFor(customer.getId());
+        return new ActivationEmailDelivery(customer.getEmail(), issuedActivationToken.rawToken());
     }
 
     private void validateCustomerCanBeUpdated(final CustomerEntity customer) {

--- a/customer/src/main/java/com/kartoush/customer/service/impl/NoOpActivationEmailService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/NoOpActivationEmailService.java
@@ -1,0 +1,20 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.service.ActivationEmailService;
+import com.kartoush.platform.types.Email;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NoOpActivationEmailService implements ActivationEmailService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NoOpActivationEmailService.class);
+
+    @Override
+    public void sendActivationToken(final Email email, final String rawToken) {
+        LOG.warn(
+            "Activation email delivery requested for email={} but no concrete email delivery provider is configured",
+            email.value());
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -5,7 +5,11 @@ import com.kartoush.customer.domain.CustomerProfile;
 import com.kartoush.customer.facade.model.CreateCustomerRequest;
 import com.kartoush.customer.facade.model.CustomerView;
 import com.kartoush.customer.internal.validation.CreateCustomerRequestValidator;
+import com.kartoush.customer.service.ActivationEmailDelivery;
+import com.kartoush.customer.service.ActivationEmailService;
+import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
@@ -18,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,26 +46,36 @@ class DefaultCustomerFacadeTest {
     @Mock
     private CustomerService customerService;
 
+    @Mock
+    private ActivationEmailService activationEmailService;
+
+    @Mock
+    private ActivationTokenService activationTokenService;
+
     @InjectMocks
     private DefaultCustomerFacade facade;
 
     @Test
     void shouldCreateCustomer() {
-
         // given
         final var request = buildCustomerRequest();
         final var saved = buildCustomer();
         final var view = buildCustomerView();
+        final var issuedActivationToken = new IssuedActivationToken(mock(com.kartoush.customer.domain.ActivationToken.class), RAW_TOKEN);
 
         // when
         when(ulidGenerator.next()).thenReturn(CUSTOMER_ID);
         when(customerService.createCustomer(any())).thenReturn(saved);
+        when(activationTokenService.createFor(CustomerId.of(CUSTOMER_ID))).thenReturn(issuedActivationToken);
 
         final var result = facade.createCustomer(request);
 
         // then
         assertThat(result).isEqualTo(view);
         verify(validator).validate(request);
+        verify(customerService).createCustomer(any());
+        verify(activationTokenService).createFor(CustomerId.of(CUSTOMER_ID));
+        verify(activationEmailService).sendActivationToken(new Email(EMAIL), RAW_TOKEN);
     }
 
     @Test
@@ -81,11 +96,17 @@ class DefaultCustomerFacadeTest {
 
     @Test
     void shouldResendActivationToken() {
+        // given
+        final ActivationEmailDelivery activationEmail =
+            new ActivationEmailDelivery(new Email(EMAIL), RAW_TOKEN);
+        when(customerService.issueActivationTokenForResend(CUSTOMER_ID)).thenReturn(activationEmail);
+
         // when
         facade.resendActivationToken(CUSTOMER_ID);
 
         // then
-        verify(customerService).resendActivationToken(CUSTOMER_ID);
+        verify(customerService).issueActivationTokenForResend(CUSTOMER_ID);
+        verify(activationEmailService).sendActivationToken(new Email(EMAIL), RAW_TOKEN);
     }
 
     private CreateCustomerRequest buildCustomerRequest(){

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenServiceTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenServiceTest.java
@@ -21,6 +21,7 @@ import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
 import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.customer.service.ActivationTokenGenerator;
 import com.kartoush.customer.service.ActivationTokenHasher;
+import com.kartoush.customer.service.IssuedActivationToken;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -94,7 +95,8 @@ class DefaultActivationTokenServiceTest {
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        ActivationToken activationToken = activationTokenService.createFor(customerId);
+        IssuedActivationToken issuedActivationToken = activationTokenService.createFor(customerId);
+        ActivationToken activationToken = issuedActivationToken.activationToken();
 
         // then
         verify(activationTokenGenerator).generate();
@@ -116,6 +118,7 @@ class DefaultActivationTokenServiceTest {
         assertThat(activationToken.getCreatedAt()).isEqualTo(FIXED_INSTANT);
         assertThat(activationToken.getExpiresAt()).isEqualTo(FIXED_INSTANT.plusSeconds(TWENTY_FOUR_HOURS_IN_SECONDS));
         assertThat(activationToken.getConsumedAt()).isNull();
+        assertThat(issuedActivationToken.rawToken()).isEqualTo(RAW_TOKEN);
     }
 
     @Test
@@ -515,13 +518,15 @@ class DefaultActivationTokenServiceTest {
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        ActivationToken resentToken = activationTokenService.resendFor(customerId);
+        IssuedActivationToken issuedActivationToken = activationTokenService.resendFor(customerId);
+        ActivationToken resentToken = issuedActivationToken.activationToken();
 
         // then
         verify(activationTokenRepository).findAllByCustomerIdAndConsumedAtIsNull(CustomerIdEmbeddable.from(customerId));
         verify(activationTokenRepository).saveAll(any());
         assertThat(existingToken.getConsumedAt()).isEqualTo(FIXED_INSTANT);
         assertThat(resentToken.getTokenHash()).isEqualTo(TOKEN_HASH);
+        assertThat(issuedActivationToken.rawToken()).isEqualTo(RAW_TOKEN);
     }
 
     private void stubExistingCustomer(CustomerId customerId) {

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
@@ -10,7 +10,9 @@ import com.kartoush.customer.persistence.entity.CustomerEntity;
 import com.kartoush.customer.persistence.mapper.CustomerMapper;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import com.kartoush.customer.persistence.repository.CustomerRepository;
+import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.ActivationTokenService;
+import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
@@ -335,27 +337,34 @@ class DefaultCustomerServiceTest
     }
 
     @Test
-    void shouldResendActivationTokenForPendingCustomer() {
+    void shouldIssueActivationTokenForResendForPendingCustomer() {
         // given
         final CustomerEntity customerEntity = mock(CustomerEntity.class);
         final Customer customer = mock(Customer.class);
+        final IssuedActivationToken issuedActivationToken =
+            new IssuedActivationToken(mock(com.kartoush.customer.domain.ActivationToken.class), RAW_TOKEN);
 
         given(customerRepository.findById(CUSTOMER_ID_EMBEDDABLE)).willReturn(Optional.of(customerEntity));
         given(customerMapper.toDomain(customerEntity)).willReturn(customer);
         given(customer.getStatus()).willReturn(CustomerStatus.PENDING);
         given(customer.getId()).willReturn(CUSTOMER_ID);
+        given(customer.getEmail()).willReturn(EMAIL);
+        given(activationTokenService.resendFor(CUSTOMER_ID)).willReturn(issuedActivationToken);
 
         // when
-        defaultCustomerService.resendActivationToken(CUSTOMER_ID_VALUE);
+        final ActivationEmailDelivery activationEmail =
+            defaultCustomerService.issueActivationTokenForResend(CUSTOMER_ID_VALUE);
 
         // then
         verify(customerRepository).findById(CUSTOMER_ID_EMBEDDABLE);
         verify(customerMapper).toDomain(customerEntity);
         verify(activationTokenService).resendFor(CUSTOMER_ID);
+        assertThat(activationEmail.email()).isEqualTo(EMAIL);
+        assertThat(activationEmail.rawToken()).isEqualTo(RAW_TOKEN);
     }
 
     @Test
-    void shouldThrowWhenResendingActivationTokenForNonPendingCustomer() {
+    void shouldThrowWhenIssuingActivationTokenForResendForNonPendingCustomer() {
         // given
         final CustomerEntity customerEntity = mock(CustomerEntity.class);
         final Customer customer = mock(Customer.class);
@@ -365,7 +374,7 @@ class DefaultCustomerServiceTest
         given(customer.getStatus()).willReturn(CustomerStatus.ACTIVE);
 
         // when / then
-        assertThatThrownBy(() -> defaultCustomerService.resendActivationToken(CUSTOMER_ID_VALUE))
+        assertThatThrownBy(() -> defaultCustomerService.issueActivationTokenForResend(CUSTOMER_ID_VALUE))
             .isInstanceOf(InvalidActivationTokenResendException.class)
             .hasMessage("Activation token cannot be resent while customer is in ACTIVE status");
 
@@ -373,6 +382,4 @@ class DefaultCustomerServiceTest
         verify(customerMapper).toDomain(customerEntity);
         verify(activationTokenService, never()).resendFor(any());
     }
-
-
 }


### PR DESCRIPTION
### Summary
Introduces an activation email delivery abstraction so activation token issuance can hand off delivery concerns without exposing raw tokens through the API layer or binding the customer module to a concrete email provider.

### Scope
- add `ActivationEmailService` as the activation email delivery abstraction
- introduce `NoOpActivationEmailService` as the placeholder implementation
- introduce `IssuedActivationToken` and `ActivationEmailDelivery` as service-layer handoff types
- update activation token issuance to return the raw token only within service-layer handoff objects
- wire customer creation to issue an activation token and trigger delivery through the abstraction
- move resend email sending out of the transactional service method and into the facade orchestration step
- rename resend issuance flow to reflect transactional issuance rather than external side effects
- update unit tests for activation token issuance, customer service resend behavior, and facade orchestration

### Notes
This task establishes the delivery seam only. The current `NoOpActivationEmailService` logs the delivery request and allows a real provider-backed implementation to be added later without changing the activation flow contract.

### Testing
`./gradlew :customer:test :app:test`

Closes #167