### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Run verification suite
+        run: ./gradlew --no-daemon verifyAll

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,11 @@ ext {
     javaToolchainVersion = 25
 }
 
+tasks.register('verifyAll') {
+    group = 'verification'
+    description = 'Runs all project verification tasks, including integration tests where defined.'
+}
+
 allprojects {
     group = 'com.kartoush'
     version = '0.0.1-SNAPSHOT'
@@ -36,5 +41,19 @@ subprojects {
 
     tasks.withType(Test).configureEach {
         useJUnitPlatform()
+    }
+}
+
+subprojects {
+    def rootVerifyAll = rootProject.tasks.named('verifyAll')
+
+    rootVerifyAll.configure {
+        dependsOn(tasks.named('test'))
+    }
+
+    tasks.matching { it.name == 'integrationTest' }.configureEach { integrationTestTask ->
+        rootVerifyAll.configure {
+            dependsOn(integrationTestTask)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the baseline GitHub Actions CI workflow for Kartoush and introduces a root `verifyAll` task so the workflow can execute project-wide verification from the repository root.

## Scope

- add a CI workflow under `.github/workflows`
- configure Java 25 using `actions/setup-java`
- enable Gradle dependency caching
- run `./gradlew --no-daemon verifyAll`
- add a root `verifyAll` task that aggregates subproject `test` and `integrationTest` tasks where defined

## Notes

The repository already expected `./gradlew verifyAll` in documentation, but this branch did not yet expose that task at the root project level. The build change keeps the workflow command aligned with the documented verification entrypoint.

## Testing

- ran `./gradlew tasks --all | grep -n "verifyAll"`
- ran `./gradlew --no-daemon verifyAll`
- verified the build completed successfully, including `:customer:integrationTest`

Closes #199
