### PR TITLE
Add REST Assured integration test support

### DIFF
--- a/app/src/test/java/com/kartoush/api/customer/CustomerRestAssuredIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerRestAssuredIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.kartoush.api.customer;
+
+import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.platform.types.CustomerStatus;
+import com.kartoush.platform.ulid.UlidGenerator;
+import com.kartoush.testsupport.HttpSpringIntegrationTest;
+import com.kartoush.testsupport.PostgresRestAssuredIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+@HttpSpringIntegrationTest
+class CustomerRestAssuredIntegrationTest extends PostgresRestAssuredIntegrationTest {
+
+    private static final String BASE_URL = "/api/customers";
+    private static final String FIRST_NAME = "Jack";
+    private static final String LAST_NAME = "Kartoush";
+    private static final String PHONE_NUMBER = "+13125550100";
+    private static final String EMAIL_LOCAL_PART_PREFIX = "jack+";
+    private static final String EMAIL_DOMAIN = "@kartoush.com";
+
+    @Autowired
+    private UlidGenerator ulidGenerator;
+
+    @Test
+    void shouldCreateCustomerThroughHttp() {
+        // given
+        final String email = EMAIL_LOCAL_PART_PREFIX + ulidGenerator.next().toLowerCase() + EMAIL_DOMAIN;
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            email,
+            PHONE_NUMBER);
+
+        // when + then
+        given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+        .when()
+            .post(BASE_URL)
+        .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .header("Location", startsWith(BASE_URL + "/"))
+            .body("customerId", not(blankOrNullString()))
+            .body("firstName", equalTo(FIRST_NAME))
+            .body("lastName", equalTo(LAST_NAME))
+            .body("email", equalTo(email))
+            .body("phoneNumber", equalTo(PHONE_NUMBER))
+            .body("status", equalTo(CustomerStatus.PENDING.name()));
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ springDependencyManagementVersion = "1.1.7"
 mapstructVersion = "1.6.3"
 junitJupiterVersion = "5.13.4"
 jspecifyVersion = "1.0.0"
+restAssuredVersion = "5.5.6"
 
 [plugins]
 springBoot = { id = "org.springframework.boot", version.ref = "springBootVersion" }
@@ -24,6 +25,7 @@ springBootStarterFlyway = { module = "org.springframework.boot:spring-boot-start
 springBootTest = { module = "org.springframework.boot:spring-boot-test", version.ref = "springBootVersion" }
 springBootTestAutoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure", version.ref = "springBootVersion" }
 springBootTestcontainers = { module = "org.springframework.boot:spring-boot-testcontainers", version.ref = "springBootVersion" }
+restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssuredVersion" }
 
 flywayPostgresql = { module = "org.flywaydb:flyway-database-postgresql" }
 postgresql = { module = "org.postgresql:postgresql" }

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api(libs.testcontainers)
     api(libs.testcontainersJunitJupiter)
     api(libs.testcontainersPostgresql)
+    api(libs.restAssured)
 
     api(libs.springBootTest)
     api(libs.springBootTestAutoconfigure)

--- a/test-support/src/main/java/com/kartoush/testsupport/HttpSpringIntegrationTest.java
+++ b/test-support/src/main/java/com/kartoush/testsupport/HttpSpringIntegrationTest.java
@@ -1,0 +1,20 @@
+package com.kartoush.testsupport;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@IntegrationTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public @interface HttpSpringIntegrationTest {}

--- a/test-support/src/main/java/com/kartoush/testsupport/PostgresRestAssuredIntegrationTest.java
+++ b/test-support/src/main/java/com/kartoush/testsupport/PostgresRestAssuredIntegrationTest.java
@@ -1,0 +1,24 @@
+package com.kartoush.testsupport;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+public abstract class PostgresRestAssuredIntegrationTest extends PostgresSpringIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    void resetRestAssured() {
+        RestAssured.reset();
+    }
+}


### PR DESCRIPTION
## Summary

Adds REST Assured to the test suite, introduces reusable Spring Boot HTTP integration-test support, and adds an example API integration test that exercises the application over a real HTTP port.

## Scope

- add the REST Assured dependency to the shared test setup
- introduce reusable random-port Spring Boot integration-test support in `test-support`
- integrate REST Assured with the existing Postgres/Testcontainers test base
- add an example customer API integration test that performs a real HTTP request
- keep the new setup compatible with the existing `verifyAll` flow

## Notes

This PR intentionally keeps the slice narrow. It adds the REST Assured foundation and one real example test without migrating the broader API integration suite away from MockMvc yet.

That larger migration belongs to the follow-on API test tasks.

## Testing

- ran `./gradlew --no-daemon :app:integrationTest --tests com.kartoush.api.customer.CustomerRestAssuredIntegrationTest`
- ran `./gradlew --no-daemon verifyAll`
- verified both commands completed successfully

Closes #195
