### PR TITLE
Improve issue import templates and metadata handling

### DIFF
--- a/.github/issue-import/.gitignore
+++ b/.github/issue-import/.gitignore
@@ -7,3 +7,5 @@
 !imported/.gitkeep
 !failed/
 !failed/.gitkeep
+!templates/
+!templates/*.md

--- a/.github/issue-import/README.md
+++ b/.github/issue-import/README.md
@@ -15,6 +15,8 @@ the file lifecycle visible in the repository.
 - `failed/`
   Contains files that could not be fully processed and were annotated with
   failure details.
+- `templates/`
+  Contains starter markdown templates for creating new epic and task files.
 
 The `.gitignore` in this directory keeps these folders in the repository while
 allowing imported artifacts to be ignored by default, except for `.gitkeep` and
@@ -24,6 +26,10 @@ this README.
 
 Each issue definition must be a markdown file in `pending/` with a small
 metadata header followed by a blank line and then the issue body.
+
+The easiest way to start a new import file is to copy one of the templates in
+`templates/` and rename it with the numeric prefix you want to use in
+`pending/`.
 
 Use a numeric filename prefix to make import order explicit, for example:
 
@@ -44,6 +50,7 @@ Required metadata:
 Optional metadata:
 
 - `Parent:`
+- `Labels:`
 
 Rules:
 
@@ -54,6 +61,7 @@ Rules:
   error
 - `Title:` is required
 - `Parent:` is optional
+- `Labels:` is optional and accepts comma-separated label names
 - dependency references belong in a markdown `Dependencies` section in the body,
   not in the metadata header
 
@@ -61,6 +69,7 @@ Example epic:
 
 ```md
 Title: Epic: Issue Import and Workflow Tooling
+Labels: enhancement, documentation
 
 ### Goal
 
@@ -79,6 +88,7 @@ Example child task:
 ```md
 Title: Task: Validate sub-issue linking during import
 Parent: Epic: Issue Import and Workflow Tooling
+Labels: enhancement, application
 
 ### Summary
 
@@ -104,8 +114,48 @@ Provision the compute layer after the network is available.
 ## Dependencies
 
 - 03-task-vpc-and-networking
-- 04-task-shared-security-groups
+- #123
 ```
+
+## Templates
+
+Starter templates are available in:
+
+- `templates/epic-template.md`
+- `templates/task-template.md`
+
+The task template includes a `Parent:` example for epic-linked work. Remove
+that line when creating a standalone task.
+
+The task template also shows:
+
+- how to use `Parent: #123` when the parent issue number is already known
+- where to list `Dependencies` using source file names or GitHub issue numbers that the importer can resolve
+- how to provide optional comma-separated `Labels:` metadata
+
+Recommended workflow:
+
+1. Copy the appropriate template into `pending/`
+2. Rename it with a numeric prefix such as `00-` or `01-`
+3. Replace the placeholder title and section content
+4. Run a dry run before importing for real
+
+Example:
+
+```bash
+cp .github/issue-import/templates/task-template.md \
+  .github/issue-import/pending/00-task-example.md
+```
+
+You can also print a template directly from the importer:
+
+```bash
+.github/scripts/import-issues.sh --print-template epic
+.github/scripts/import-issues.sh --print-template task
+```
+
+Template files must remain outside `pending/` so they are not imported
+accidentally.
 
 ## Parent Resolution
 
@@ -123,6 +173,32 @@ children to be imported together from `pending/`.
 If the parent cannot be resolved, the child issue may already exist in GitHub,
 but the file will be moved to `failed/` and marked for manual follow-up.
 
+## Dependency Resolution
+
+Entries in a `Dependencies` section can be defined in either of these ways:
+
+- by source file name, for example: `03-task-vpc-and-networking`
+- by explicit GitHub issue number, for example: `#123`
+
+Source file names are useful when related work is being imported from local
+markdown files. GitHub issue numbers are useful when a dependency already
+exists in GitHub and is not represented by a local import file.
+
+## Label Handling
+
+`Labels:` can be defined as a comma-separated metadata value, for example:
+
+```md
+Labels: customer, application
+```
+
+During import, the script validates requested labels against the repository's
+existing GitHub labels.
+
+- valid labels are applied during issue creation
+- invalid labels are ignored so they do not block issue creation
+- ignored labels are reported as warnings in the importer output
+
 ## Import Script
 
 The main import entrypoint is:
@@ -135,6 +211,7 @@ Optional flag:
 
 - `--dry-run`
 - `--verbose`
+- `--print-template epic|task`
 
 Environment variables supported by the script:
 
@@ -159,6 +236,7 @@ Pass 1: create issues
 
 - reads each `pending/*.md` file
 - parses `Title:` and optional `Parent:`
+- parses optional `Labels:`
 - appends this footer to the GitHub issue body:
 
   ```html
@@ -168,6 +246,7 @@ Pass 1: create issues
   ```
 
 - creates the issue with `gh issue create`
+- applies any valid requested labels during issue creation
 - optionally assigns the issue to the authenticated GitHub user when
   `--assign-to-self` is used
 - records the created issue number, URL, and internal GitHub issue id for use in
@@ -196,6 +275,18 @@ Dry run with verbose logging:
 
 ```bash
 .github/scripts/import-issues.sh --dry-run --verbose
+```
+
+Print the epic template:
+
+```bash
+.github/scripts/import-issues.sh --print-template epic
+```
+
+Print the task template:
+
+```bash
+.github/scripts/import-issues.sh --print-template task
 ```
 
 Import into the default repository:

--- a/.github/issue-import/templates/epic-template.md
+++ b/.github/issue-import/templates/epic-template.md
@@ -1,0 +1,31 @@
+Title: [Epic]: Replace with epic title
+Labels: enhancement, documentation
+
+<!--
+Remove the Labels line when no labels should be applied.
+Labels must already exist in GitHub to be applied during import.
+-->
+
+## Summary
+
+Describe the broader problem or outcome this epic is intended to cover.
+
+## Scope
+
+- list the major workstreams or deliverables included in this epic
+- keep scope high level and outcome-oriented
+
+## Acceptance Criteria
+
+- the epic defines a clear and coherent slice of work
+- the scope is broad enough to justify grouping multiple tasks beneath it
+- the expected outcome is understandable without additional context
+
+## Dependencies
+
+- None
+
+## Notes
+
+Add any constraints, sequencing guidance, or follow-up considerations that
+would help when breaking this epic into tasks.

--- a/.github/issue-import/templates/task-template.md
+++ b/.github/issue-import/templates/task-template.md
@@ -1,0 +1,37 @@
+Title: [Task]: Replace with task title
+Parent: [Epic]: Replace with epic title
+Labels: enhancement, application
+
+<!--
+Alternative parent format when the GitHub issue number is already known:
+Parent: #123
+
+Remove the Parent line when creating a standalone task.
+Remove the Labels line when no labels should be applied.
+Labels that do not exist in GitHub are ignored during import.
+-->
+
+## Summary
+
+Describe the specific change or capability this task should deliver.
+
+## Scope
+
+- list the concrete implementation work included in this task
+- keep each bullet specific enough to guide execution
+
+## Acceptance Criteria
+
+- describe the expected behavior or outcome that defines completion
+- include any important validation expectations
+
+## Dependencies
+
+- None
+- Example source file name: `03-task-vpc-and-networking`
+- Example GitHub issue reference: `#123`
+
+## Notes
+
+Add any design constraints, implementation guidance, or deferred work relevant
+to this task.

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 VERBOSE="false"
 DRY_RUN="false"
 ASSIGN_TO_SELF="false"
+PRINT_TEMPLATE=""
+declare -A REPO_LABELS
 
 print_help() {
   cat <<'EOF'
@@ -14,8 +16,39 @@ Options:
   -n, --dry-run         Validate and simulate issue creation without changing GitHub
   -v, --verbose         Print verbose diagnostic output
   -a, --assign-to-self  Assign newly created issues to the authenticated GitHub user
+      --print-template  Print the requested template (`epic` or `task`) and exit
   -h, --help            Show this help text
+
+Templates:
+  Epic template: .github/issue-import/templates/epic-template.md
+  Task template: .github/issue-import/templates/task-template.md
 EOF
+}
+
+print_template() {
+  local template_name="$1"
+  local template_file
+
+  case "$template_name" in
+    epic)
+      template_file="$IMPORT_ROOT/templates/epic-template.md"
+      ;;
+    task)
+      template_file="$IMPORT_ROOT/templates/task-template.md"
+      ;;
+    *)
+      print_error "✗ Unknown template: $template_name"
+      print_info "  Supported templates: epic, task"
+      exit 1
+      ;;
+  esac
+
+  if [[ ! -f "$template_file" ]]; then
+    print_error "✗ Template file not found: $template_file"
+    exit 1
+  fi
+
+  cat "$template_file"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -31,6 +64,14 @@ while [[ $# -gt 0 ]]; do
     -a|--assign-to-self)
       ASSIGN_TO_SELF="true"
       shift
+      ;;
+    --print-template)
+      [[ $# -ge 2 ]] || {
+        print_error "✗ --print-template requires a value: epic or task"
+        exit 1
+      }
+      PRINT_TEMPLATE="$2"
+      shift 2
       ;;
     -h|--help)
       print_help
@@ -59,28 +100,14 @@ source "$SCRIPT_PATH/issue-import-common.sh"
 AUTHENTICATED_USER=""
 
 setup_repo_paths
-preflight_import
 
-if [[ "$DRY_RUN" != "true" && "$ASSIGN_TO_SELF" == "true" ]]; then
-  if ! lookup_authenticated_user; then
-    print_error "✗ Unable to determine authenticated GitHub user"
-    exit 1
-  fi
-fi
-
-print_verbose "REPO=$REPO"
-print_verbose "REPO_ROOT=$REPO_ROOT"
-print_verbose "IMPORT_ROOT=$IMPORT_ROOT"
-print_verbose "PENDING_DIR=$PENDING_DIR"
-print_verbose "IMPORTED_DIR=$IMPORTED_DIR"
-print_verbose "FAILED_DIR=$FAILED_DIR"
-print_verbose "DRY_RUN=$DRY_RUN"
-print_verbose "ASSIGN_TO_SELF=$ASSIGN_TO_SELF"
-if [[ -n "$AUTHENTICATED_USER" ]]; then
-  print_verbose "AUTHENTICATED_USER=$AUTHENTICATED_USER"
+if [[ -n "$PRINT_TEMPLATE" ]]; then
+  print_template "$PRINT_TEMPLATE"
+  exit 0
 fi
 
 declare -A FILE_PARENT
+declare -A FILE_LABELS
 declare -A FILE_ISSUE_NUMBER
 declare -A FILE_ISSUE_ID
 declare -A FILE_ISSUE_URL
@@ -95,6 +122,7 @@ parse_metadata() {
   local file="$1"
   local title=""
   local parent=""
+  local labels=""
   local body_file
   local in_metadata="true"
 
@@ -109,6 +137,8 @@ parse_metadata() {
         title="$(trim "${line#Title:}")"
       elif [[ "$line" == Parent:* ]]; then
         parent="$(trim "${line#Parent:}")"
+      elif [[ "$line" == Labels:* ]]; then
+        labels="$(trim "${line#Labels:}")"
       else
         print_verbose "Invalid metadata line in $(basename "$file"): $line"
         rm -f "$body_file"
@@ -127,6 +157,7 @@ parse_metadata() {
 
   PARSED_TITLE="$title"
   PARSED_PARENT="$parent"
+  PARSED_LABELS="$labels"
   PARSED_BODY_FILE="$body_file"
 }
 
@@ -153,6 +184,101 @@ lookup_authenticated_user() {
 
   AUTHENTICATED_USER="$gh_output"
 }
+
+load_repo_labels() {
+  local gh_output
+  local gh_exit_code
+  local label_name
+
+  set +e
+  gh_output="$(
+    gh api \
+      --paginate \
+      "/repos/$REPO/labels" \
+      --jq '.[].name' 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "gh api label lookup failed: $gh_output"
+    return 1
+  fi
+
+  while IFS= read -r label_name || [[ -n "$label_name" ]]; do
+    [[ -n "$label_name" ]] || continue
+    REPO_LABELS["$label_name"]="true"
+  done <<< "$gh_output"
+}
+
+parse_label_list() {
+  local raw_labels="$1"
+  local -a parsed_labels=()
+  local label
+
+  if [[ -z "$raw_labels" ]]; then
+    PARSED_LABEL_LIST=()
+    return 0
+  fi
+
+  IFS=',' read -r -a parsed_labels <<< "$raw_labels"
+
+  PARSED_LABEL_LIST=()
+  for label in "${parsed_labels[@]}"; do
+    label="$(trim "$label")"
+    [[ -n "$label" ]] || continue
+    PARSED_LABEL_LIST+=("$label")
+  done
+}
+
+filter_valid_labels() {
+  local -a requested_labels=("$@")
+  local label
+
+  FILTERED_VALID_LABELS=()
+  FILTERED_INVALID_LABELS=()
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    FILTERED_VALID_LABELS=("${requested_labels[@]}")
+    return 0
+  fi
+
+  for label in "${requested_labels[@]}"; do
+    if [[ -n "${REPO_LABELS[$label]:-}" ]]; then
+      FILTERED_VALID_LABELS+=("$label")
+    else
+      FILTERED_INVALID_LABELS+=("$label")
+    fi
+  done
+}
+
+preflight_import
+
+if [[ "$DRY_RUN" != "true" ]]; then
+  if ! load_repo_labels; then
+    print_error "✗ Unable to load repository labels"
+    exit 1
+  fi
+fi
+
+if [[ "$DRY_RUN" != "true" && "$ASSIGN_TO_SELF" == "true" ]]; then
+  if ! lookup_authenticated_user; then
+    print_error "✗ Unable to determine authenticated GitHub user"
+    exit 1
+  fi
+fi
+
+print_verbose "REPO=$REPO"
+print_verbose "REPO_ROOT=$REPO_ROOT"
+print_verbose "IMPORT_ROOT=$IMPORT_ROOT"
+print_verbose "PENDING_DIR=$PENDING_DIR"
+print_verbose "IMPORTED_DIR=$IMPORTED_DIR"
+print_verbose "FAILED_DIR=$FAILED_DIR"
+print_verbose "DRY_RUN=$DRY_RUN"
+print_verbose "ASSIGN_TO_SELF=$ASSIGN_TO_SELF"
+if [[ -n "$AUTHENTICATED_USER" ]]; then
+  print_verbose "AUTHENTICATED_USER=$AUTHENTICATED_USER"
+fi
 
 append_footer() {
   local body_file="$1"
@@ -189,6 +315,28 @@ lookup_issue_rest_id() {
   fi
 
   LOOKED_UP_ISSUE_ID="$issue_id"
+}
+
+lookup_issue_rest_id_with_retry() {
+  local issue_number="$1"
+  local max_attempts="${2:-5}"
+  local sleep_seconds="${3:-1}"
+  local attempt=1
+
+  while (( attempt <= max_attempts )); do
+    if lookup_issue_rest_id "$issue_number"; then
+      return 0
+    fi
+
+    if (( attempt < max_attempts )); then
+      print_verbose "Retrying issue lookup for #$issue_number (attempt $((attempt + 1))/$max_attempts)"
+      sleep "$sleep_seconds"
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  return 1
 }
 
 lookup_issue_number_by_title_in_dir() {
@@ -264,6 +412,11 @@ lookup_issue_number_by_source_name_in_dir() {
 resolve_dependency_issue_number() {
   local dependency_source="$1"
   local source_key
+
+  if [[ "$dependency_source" =~ ^#([0-9]+)$ ]]; then
+    RESOLVED_DEPENDENCY_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+    return 0
+  fi
 
   if [[ -n "${SOURCE_TO_ISSUE_NUMBER[$dependency_source]:-}" ]]; then
     RESOLVED_DEPENDENCY_ISSUE_NUMBER="${SOURCE_TO_ISSUE_NUMBER[$dependency_source]}"
@@ -467,8 +620,11 @@ create_issue() {
   local file="$1"
   local title="$2"
   local body_file="$3"
+  shift 3
+  local -a labels=("$@")
   local issue_body_file
   local -a gh_create_args
+  local label
 
   build_issue_body_file "$body_file"
   issue_body_file="$BUILT_ISSUE_BODY_FILE"
@@ -483,6 +639,10 @@ create_issue() {
     gh_create_args+=(--assignee "$AUTHENTICATED_USER")
   fi
 
+  for label in "${labels[@]}"; do
+    gh_create_args+=(--label "$label")
+  done
+
   if [[ "$DRY_RUN" == "true" ]]; then
     local key
     local dry_run_issue_number
@@ -492,6 +652,9 @@ create_issue() {
     printf '    Title: %s\n' "$title"
     if [[ "$ASSIGN_TO_SELF" == "true" ]]; then
       printf '    Assign to self: yes\n'
+    fi
+    if [[ ${#labels[@]} -gt 0 ]]; then
+      printf '    Labels: %s\n' "$(IFS=', '; printf '%s' "${labels[*]}")"
     fi
     CREATED_ISSUE_URL="dry-run://$key"
     CREATED_ISSUE_NUMBER="$dry_run_issue_number"
@@ -518,12 +681,13 @@ create_issue() {
   issue_url="$(printf '%s\n' "$gh_output" | tail -n 1 | tr -d '\r')"
   issue_number="$(echo "$issue_url" | sed -E 's#.*/issues/([0-9]+)$#\1#')"
 
