### PR TITLE
Add Terms of Service acceptance to customer registration

### DIFF
--- a/app/src/test/java/com/kartoush/api/customer/CustomerActivationIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerActivationIntegrationTest.java
@@ -54,6 +54,7 @@ class CustomerActivationIntegrationTest extends PostgresSpringIntegrationTest {
     private static final String EMAIL_LOCAL_PART_PREFIX = "jack+";
     private static final String EMAIL_DOMAIN = "@kartoush.com";
     private static final String EXPIRED_RAW_TOKEN = "expired-activation-token";
+    private static final String CURRENT_TERMS_VERSION = "2026-04";
 
     @Autowired
     private MockMvc mockMvc;
@@ -218,7 +219,9 @@ class CustomerActivationIntegrationTest extends PostgresSpringIntegrationTest {
             FIRST_NAME,
             LAST_NAME,
             email,
-            PHONE_NUMBER);
+            PHONE_NUMBER,
+            true,
+            CURRENT_TERMS_VERSION);
 
         final String responseBody = mockMvc.perform(post(BASE_URL)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/app/src/test/java/com/kartoush/api/customer/CustomerControllerWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerControllerWebMvcTest.java
@@ -45,6 +45,8 @@ class CustomerControllerWebMvcTest {
 
     private static final String PHONE = "+16305551234";
 
+    private static final String TERMS_VERSION = "2026-04";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -83,7 +85,9 @@ class CustomerControllerWebMvcTest {
             FIRST_NAME,
             LAST_NAME,
             EMAIL,
-            PHONE
+            PHONE,
+            true,
+            TERMS_VERSION
         );
 
         when(customerFacade.createCustomer(any()))

--- a/app/src/test/java/com/kartoush/api/customer/CustomerCreationRestAssuredIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerCreationRestAssuredIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.startsWith;
 class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAssuredIntegrationTest {
 
     private static final String INVALID_EMAIL = "not-an-email";
+    private static final String CURRENT_TERMS_VERSION = "2026-04";
 
     @Autowired
     private CustomerRepository customerRepository;
@@ -34,7 +35,9 @@ class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAss
             FIRST_NAME,
             LAST_NAME,
             email,
-            PHONE_NUMBER);
+            PHONE_NUMBER,
+            true,
+            CURRENT_TERMS_VERSION);
 
         // when + then
         given()
@@ -61,7 +64,9 @@ class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAss
             FIRST_NAME,
             LAST_NAME,
             INVALID_EMAIL,
-            PHONE_NUMBER);
+            PHONE_NUMBER,
+            true,
+            CURRENT_TERMS_VERSION);
 
         // when + then
         given()
@@ -93,7 +98,9 @@ class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAss
             FIRST_NAME,
             LAST_NAME,
             uniqueEmail(),
-            "abc123");
+            "abc123",
+            true,
+            CURRENT_TERMS_VERSION);
 
         // when + then
         given()
@@ -113,6 +120,70 @@ class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAss
             .body("errors[0].field", equalTo("phoneNumber"))
             .body("errors[0].message", not(blankOrNullString()))
             .body("errors[0].rejectedValue", nullValue());
