### PR TITLE
Improve issue import dry-run validation

### DIFF
--- a/.github/issue-import/README.md
+++ b/.github/issue-import/README.md
@@ -198,6 +198,7 @@ existing GitHub labels.
 - valid labels are applied during issue creation
 - invalid labels are ignored so they do not block issue creation
 - ignored labels are reported as warnings in the importer output
+- when the title starts with `[Task]`, `Task:`, `[Epic]`, or `Epic:`, the importer automatically adds the corresponding `task` or `epic` label if it is not already present
 
 ## Import Script
 
@@ -270,6 +271,8 @@ Dry run:
 ```bash
 .github/scripts/import-issues.sh --dry-run
 ```
+
+Dry-run performs read-only GitHub validation for importer prerequisites such as authentication and label lookup, but it does not create, edit, or link issues.
 
 Dry run with verbose logging:
 
@@ -516,8 +519,8 @@ For real imports, `gh` must be authenticated against GitHub.
 If you use `--assign-to-self`, the authenticated user must also be assignable in
 the target repository.
 
-For `--dry-run`, `gh` must still be installed, but GitHub authentication is not
-required.
+For `--dry-run`, `gh` must still be installed and authenticated so the importer
+can validate safe read-only GitHub dependencies without mutating issues.
 
 ### Install GitHub CLI
 

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -117,6 +117,8 @@ declare -A SOURCE_TO_ISSUE_NUMBER
 created_count=0
 linked_count=0
 failed_count=0
