### PR TITLE
[Task]: Add Bruno API collection to repository

### DIFF
--- a/bruno/README.md
+++ b/bruno/README.md
@@ -1,0 +1,51 @@
+# Bruno Collection
+
+This directory contains a Bruno collection for manually exploring the
+Kartoush HTTP API during local development.
+
+## Prerequisites
+
+- Bruno installed locally
+- Kartoush running on `http://localhost:8080`
+
+## Collection Layout
+
+- `bruno.json`
+  Bruno collection metadata
+- `collection.bru`
+  Collection-level configuration
+- `environments/local.bru`
+  Local environment variables for the running application
+- `customers/`
+  Customer API requests, including both happy-path and failure scenarios
+
+## How To Use
+
+1. Open the `bruno/` directory as a Bruno collection.
+2. Select the `local` environment.
+3. Run `customers/02-create-customer.bru` first to create a customer and
+   capture `customerId` into the environment.
+4. Use the remaining customer requests to inspect success and error
+   behavior.
+
+The create request also refreshes the `email` environment variable with a
+timestamp-based value so repeated runs stay usable without manual cleanup.
+
+## Activation Flow Caveat
+
+The activation endpoints are included in this collection, but the full
+manual happy path still depends on a development-only fallback.
+
+Kartoush does not expose the raw activation token through the API. For
+local development, the current `NoOpActivationEmailService` logs the raw
+token so it can be copied into the Bruno environment. That means:
+
+- `customers/06-resend-activation-token.bru` is usable for pending customers
+- `customers/07-activate-customer.bru` requires a valid token to be copied
+  from the local application logs into the environment
+- the invalid-token and blank-token activation requests are the current
+  out-of-the-box error-path requests for activation
+
+Once a real email delivery implementation exists, this collection can be
+updated to use the delivered token instead of relying on the no-op log
+output.

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "kartoush-api",
+  "type": "collection",
+  "ignore": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/bruno/collection.bru
+++ b/bruno/collection.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Kartoush API
+  type: collection
+}
+
+auth {
+  mode: none
+}

--- a/bruno/customers/01-list-customers.bru
+++ b/bruno/customers/01-list-customers.bru
@@ -1,0 +1,17 @@
+meta {
+  name: List customers
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/api/customers
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/customers/02-create-customer.bru
+++ b/bruno/customers/02-create-customer.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Create customer
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{host}}/api/customers
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "firstName": "{{firstName}}",
+    "lastName": "{{lastName}}",
+    "email": "{{email}}",
+    "phoneNumber": "{{phoneNumber}}"
+  }
+}
+
+script:pre-request {
+  const uniqueEmail = `jack+bruno-${Date.now()}@kartoush.dev`;
+  bru.setEnvVar("email", uniqueEmail);
+}
+
+script:post-response {
+  if (res.status === 201 && res.body && res.body.customerId) {
+    bru.setEnvVar("customerId", res.body.customerId);
+  }
+}
+
+tests {
+  test("should return 201", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/bruno/customers/03-get-customer-by-id.bru
+++ b/bruno/customers/03-get-customer-by-id.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get customer by id
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{host}}/api/customers/{{customerId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/customers/04-update-customer.bru
+++ b/bruno/customers/04-update-customer.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Update customer
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{host}}/api/customers/{{customerId}}
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "firstName": "{{updatedFirstName}}",
+    "lastName": "{{updatedLastName}}",
+    "phoneNumber": "{{updatedPhoneNumber}}"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/customers/05-get-missing-customer.bru
+++ b/bruno/customers/05-get-missing-customer.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get missing customer
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{host}}/api/customers/{{missingCustomerId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/bruno/customers/06-resend-activation-token.bru
+++ b/bruno/customers/06-resend-activation-token.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Resend activation token
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}/api/customers/{{customerId}}/activation/resend
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/customers/07-activate-customer.bru
+++ b/bruno/customers/07-activate-customer.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Activate customer
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{host}}/api/customers/{{customerId}}/activation
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "token": "{{activationToken}}"
+  }
+}
+
+tests {
+  test("should return 200 when a valid activation token is supplied", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/customers/08-activate-customer-invalid-token.bru
+++ b/bruno/customers/08-activate-customer-invalid-token.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Activate customer with invalid token
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host}}/api/customers/{{customerId}}/activation
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "token": "{{invalidActivationToken}}"
+  }
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/bruno/customers/09-activate-customer-blank-token.bru
+++ b/bruno/customers/09-activate-customer-blank-token.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Activate customer with blank token
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{host}}/api/customers/{{customerId}}/activation
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "token": "   "
+  }
+}
+
+tests {
+  test("should return 400", function() {
+    expect(res.status).to.equal(400);
+  });
+}

