### PR TITLE
[Task]: Define registration requirements and request validation

### DIFF
--- a/app/src/test/java/com/kartoush/api/customer/CustomerCreationRestAssuredIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerCreationRestAssuredIntegrationTest.java
@@ -2,12 +2,15 @@ package com.kartoush.api.customer;
 
 import com.kartoush.api.error.ErrorCode;
 import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.platform.types.CustomerStatus;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -19,6 +22,9 @@ import static org.hamcrest.Matchers.startsWith;
 class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAssuredIntegrationTest {
 
     private static final String INVALID_EMAIL = "not-an-email";
+
+    @Autowired
+    private CustomerRepository customerRepository;
 
     @Test
     void shouldCreateCustomerThroughHttp() {
@@ -50,6 +56,7 @@ class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAss
     @Test
     void shouldReturnValidationProblemForInvalidEmail() {
         // given
+        final long customerCountBeforeRequest = customerRepository.count();
         final CreateCustomerRequest request = new CreateCustomerRequest(
             FIRST_NAME,
             LAST_NAME,
@@ -74,5 +81,39 @@ class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAss
             .body("errors[0].field", equalTo("email"))
             .body("errors[0].message", not(blankOrNullString()))
             .body("errors[0].rejectedValue", nullValue());
+
+        assertThat(customerRepository.count()).isEqualTo(customerCountBeforeRequest);
+    }
+
+    @Test
+    void shouldReturnValidationProblemForInvalidPhoneNumber() {
+        // given
+        final long customerCountBeforeRequest = customerRepository.count();
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            uniqueEmail(),
+            "abc123");
+
+        // when + then
+        given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+        .when()
+            .post(BASE_URL)
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("title", equalTo("Request Validation Failed"))
+            .body("detail", equalTo("Request validation failed"))
+            .body("errorCode", equalTo(ErrorCode.VALIDATION_FAILED.name()))
+            .body("type", equalTo(ErrorCode.VALIDATION_FAILED.urn()))
+            .body("instance", equalTo(BASE_URL))
+            .body("timestamp", notNullValue())
+            .body("errors", hasSize(1))
+            .body("errors[0].field", equalTo("phoneNumber"))
+            .body("errors[0].message", not(blankOrNullString()))
+            .body("errors[0].rejectedValue", nullValue());
+
+        assertThat(customerRepository.count()).isEqualTo(customerCountBeforeRequest);
     }
 }

--- a/customer/src/main/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidator.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidator.java
@@ -33,7 +33,7 @@ public class CreateCustomerRequestValidator {
         RequestValidationSupport.validateRequiredEmail("email", request.email(), errors);
         RequestValidationSupport.validateRequiredText("firstName", request.firstName(), 100, errors);
         RequestValidationSupport.validateRequiredText("lastName", request.lastName(), 100, errors);
-        RequestValidationSupport.validateOptionalPhoneNumber("phoneNUmber", request.phoneNumber(), errors);
+        RequestValidationSupport.validateOptionalPhoneNumber("phoneNumber", request.phoneNumber(), errors);
 
         throwIfErrors(errors);
     }

--- a/customer/src/test/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidatorTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidatorTest.java
@@ -1,93 +1,158 @@
 package com.kartoush.customer.internal.validation;
 
-
 import com.kartoush.customer.facade.model.CreateCustomerRequest;
 import com.kartoush.platform.validation.RequestValidationException;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CreateCustomerRequestValidatorTest {
 
-    private static final String EMAIL = "jack@kartoush.com";
-    private static final String INVALID_EMAIL = "@";
-    private static final String PHONE_NUMBER = "312-555-0100";
-    private static final String INVALID_PHONE_NUMBER = "abc-123";
     private static final String FIRST_NAME = "Jack";
     private static final String LAST_NAME = "Kartoush";
+    private static final String VALID_EMAIL = "jack@kartoush.com";
+    private static final String INVALID_EMAIL = "@";
+    private static final String VALID_PHONE = "+16305551234";
+    private static final String INVALID_PHONE = "abc123";
 
     private final CreateCustomerRequestValidator validator = new CreateCustomerRequestValidator();
 
     @Test
-    @DisplayName("Should reject null request")
-    void shouldRejectNullRequest() {
-        // then
-        assertThatThrownBy(() -> validator.validate(null))
-                .isInstanceOf(RequestValidationException.class);
+    void shouldAllowValidRequest() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE);
+
+        assertThatCode(() -> validator.validate(request)).doesNotThrowAnyException();
     }
 
     @Test
-    void shouldAllowBlankPhoneNumber() {
-        // given
-        final var request = new CreateCustomerRequest(
-                FIRST_NAME,
-                LAST_NAME,
-                EMAIL,
+    void shouldAllowValidRequestWithNullPhoneNumber() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            null);
+
+        assertThatCode(() -> validator.validate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAllowValidRequestWithBlankPhoneNumber() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
             " ");
 
-        // then
-        assertThatNoException()
-            .isThrownBy(() -> validator.validate(request));
+        assertThatCode(() -> validator.validate(request)).doesNotThrowAnyException();
     }
 
     @Test
-    @DisplayName("Should reject an invalid phone number")
-    void shouldRejectInvalidPhoneNumberWhenPresent() {
-
-        // given
-        final var request = new CreateCustomerRequest(
-                EMAIL,
-                INVALID_PHONE_NUMBER,
-                FIRST_NAME,
-                LAST_NAME);
-
-        // then
-        assertThatThrownBy(() ->
-                validator.validate(request))
-                .isInstanceOf(RequestValidationException.class);
+    void shouldThrowWhenRequestIsNull() {
+        assertThatThrownBy(() -> validator.validate(null))
+            .isInstanceOf(RequestValidationException.class)
+            .hasMessage("Request validation failed");
     }
 
     @Test
-    @DisplayName("Should reject invalid email")
-    void shouldRejectInvalidEmailWhenPresent() {
+    void shouldThrowWhenFirstNameIsNull() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            null,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE);
 
-        // given
-        final var request = new CreateCustomerRequest(
-                INVALID_EMAIL,
-                PHONE_NUMBER,
-                FIRST_NAME,
-                LAST_NAME);
-
-        // then
-        assertThatThrownBy(() ->
-                validator.validate(request))
-                .isInstanceOf(RequestValidationException.class);
+        assertValidationError(request, "firstName");
     }
 
     @Test
-    @DisplayName("Should reject missing first and last name")
-    void shouldRejectMissingFirstAndLastName() {
-        // given
-        final var request = new CreateCustomerRequest(
-                EMAIL,
-                PHONE_NUMBER,
-                "",
-                "");
+    void shouldThrowWhenFirstNameIsBlank() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            " ",
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE);
 
-        // then
+        assertValidationError(request, "firstName");
+    }
+
+    @Test
+    void shouldThrowWhenLastNameIsNull() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            null,
+            VALID_EMAIL,
+            VALID_PHONE);
+
+        assertValidationError(request, "lastName");
+    }
+
+    @Test
+    void shouldThrowWhenLastNameIsBlank() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            " ",
+            VALID_EMAIL,
+            VALID_PHONE);
+
+        assertValidationError(request, "lastName");
+    }
+
+    @Test
+    void shouldThrowWhenEmailIsNull() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            null,
+            VALID_PHONE);
+
+        assertValidationError(request, "email");
+    }
+
+    @Test
+    void shouldThrowWhenEmailIsBlank() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            " ",
+            VALID_PHONE);
+
+        assertValidationError(request, "email");
+    }
+
+    @Test
+    void shouldThrowWhenEmailIsInvalid() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            INVALID_EMAIL,
+            VALID_PHONE);
+
+        assertValidationError(request, "email");
+    }
+
+    @Test
+    void shouldThrowWhenPhoneNumberIsInvalid() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            INVALID_PHONE);
+
+        assertValidationError(request, "phoneNumber");
+    }
+
+    private void assertValidationError(final CreateCustomerRequest request, final String field) {
         assertThatThrownBy(() -> validator.validate(request))
-                .isInstanceOf(RequestValidationException.class);
+            .isInstanceOfSatisfying(RequestValidationException.class, exception -> {
+                assertThat(exception.getErrors())
+                    .extracting(error -> error.field())
+                    .contains(field);
+            });
     }
 }

