### PR TITLE
Integrate API tests into CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,28 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit test suite
+        run: ./gradlew --no-daemon test
+
+  integration-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -28,5 +49,22 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
-      - name: Run verification suite
-        run: ./gradlew --no-daemon verifyAll
+      - name: Run integration test suite
+        run: ./gradlew --no-daemon :app:integrationTest :customer:integrationTest
+
+  verify:
+    runs-on: ubuntu-latest
+    needs:
+      - unit-tests
+      - integration-tests
+    if: ${{ always() }}
+
+    steps:
+      - name: Validate upstream job results
+        run: |
+          if [ "${{ needs.unit-tests.result }}" != "success" ] || [ "${{ needs.integration-tests.result }}" != "success" ]; then
+            echo "One or more verification jobs failed."
+            echo "unit-tests=${{ needs.unit-tests.result }}"
+            echo "integration-tests=${{ needs.integration-tests.result }}"
+            exit 1
+          fi

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ tasks.register("integrationTest", Test) {
     description = "Runs integration tests (Docker/Testcontainers)."
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
+    environment "TESTCONTAINERS_RYUK_DISABLED", "true"
     useJUnitPlatform {
         includeTags "integration"
     }


### PR DESCRIPTION
## Summary

Integrates API integration tests into the CI pipeline and parallelizes CI execution so unit tests and integration tests run independently while preserving a single required `verify` gate for branch protection.

## Scope

- run unit tests and integration tests in separate GitHub Actions jobs
- keep a `verify` aggregation job so branch protection can continue to require one stable check
- run API integration tests through `:app:integrationTest`
- run customer integration tests through `:customer:integrationTest`
- align the app integration-test task with CI Testcontainers expectations

## Notes

The workflow from `#199` already executed `verifyAll`, so the remaining gap for this task was making the API integration-test path explicit and CI-friendly.

This PR widens the task slightly by parallelizing CI execution instead of keeping all verification work in a single serial job. That improves signal and reduces total CI wall-clock time without changing the branch protection contract, because the aggregate `verify` job is still present.

## Testing

- ran `./gradlew --no-daemon test`
- ran `./gradlew --no-daemon :app:integrationTest :customer:integrationTest`
- verified both commands completed successfully

Closes #201