+warning_count=0
+LOOKUP_ISSUE_ID_ATTEMPTS=0
 
 parse_metadata() {
   local file="$1"
@@ -271,6 +273,12 @@ filter_valid_labels() {
   done
 }
 
+emit_warning() {
+  local message="$1"
+  warning_count=$((warning_count + 1))
+  print_warning "$message"
+}
+
 preflight_import
 
 if ! load_repo_labels; then
@@ -327,7 +335,6 @@ lookup_issue_rest_id() {
   set -e
 
   if [[ $gh_exit_code -ne 0 ]]; then
-    print_verbose "gh api issue lookup failed: $issue_id"
     return 1
   fi
 
@@ -340,16 +347,23 @@ lookup_issue_rest_id_with_retry() {
   local sleep_seconds="${3:-1}"
   local attempt=1
 
+  LOOKUP_ISSUE_ID_ATTEMPTS=0
+
   while (( attempt <= max_attempts )); do
+    LOOKUP_ISSUE_ID_ATTEMPTS="$attempt"
+
     if lookup_issue_rest_id "$issue_number"; then
+      if (( attempt > 1 )); then
+        print_verbose "Recovered REST issue ID lookup for #$issue_number after $attempt attempts"
+      fi
       return 0
     fi
 
-    if (( attempt < max_attempts )); then
-      print_verbose "Retrying issue lookup for #$issue_number (attempt $((attempt + 1))/$max_attempts)"
-      sleep "$sleep_seconds"
+    if (( attempt == max_attempts )); then
+      return 1
     fi
 
+    sleep "$sleep_seconds"
     attempt=$((attempt + 1))
   done
 
@@ -545,6 +559,8 @@ update_issue_body() {
     print_verbose "gh issue edit failed: $gh_output"
     return 1
   fi
+
+  print_success "  Updated dependencies"
 }
 
 move_to_failed() {
@@ -597,7 +613,7 @@ move_to_failed() {
   } > "$failed_file"
 
   rm -f "$file"
-  print_warning "  Failed"
+  print_warning "  Failed: $error_message"
 }
 
 move_to_imported() {
@@ -701,6 +717,10 @@ create_issue() {
   CREATED_ISSUE_URL="$issue_url"
   CREATED_ISSUE_NUMBER="$issue_number"
 
+  print_success "  Created (#$issue_number)"
+  printf '    URL: %s\n' "$issue_url"
+  print_verbose "Looking up REST issue ID for #$issue_number"
+
   if ! lookup_issue_rest_id_with_retry "$issue_number"; then
     return 1
   fi
@@ -708,8 +728,6 @@ create_issue() {
   CREATED_ISSUE_ID="$LOOKED_UP_ISSUE_ID"
 
   created_count=$((created_count + 1))
-  print_success "  Created (#$issue_number)"
-  printf '    URL: %s\n' "$issue_url"
   print_verbose "Issue ID: $LOOKED_UP_ISSUE_ID"
 }
 
@@ -823,7 +841,7 @@ for file in "${files[@]}"; do
 
   if [[ ${#FILTERED_INVALID_LABELS[@]} -gt 0 ]]; then
     for invalid_label in "${FILTERED_INVALID_LABELS[@]}"; do
-      print_warning "  Warning: ignoring unknown label '$invalid_label'"
+      emit_warning "  Warning: ignoring unknown label '$invalid_label'"
     done
   fi
 
@@ -853,7 +871,7 @@ for file in "${files[@]}"; do
   if ! create_issue "$file" "$PARSED_TITLE" "$PARSED_BODY_FILE" "${FILTERED_VALID_LABELS[@]}"; then
     rm -f "$PARSED_BODY_FILE"
     if [[ -n "${CREATED_ISSUE_NUMBER:-}" ]]; then
-      move_to_failed "$file" "Create follow-up failed" "true" "$CREATED_ISSUE_NUMBER" "$CREATED_ISSUE_URL"
+      move_to_failed "$file" "Issue created but REST issue ID lookup failed after $LOOKUP_ISSUE_ID_ATTEMPTS attempts" "true" "$CREATED_ISSUE_NUMBER" "$CREATED_ISSUE_URL"
     else
       move_to_failed "$file" "Create failed"
     fi
@@ -911,7 +929,7 @@ for file in "${files[@]}"; do
 
   if [[ ${#DEPENDENCY_WARNINGS[@]} -gt 0 ]]; then
     for unresolved_dependency in "${DEPENDENCY_WARNINGS[@]}"; do
-      print_warning "  Warning: unresolved dependency '$unresolved_dependency'"
+      emit_warning "  Warning: unresolved dependency '$unresolved_dependency'"
     done
   fi
 
@@ -941,6 +959,11 @@ printf '%sSummary%s\n' "$COLOR_BOLD" "$COLOR_RESET"
 printf '%s\n' "-------"
 printf '%sCreated:%s %s\n' "$COLOR_BOLD" "$COLOR_RESET" "$created_count"
 printf '%sLinked:%s  %s\n' "$COLOR_BOLD" "$COLOR_RESET" "$linked_count"
+if (( warning_count > 0 )); then
+  print_warning "${COLOR_BOLD}Warnings:${COLOR_RESET} $warning_count"
+else
+  printf '%s%sWarnings:%s %s%s\n' "$COLOR_YELLOW" "$COLOR_BOLD" "$COLOR_RESET" "$warning_count" "$COLOR_RESET"
+fi
 if (( failed_count > 0 )); then
   print_error "${COLOR_BOLD}Failed:${COLOR_RESET}  $failed_count"
 else

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -231,17 +231,36 @@ parse_label_list() {
   done
 }
 
+add_inferred_type_label() {
+  local title="$1"
+  local inferred_label=""
+  local label
+
+  if [[ "$title" =~ ^\[Task\]:[[:space:]] || "$title" =~ ^Task:[[:space:]] ]]; then
+    inferred_label="task"
+  elif [[ "$title" =~ ^\[Epic\]:[[:space:]] || "$title" =~ ^Epic:[[:space:]] ]]; then
+    inferred_label="epic"
+  fi
+
+  if [[ -z "$inferred_label" ]]; then
+    return 0
+  fi
+
+  for label in "${PARSED_LABEL_LIST[@]}"; do
+    if [[ "$label" == "$inferred_label" ]]; then
+      return 0
+    fi
+  done
+
+  PARSED_LABEL_LIST+=("$inferred_label")
+}
+
 filter_valid_labels() {
   local -a requested_labels=("$@")
   local label
 
   FILTERED_VALID_LABELS=()
   FILTERED_INVALID_LABELS=()
-
-  if [[ "$DRY_RUN" == "true" ]]; then
-    FILTERED_VALID_LABELS=("${requested_labels[@]}")
-    return 0
-  fi
 
   for label in "${requested_labels[@]}"; do
     if [[ -n "${REPO_LABELS[$label]:-}" ]]; then
@@ -254,14 +273,12 @@ filter_valid_labels() {
 
 preflight_import
 
-if [[ "$DRY_RUN" != "true" ]]; then
-  if ! load_repo_labels; then
-    print_error "✗ Unable to load repository labels"
-    exit 1
-  fi
+if ! load_repo_labels; then
+  print_error "✗ Unable to load repository labels"
+  exit 1
 fi
 
-if [[ "$DRY_RUN" != "true" && "$ASSIGN_TO_SELF" == "true" ]]; then
+if [[ "$ASSIGN_TO_SELF" == "true" ]]; then
   if ! lookup_authenticated_user; then
     print_error "✗ Unable to determine authenticated GitHub user"
     exit 1
@@ -792,6 +809,7 @@ for file in "${files[@]}"; do
   FILE_LABELS["$file"]="$PARSED_LABELS"
 
   parse_label_list "$PARSED_LABELS"
+  add_inferred_type_label "$PARSED_TITLE"
   filter_valid_labels "${PARSED_LABEL_LIST[@]}"
 
   if [[ ${#FILTERED_VALID_LABELS[@]} -gt 0 ]]; then

--- a/.github/scripts/issue-import-common.sh
+++ b/.github/scripts/issue-import-common.sh
@@ -106,12 +106,12 @@ preflight_import() {
 
   print_success "✓ GitHub CLI found"
 
-  if [[ "${DRY_RUN:-false}" == "true" ]]; then
-    print_info "• Skipping GitHub authentication check in dry-run mode"
-  elif ! gh auth status >/dev/null 2>&1; then
+  if ! gh auth status >/dev/null 2>&1; then
     print_error "✗ GitHub CLI is not authenticated"
     print_info "  Run: gh auth login"
     exit 1
+  elif [[ "${DRY_RUN:-false}" == "true" ]]; then
+    print_success "✓ GitHub CLI authenticated (read-only validation enabled for dry-run)"
   else
     print_success "✓ GitHub CLI authenticated"
   fi


### PR DESCRIPTION
## Summary

Improves the issue importer dry-run so it validates safe read-only GitHub dependencies more like a real import while remaining non-mutating.

It also refines importer progress output so warning totals and post-create follow-up steps are easier to understand during real imports.

## Scope

- require GitHub authentication during dry-run
- load repository labels during dry-run instead of skipping label validation
- validate label metadata during dry-run using the repository's actual labels
- infer `task` or `epic` labels from issue titles when those labels are not explicitly provided
- add warning totals to the import summary for unknown labels and unresolved dependencies
- log issue creation immediately after `gh issue create` succeeds before follow-up REST ID lookup
- collapse noisy REST ID lookup retry output into a single recovery or failure outcome
- make post-create lookup failures explicit in terminal output and failed-file metadata
- print a visible `Updated dependencies` success line after dependency body rewrites
- document the stronger dry-run behavior in the issue import README

## Notes

Dry-run now performs read-only GitHub validation instead of purely local simulation. It still does not create, edit, or link GitHub issues.

This closes the gap where dry-run could appear healthy even though a real import would fail on label lookup or similar read-only GitHub prerequisites.

The importer output changes are focused on readability during batch imports. They keep the existing workflow intact while making partial failures and follow-up recovery easier to understand.

## Testing

- ran `bash -n .github/scripts/import-issues.sh .github/scripts/requeue-failed-imports.sh .github/scripts/issue-import-common.sh`
- ran `./.github/scripts/import-issues.sh --dry-run --verbose`
- verified dry-run performs authenticated read-only validation
- verified a temporary sample task without explicit `Labels:` receives the inferred `task` label during dry-run output
- verified warning totals are included in the summary output
- verified create-follow-up logging now reports creation, REST ID lookup recovery, and dependency update steps more clearly

Closes #188