--- a/bruno/customers/10-create-customer-invalid-email.bru
+++ b/bruno/customers/10-create-customer-invalid-email.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Create customer with invalid email
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{host}}/api/customers
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "firstName": "{{firstName}}",
+    "lastName": "{{lastName}}",
+    "email": "{{invalidEmail}}",
+    "phoneNumber": "{{phoneNumber}}"
+  }
+}
+
+tests {
+  test("should return 400", function() {
+    expect(res.status).to.equal(400);
+  });
+}

--- a/bruno/customers/11-create-customer-duplicate-pending.bru
+++ b/bruno/customers/11-create-customer-duplicate-pending.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Create duplicate pending customer
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{host}}/api/customers
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "firstName": "{{firstName}}",
+    "lastName": "{{lastName}}",
+    "email": "{{email}}",
+    "phoneNumber": "{{phoneNumber}}"
+  }
+}
+
+tests {
+  test("should return 409", function() {
+    expect(res.status).to.equal(409);
+  });
+}

--- a/bruno/customers/12-delete-customer.bru
+++ b/bruno/customers/12-delete-customer.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete customer
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{host}}/api/customers/{{customerId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,0 +1,15 @@
+vars {
+  host: http://localhost:8080
+  customerId: 01KPHNWQVXB3GJ6YRWVFBVZJCZ
+  missingCustomerId: 01MISSINGCUSTOMER0000000000000
+  firstName: Jack
+  lastName: Kartoush
+  updatedFirstName: Jackson
+  updatedLastName: Kartoush
+  email: replace-during-create
+  invalidEmail: not-an-email
+  phoneNumber: +13125550100
+  updatedPhoneNumber: +13125550101
+  activationToken: N7o09al5ldRf1hPTDHMYfwAOhAKvlDntLnQYLhyW5MI
+  invalidActivationToken: invalid-activation-token
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/NoOpActivationEmailService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/NoOpActivationEmailService.java
@@ -14,7 +14,9 @@ public class NoOpActivationEmailService implements ActivationEmailService {
     @Override
     public void sendActivationToken(final Email email, final String rawToken) {
         LOG.warn(
-            "Activation email delivery requested for email={} but no concrete email delivery provider is configured",
-            email.value());
+            "Activation email delivery requested for email={} but no concrete email delivery provider is configured. " +
+                "Development activation token={}",
+            email.value(),
+            rawToken);
     }
 }


### PR DESCRIPTION
## Summary

Adds a committed Bruno collection for local customer API exploration, including request organization, a reusable local environment, and manual activation testing support through the no-op email delivery fallback.

## Scope

- add a `bruno/` collection to the repository
- add a local Bruno environment for Kartoush development
- add customer API requests for create, read, update, activation, resend, and delete flows
- add Bruno requests for common error scenarios such as invalid email, missing customer, duplicate pending customer, and invalid activation token
- document how to use the collection for local development
- update `NoOpActivationEmailService` to log the raw activation token for local manual testing

## Notes

The Bruno collection is organized by domain and is intended for manual API exploration and debugging alongside the automated test suite.

Kartoush does not currently expose raw activation tokens through the API. To keep the manual activation flow usable in local development, the no-op activation email implementation now logs the raw token so it can be copied into the Bruno environment.

## Testing

- manual review of the Bruno collection layout and request definitions
- local application startup verification after resetting the local Flyway database state

Closes #197