+
+        assertThat(customerRepository.count()).isEqualTo(customerCountBeforeRequest);
+    }
+
+    @Test
+    void shouldReturnValidationProblemWhenTermsAreNotAccepted() {
+        // given
+        final long customerCountBeforeRequest = customerRepository.count();
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            uniqueEmail(),
+            PHONE_NUMBER,
+            false,
+            CURRENT_TERMS_VERSION);
+
+        // when + then
+        given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+        .when()
+            .post(BASE_URL)
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("title", equalTo("Request Validation Failed"))
+            .body("detail", equalTo("Request validation failed"))
+            .body("errorCode", equalTo(ErrorCode.VALIDATION_FAILED.name()))
+            .body("type", equalTo(ErrorCode.VALIDATION_FAILED.urn()))
+            .body("instance", equalTo(BASE_URL))
+            .body("timestamp", notNullValue())
+            .body("errors", hasSize(1))
+            .body("errors[0].field", equalTo("termsAccepted"));
+
+        assertThat(customerRepository.count()).isEqualTo(customerCountBeforeRequest);
+    }
+
+    @Test
+    void shouldReturnValidationProblemWhenTermsVersionIsInvalid() {
+        // given
+        final long customerCountBeforeRequest = customerRepository.count();
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            uniqueEmail(),
+            PHONE_NUMBER,
+            true,
+            "2026-03");
+
+        // when + then
+        given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+        .when()
+            .post(BASE_URL)
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("title", equalTo("Request Validation Failed"))
+            .body("detail", equalTo("Request validation failed"))
+            .body("errorCode", equalTo(ErrorCode.VALIDATION_FAILED.name()))
+            .body("type", equalTo(ErrorCode.VALIDATION_FAILED.urn()))
+            .body("instance", equalTo(BASE_URL))
+            .body("timestamp", notNullValue())
+            .body("errors", hasSize(1))
+            .body("errors[0].field", equalTo("termsVersion"));
 
         assertThat(customerRepository.count()).isEqualTo(customerCountBeforeRequest);
     }

--- a/app/src/test/java/com/kartoush/api/customer/CustomerDuplicateEmailRestAssuredIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerDuplicateEmailRestAssuredIntegrationTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.Matchers.notNullValue;
 
 class CustomerDuplicateEmailRestAssuredIntegrationTest extends AbstractCustomerRestAssuredIntegrationTest {
 
+    private static final String CURRENT_TERMS_VERSION = "2026-04";
+
     @Test
     void shouldReturnConflictProblemForDuplicateEmailWhenCustomerIsActive() {
         // given
@@ -21,7 +23,9 @@ class CustomerDuplicateEmailRestAssuredIntegrationTest extends AbstractCustomerR
             FIRST_NAME,
             LAST_NAME,
             email,
-            PHONE_NUMBER);
+            PHONE_NUMBER,
+            true,
+            CURRENT_TERMS_VERSION);
 
         final String customerId = given()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