-  if ! lookup_issue_rest_id "$issue_number"; then
+  CREATED_ISSUE_URL="$issue_url"
+  CREATED_ISSUE_NUMBER="$issue_number"
+
+  if ! lookup_issue_rest_id_with_retry "$issue_number"; then
     return 1
   fi
 
-  CREATED_ISSUE_URL="$issue_url"
-  CREATED_ISSUE_NUMBER="$issue_number"
   CREATED_ISSUE_ID="$LOOKED_UP_ISSUE_ID"
 
   created_count=$((created_count + 1))
@@ -618,15 +782,39 @@ for file in "${files[@]}"; do
   else
     print_verbose "Parsed parent: <none>"
   fi
+  if [[ -n "$PARSED_LABELS" ]]; then
+    print_verbose "Parsed labels: $PARSED_LABELS"
+  else
+    print_verbose "Parsed labels: <none>"
+  fi
 
   FILE_PARENT["$file"]="$PARSED_PARENT"
+  FILE_LABELS["$file"]="$PARSED_LABELS"
+
+  parse_label_list "$PARSED_LABELS"
+  filter_valid_labels "${PARSED_LABEL_LIST[@]}"
+
+  if [[ ${#FILTERED_VALID_LABELS[@]} -gt 0 ]]; then
+    printf '  Labels\n'
+    if [[ "$DRY_RUN" == "true" ]]; then
+      printf '    [DRY RUN] %s\n' "$(IFS=', '; printf '%s' "${FILTERED_VALID_LABELS[*]}")"
+    else
+      printf '    %s\n' "$(IFS=', '; printf '%s' "${FILTERED_VALID_LABELS[*]}")"
+    fi
+  fi
+
+  if [[ ${#FILTERED_INVALID_LABELS[@]} -gt 0 ]]; then
+    for invalid_label in "${FILTERED_INVALID_LABELS[@]}"; do
+      print_warning "  Warning: ignoring unknown label '$invalid_label'"
+    done
+  fi
 
   parse_existing_issue_metadata "$file"
 
   if [[ -n "$EXISTING_ISSUE_NUMBER" ]]; then
     print_info "  Reusing existing issue #$EXISTING_ISSUE_NUMBER"
 
-    if ! lookup_issue_rest_id "$EXISTING_ISSUE_NUMBER"; then
+    if ! lookup_issue_rest_id_with_retry "$EXISTING_ISSUE_NUMBER"; then
       rm -f "$PARSED_BODY_FILE"
       move_to_failed "$file" "Existing issue lookup failed" "true" "$EXISTING_ISSUE_NUMBER" "$EXISTING_ISSUE_URL"
       printf '\n'
@@ -644,9 +832,13 @@ for file in "${files[@]}"; do
     continue
   fi
 
-  if ! create_issue "$file" "$PARSED_TITLE" "$PARSED_BODY_FILE"; then
+  if ! create_issue "$file" "$PARSED_TITLE" "$PARSED_BODY_FILE" "${FILTERED_VALID_LABELS[@]}"; then
     rm -f "$PARSED_BODY_FILE"
-    move_to_failed "$file" "Create failed"
+    if [[ -n "${CREATED_ISSUE_NUMBER:-}" ]]; then
+      move_to_failed "$file" "Create follow-up failed" "true" "$CREATED_ISSUE_NUMBER" "$CREATED_ISSUE_URL"
+    else
+      move_to_failed "$file" "Create failed"
+    fi
     printf '\n'
     continue
   fi


### PR DESCRIPTION
## Summary

Improves the issue import workflow by adding reusable templates, CLI template output, richer metadata support, and reliability fixes discovered while importing new work.

## Scope

- add tracked epic and task templates under `.github/issue-import/templates/`
- add `--print-template epic|task` to the importer
- document the template workflow in the issue import README
- add support for dependency references by GitHub issue number as well as source file name
- add optional `Labels:` metadata with repository label validation
- ignore invalid labels with warnings instead of blocking issue creation
- preserve created issue metadata when follow-up importer steps fail after issue creation
- add retry logic for post-create issue lookup to tolerate transient GitHub propagation lag
- update `.gitignore` so issue import templates are committed

## Notes

Static templates remain the baseline workflow, but the importer can now print them directly for quick copying.

Label validation uses the repository's existing GitHub labels. Valid labels are applied during creation, and invalid labels are reported and ignored so they do not block imports.

The importer now preserves issue identity on partial failures after `gh issue create`, which makes requeue and recovery safe when GitHub issue creation succeeds but a later lookup or follow-up step fails.

## Testing

- ran `bash -n .github/scripts/import-issues.sh .github/scripts/requeue-failed-imports.sh .github/scripts/issue-import-common.sh`
- verified `import-issues --help`
- verified `import-issues --print-template epic`
- verified `import-issues --print-template task`
- exercised real imports for the new task and AWS pre-flight task files
- confirmed retry-based recovery path for the transient post-create lookup failure affecting issue `#187`

Closes #184