--- a/docs/customer/customer-lifecycle-and-api-behavior.md
+++ b/docs/customer/customer-lifecycle-and-api-behavior.md
@@ -117,6 +117,36 @@ The customer status is set to DELETED, and the record remains in persistence. Th
 
 ### Endpoints
 
+### Registration requirements
+
+Kartoush currently treats `POST /api/customers` as the registration entry
+point for new customers.
+
+A registration request is valid only when all of the following requirements are
+satisfied:
+
+- first name is present and not blank
+- last name is present and not blank
+- email is present and valid
+- phone number is optional, but if provided it must be valid
+
+Successful registration always creates a customer in `PENDING` status. The
+public API does not allow callers to choose an alternative initial lifecycle
+state.
+
+If registration validation fails:
+
+- the request is rejected with a ProblemDetails response
+- no customer record is created
+- no activation token is issued
+
+These requirements define the current registration contract and are separate
+from future onboarding requirements such as Terms of Service acceptance.
+Terms of Service acceptance is planned as a future registration requirement
+but is not yet enforced by the current API.
+
+---
+
 #### Get all customers
 
 `GET /api/customers`


### PR DESCRIPTION
## Summary

Defines the current non-TOS registration requirements for `POST /api/customers`, fixes the request validation behavior around customer creation, and strengthens automated coverage for invalid registration scenarios.

## Scope

- document the current registration requirements for customer creation
- fix create-customer validation field reporting for invalid phone numbers
- rewrite create-customer validator tests to match the real request contract
- strengthen API integration coverage for representative invalid registration scenarios
- verify invalid registration attempts do not create customer records
- clarify that Terms of Service acceptance is planned but not yet part of the enforced registration contract

## Notes

This task is intentionally limited to the current registration contract and request validation behavior. It does not implement Terms of Service acceptance or Terms persistence.

For the current API, registration is handled through `POST /api/customers`. Successful registration requires valid customer identity/contact input and always initializes the customer in `PENDING` status.

## Testing

- `./gradlew --no-daemon :customer:test --tests com.kartoush.customer.internal.validation.CreateCustomerRequestValidatorTest :app:integrationTest --tests com.kartoush.api.customer.CustomerCreationRestAssuredIntegrationTest`

Closes #153