@@ -31,6 +31,20 @@ public record CreateCustomerRequest(
         example = "+16305551234",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    String phoneNumber
+    String phoneNumber,
+
+    @Schema(
+        description = "Whether the customer explicitly accepted the current Terms of Service",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    Boolean termsAccepted,
+
+    @Schema(
+        description = "The Terms of Service version accepted during registration",
+        example = "2026-04",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String termsVersion
 ) {
 }

--- a/customer/src/main/java/com/kartoush/customer/internal/registration/TermsOfServicePolicy.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/registration/TermsOfServicePolicy.java
@@ -1,0 +1,13 @@
+package com.kartoush.customer.internal.registration;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TermsOfServicePolicy {
+
+    private static final String CURRENT_TERMS_VERSION = "2026-04";
+
+    public String currentVersion() {
+        return CURRENT_TERMS_VERSION;
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidator.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidator.java
@@ -1,6 +1,7 @@
 package com.kartoush.customer.internal.validation;
 
 import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.internal.registration.TermsOfServicePolicy;
 import com.kartoush.platform.validation.RequestValidationException;
 import com.kartoush.platform.validation.RequestValidationSupport;
 import com.kartoush.platform.validation.ValidationError;
@@ -18,6 +19,12 @@ public class CreateCustomerRequestValidator {
 
     private static final String VALIDATION_MESSAGE = "Request validation failed";
 
+    private final TermsOfServicePolicy termsOfServicePolicy;
+
+    public CreateCustomerRequestValidator(final TermsOfServicePolicy termsOfServicePolicy) {
+        this.termsOfServicePolicy = termsOfServicePolicy;
+    }
+
     public void validate(final CreateCustomerRequest request) {
         LOG.debug("Validating create customer request");
 
@@ -34,6 +41,7 @@ public class CreateCustomerRequestValidator {
         RequestValidationSupport.validateRequiredText("firstName", request.firstName(), 100, errors);
         RequestValidationSupport.validateRequiredText("lastName", request.lastName(), 100, errors);
         RequestValidationSupport.validateOptionalPhoneNumber("phoneNumber", request.phoneNumber(), errors);
+        validateTermsAcceptance(request, errors);
 
         throwIfErrors(errors);
     }
@@ -47,6 +55,21 @@ public class CreateCustomerRequestValidator {
     private void throwIfErrors(final List<ValidationError> errors) {
         if (!errors.isEmpty()) {
             throw new RequestValidationException(VALIDATION_MESSAGE, errors);
+        }
+    }
+
+    private void validateTermsAcceptance(final CreateCustomerRequest request, final List<ValidationError> errors) {
+        if (!Boolean.TRUE.equals(request.termsAccepted())) {
+            errors.add(new ValidationError("termsAccepted", "termsAccepted must be true"));
+        }
+
+        if (request.termsVersion() == null || request.termsVersion().isBlank()) {
+            errors.add(new ValidationError("termsVersion", "termsVersion must not be blank"));
+            return;
+        }
+
+        if (!termsOfServicePolicy.currentVersion().equals(request.termsVersion())) {
+            errors.add(new ValidationError("termsVersion", "termsVersion must match the current supported Terms of Service version"));
         }
     }
 }

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -36,6 +36,7 @@ class DefaultCustomerFacadeTest {
     private static final String PHONE_NUMBER = "312-555-0100";
     private static final String FIRST_NAME = "Jack";
     private static final String LAST_NAME = "Kartoush";
+    private static final String TERMS_VERSION = "2026-04";
 
     @Mock
     private UlidGenerator ulidGenerator;
@@ -114,7 +115,9 @@ class DefaultCustomerFacadeTest {
                 FIRST_NAME,
                 LAST_NAME,
                 EMAIL,
-                PHONE_NUMBER);
+                PHONE_NUMBER,
+                true,
+                TERMS_VERSION);
     }
 
     private Customer buildCustomer(){

--- a/customer/src/test/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidatorTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/validation/CreateCustomerRequestValidatorTest.java
@@ -1,6 +1,7 @@
 package com.kartoush.customer.internal.validation;
 
 import com.kartoush.customer.facade.model.CreateCustomerRequest;
+import com.kartoush.customer.internal.registration.TermsOfServicePolicy;
 import com.kartoush.platform.validation.RequestValidationException;
 import org.junit.jupiter.api.Test;
 
@@ -16,8 +17,11 @@ class CreateCustomerRequestValidatorTest {
     private static final String INVALID_EMAIL = "@";
     private static final String VALID_PHONE = "+16305551234";
     private static final String INVALID_PHONE = "abc123";
+    private static final String CURRENT_TERMS_VERSION = "2026-04";
+    private static final String INVALID_TERMS_VERSION = "2026-03";
 
-    private final CreateCustomerRequestValidator validator = new CreateCustomerRequestValidator();
+    private final CreateCustomerRequestValidator validator =
+        new CreateCustomerRequestValidator(new TermsOfServicePolicy());
 
     @Test
     void shouldAllowValidRequest() {
@@ -25,7 +29,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             VALID_EMAIL,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertThatCode(() -> validator.validate(request)).doesNotThrowAnyException();
     }
@@ -36,7 +42,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             VALID_EMAIL,
-            null);
+            null,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertThatCode(() -> validator.validate(request)).doesNotThrowAnyException();
     }
@@ -47,7 +55,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             VALID_EMAIL,
-            " ");
+            " ",
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertThatCode(() -> validator.validate(request)).doesNotThrowAnyException();
     }
@@ -65,7 +75,9 @@ class CreateCustomerRequestValidatorTest {
             null,
             LAST_NAME,
             VALID_EMAIL,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "firstName");
     }
@@ -76,7 +88,9 @@ class CreateCustomerRequestValidatorTest {
             " ",
             LAST_NAME,
             VALID_EMAIL,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "firstName");
     }
@@ -87,7 +101,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             null,
             VALID_EMAIL,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "lastName");
     }
@@ -98,7 +114,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             " ",
             VALID_EMAIL,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "lastName");
     }
@@ -109,7 +127,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             null,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "email");
     }
@@ -120,7 +140,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             " ",
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "email");
     }
@@ -131,7 +153,9 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             INVALID_EMAIL,
-            VALID_PHONE);
+            VALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "email");
     }
