### PR TITLE
[Task]: Document activation workflow and architecture decisions

### DIFF
--- a/docs/architecture/decisions/0024-customer-activation-token-ownership-and-lifecycle.md
+++ b/docs/architecture/decisions/0024-customer-activation-token-ownership-and-lifecycle.md
@@ -1,0 +1,112 @@
+# ADR 0024: Customer activation token ownership and lifecycle
+
+Date: 2026-04-18
+
+## Status
+
+Accepted
+
+## Context
+
+Kartoush now supports customer activation and activation token resend flows.
+That introduces several architectural questions:
+
+- which module should own activation tokens and activation rules
+- how resend should affect previously issued tokens
+- whether activation belongs in customer lifecycle management or in a future
+  authentication module
+- how much token behavior should be exposed through the public API
+
+These decisions affect lifecycle consistency, module boundaries, and how the
+system evolves once authentication capabilities become more sophisticated.
+
+## Decision
+
+Activation tokens remain owned by the customer module and are treated as part
+of the customer lifecycle rather than as part of authentication.
+
+The following rules apply:
+
+1. customer activation is modeled as the transition from `PENDING` to `ACTIVE`
+2. activation tokens are owned by the customer module because they exist only
+   to govern that lifecycle transition
+3. activation token validation requires the token to belong to the target
+   customer, be unexpired, and be unconsumed
+4. successful activation consumes the token and activates the customer in the
+   same service flow
+5. resend is allowed only while the customer is still `PENDING`
+6. resend invalidates prior outstanding activation tokens by consuming them
+   before issuing a new token
+7. the public API does not expose token hashes or token management operations
+
+## Why this remains in the customer module
+
+Activation is not currently an authentication concern in Kartoush.
+
+The purpose of the activation token is to determine whether a newly created
+customer has completed the transition into an active lifecycle state. That is
+closer to customer onboarding and customer status management than to login,
+session management, credential verification, or authorization.
+
+Moving this behavior into a future authentication module too early would blur
+the current module boundary and force the authentication module to own
+customer lifecycle transitions that it does not yet need to control.
+
+## Resend and invalidation strategy
+
+Kartoush uses a supersession strategy for resend flows.
+
+When resend is requested for a pending customer:
+
+- any currently active activation token for that customer is consumed
+- a new activation token is issued
+- only the newest token remains valid for activation
+
+This strategy was chosen because it is simpler and safer than keeping multiple
+concurrently valid activation tokens.
+
+## Consequences
+
+### Positive
+
+This decision:
+
+- keeps activation behavior aligned with customer lifecycle ownership
+- avoids premature coupling to a future authentication module
+- ensures resend behavior is deterministic and easy to reason about
+- reduces the risk of multiple valid activation tokens existing at once
+
+### Negative
+
+This decision:
+
+- keeps token delivery concerns temporarily adjacent to customer lifecycle work
+- may require a future ADR if authentication responsibilities expand enough to
+  justify moving parts of the flow
+- does not yet provide a production-grade delivery mechanism beyond the
+  configured email service abstraction
+
+## Alternatives considered
+
+### Move activation immediately into a dedicated authentication module
+
+This was rejected because the current activation flow is about onboarding a
+customer into the `ACTIVE` lifecycle state, not about authenticating an
+existing customer.
+
+### Keep multiple resend tokens valid until one is used
+
+This was rejected because it increases state complexity and makes it harder to
+reason about which token should be considered authoritative.
+
+### Expose raw activation token behavior directly through the public API
+
+This was rejected because tokens are externally usable secrets and should not
+become part of the public customer contract except where explicitly required.
+
+## Related Decisions
+
+- ADR 0003: Data Ownership
+- ADR 0011: Layering and Facade Contracts
+- ADR 0018: Module Boundaries and Dependencies
+- ADR 0019: Internal vs External APIs

--- a/docs/customer/customer-lifecycle-and-api-behavior.md
+++ b/docs/customer/customer-lifecycle-and-api-behavior.md
@@ -139,6 +139,10 @@ Returns a single customer. Returns 404 if the customer does not exist.
 
 Creates a new customer and returns 201 Created with the created customer.
 
+New customers are created in `PENDING` status. Customer creation also issues an
+activation token and requests delivery through the configured activation email
+service.
+
 Validation rules:
 
 - First name and last name are required
@@ -149,6 +153,31 @@ Error scenarios:
 
 - 400 Bad Request for validation failures
 - 409 Conflict if the customer already exists or is in a conflicting state
+
+---
+
+#### Activate customer
+
+`POST /api/customers/{customerId}/activation`
+
+Activates a pending customer using a valid activation token and returns the
+updated customer.
+
+Activation behavior:
+
+- the customer must exist
+- the customer must currently be in `PENDING` status
+- the activation token must belong to the target customer
+- the activation token must exist, be unexpired, and not already be consumed
+- a successful activation moves the customer to `ACTIVE`
+- a successful activation consumes the activation token so it cannot be reused
+
+Error scenarios:
+
+- 400 Bad Request for request validation failures, such as a blank token
+- 404 Not Found if the customer or activation token does not exist
+- 409 Conflict if the token is expired, already consumed, or the customer
+  cannot be activated from the current lifecycle state
 
 ---
 
@@ -164,6 +193,28 @@ Error scenarios:
 
 - 400 Bad Request for validation failures
 - 404 Not Found if the customer does not exist
+
+---
+
+#### Resend activation token
+
+`POST /api/customers/{customerId}/activation/resend`
+
+Issues a new activation token for a pending customer and returns 204 No
+Content.
+
+Resend behavior:
+
+- resend is allowed only for customers in `PENDING` status
+- issuing a new activation token consumes any existing active token for that
+  customer before creating the replacement
+- the new token becomes the only valid activation token for that customer
+- token delivery is delegated to the configured activation email service
+
+Error scenarios:
+
+- 404 Not Found if the customer does not exist
+- 409 Conflict if the customer is not in a state that allows resend
 
 ---
 
@@ -207,13 +258,13 @@ Validation errors are standardized across both custom validation logic and frame
 
 ---
 
-## Deferred / Not Yet Exposed
+## Not Yet Exposed
 
 The following capabilities are not currently exposed via the API:
 
-- Activation endpoint
 - Reactivation endpoint
-- Token-based activation or verification flows
+- Administrative or support-oriented activation recovery flows
+- Public token introspection or token management APIs
 
 These will be introduced in a future iteration.
 


### PR DESCRIPTION
## Summary

Updates the customer lifecycle documentation to reflect the live activation API behavior and adds an ADR that captures activation token ownership, resend invalidation, and module boundary rationale.

## Scope

- update customer lifecycle documentation to include activation and resend endpoint behavior
- remove outdated statements that activation and token-based flows are not exposed
- document activation token supersession behavior for resend flows
- add an ADR covering activation token ownership and lifecycle rules
- document why activation remains in the customer module instead of moving into authentication prematurely

## Notes

The customer lifecycle document had drifted behind the implementation and still described activation flows as deferred even though the API endpoints and service behavior already exist.

The new ADR makes the architectural rationale explicit: activation tokens are owned by the customer module because they govern the `PENDING -> ACTIVE` lifecycle transition, and resend uses token supersession so only the newest token remains valid.

## Testing

- manual review of `docs/customer/customer-lifecycle-and-api-behavior.md`
- manual review of `docs/architecture/decisions/0024-customer-activation-token-ownership-and-lifecycle.md`

Closes #148
Closes #139