@@ -142,9 +166,76 @@ class CreateCustomerRequestValidatorTest {
             FIRST_NAME,
             LAST_NAME,
             VALID_EMAIL,
-            INVALID_PHONE);
+            INVALID_PHONE,
+            true,
+            CURRENT_TERMS_VERSION);
 
         assertValidationError(request, "phoneNumber");
+    }
+
+    @Test
+    void shouldThrowWhenTermsAcceptedIsMissing() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE,
+            null,
+            CURRENT_TERMS_VERSION);
+
+        assertValidationError(request, "termsAccepted");
+    }
+
+    @Test
+    void shouldThrowWhenTermsAcceptedIsFalse() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE,
+            false,
+            CURRENT_TERMS_VERSION);
+
+        assertValidationError(request, "termsAccepted");
+    }
+
+    @Test
+    void shouldThrowWhenTermsVersionIsMissing() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE,
+            true,
+            null);
+
+        assertValidationError(request, "termsVersion");
+    }
+
+    @Test
+    void shouldThrowWhenTermsVersionIsBlank() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE,
+            true,
+            " ");
+
+        assertValidationError(request, "termsVersion");
+    }
+
+    @Test
+    void shouldThrowWhenTermsVersionDoesNotMatchCurrentVersion() {
+        final CreateCustomerRequest request = new CreateCustomerRequest(
+            FIRST_NAME,
+            LAST_NAME,
+            VALID_EMAIL,
+            VALID_PHONE,
+            true,
+            INVALID_TERMS_VERSION);
+
+        assertValidationError(request, "termsVersion");
     }
 
     private void assertValidationError(final CreateCustomerRequest request, final String field) {

--- a/docs/customer/customer-lifecycle-and-api-behavior.md
+++ b/docs/customer/customer-lifecycle-and-api-behavior.md
@@ -129,6 +129,8 @@ satisfied:
 - last name is present and not blank
 - email is present and valid
 - phone number is optional, but if provided it must be valid
+- Terms of Service acceptance must be explicitly true
+- the submitted Terms version must match the current supported Terms version
 
 Successful registration always creates a customer in `PENDING` status. The
 public API does not allow callers to choose an alternative initial lifecycle
@@ -140,10 +142,8 @@ If registration validation fails:
 - no customer record is created
 - no activation token is issued
 
-These requirements define the current registration contract and are separate
-from future onboarding requirements such as Terms of Service acceptance.
-Terms of Service acceptance is planned as a future registration requirement
-but is not yet enforced by the current API.
+These requirements define the current registration contract for onboarding a
+new customer into the `PENDING` lifecycle state.
 
 ---
 


### PR DESCRIPTION
## Summary

Requires explicit Terms of Service acceptance during customer registration, enforces version matching against the current supported Terms version, and rejects invalid registration attempts before any customer record is created.

## Scope

- extend the customer registration request contract with Terms acceptance inputs
- require `termsAccepted` to be explicitly true during registration
- require `termsVersion` to match the current supported Terms version
- reject missing, false, blank, or invalid Terms acceptance input through the existing ProblemDetails flow
- update unit, MVC, and integration tests for valid and invalid Terms acceptance scenarios
- update customer lifecycle documentation to reflect the current registration contract

## Notes

This task is intentionally limited to request-contract and validation enforcement. It does not persist Terms acceptance records; that follow-up remains in `#155`.

The current supported Terms version is provided through a small backend policy component so the registration validator has a single source of truth.

## Testing

- `./gradlew --no-daemon :customer:test --tests com.kartoush.customer.internal.validation.CreateCustomerRequestValidatorTest --tests com.kartoush.customer.internal.facade.DefaultCustomerFacadeTest :app:test --tests com.kartoush.api.customer.CustomerControllerWebMvcTest :app:integrationTest --tests com.kartoush.api.customer.CustomerCreationRestAssuredIntegrationTest --tests com.kartoush.api.customer.CustomerDuplicateEmailRestAssuredIntegrationTest --tests com.kartoush.api.customer.CustomerActivationIntegrationTest`

Closes #154
