### PR TITLE
Add Terms of Service management operations

### DIFF
--- a/customer/src/main/java/com/kartoush/customer/exception/InvalidTermsOfServiceScheduleException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/InvalidTermsOfServiceScheduleException.java
@@ -1,0 +1,10 @@
+package com.kartoush.customer.exception;
+
+import java.time.Instant;
+
+public class InvalidTermsOfServiceScheduleException extends RuntimeException {
+
+    public InvalidTermsOfServiceScheduleException(final Instant effectiveAt) {
+        super("Terms of Service can only be scheduled for a future effectiveAt: " + effectiveAt);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/InvalidTermsOfServiceTransitionException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/InvalidTermsOfServiceTransitionException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class InvalidTermsOfServiceTransitionException extends RuntimeException {
+
+    public InvalidTermsOfServiceTransitionException(final String message) {
+        super(message);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/NoDueScheduledTermsOfServiceException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/NoDueScheduledTermsOfServiceException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class NoDueScheduledTermsOfServiceException extends RuntimeException {
+
+    public NoDueScheduledTermsOfServiceException() {
+        super("No due scheduled Terms of Service found");
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceNotFoundException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class TermsOfServiceNotFoundException extends RuntimeException {
+
+    public TermsOfServiceNotFoundException(final String termsOfServiceId) {
+        super("Terms of Service not found for id: " + termsOfServiceId);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceVersionAlreadyExistsException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceVersionAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class TermsOfServiceVersionAlreadyExistsException extends RuntimeException {
+
+    public TermsOfServiceVersionAlreadyExistsException(final String version) {
+        super("Terms of Service already exists for version: " + version);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceVersionAlreadyScheduledException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceVersionAlreadyScheduledException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class TermsOfServiceVersionAlreadyScheduledException extends RuntimeException {
+
+    public TermsOfServiceVersionAlreadyScheduledException(final String termsOfServiceId) {
+        super("Another Terms of Service version is already scheduled: " + termsOfServiceId);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/entity/TermsOfServiceEntity.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/entity/TermsOfServiceEntity.java
@@ -179,6 +179,17 @@ public class TermsOfServiceEntity implements Persistable<String> {
         validateState();
     }
 
+    public void unschedule() {
+        if (status != TermsOfServiceStatus.SCHEDULED) {
+            throw new IllegalStateException("Terms of Service can only be unscheduled from SCHEDULED");
+        }
+
+        this.status = TermsOfServiceStatus.DRAFT;
+        this.effectiveAt = null;
+        this.supersededAt = null;
+        validateState();
+    }
+
     public void activate(final Instant effectiveAt) {
         if (status != TermsOfServiceStatus.DRAFT && status != TermsOfServiceStatus.SCHEDULED) {
             throw new IllegalStateException("Terms of Service can only be activated from DRAFT or SCHEDULED");

--- a/customer/src/main/java/com/kartoush/customer/persistence/repository/TermsOfServiceRepository.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/repository/TermsOfServiceRepository.java
@@ -15,6 +15,10 @@ public interface TermsOfServiceRepository extends JpaRepository<TermsOfServiceEn
 
     Optional<TermsOfServiceEntity> findByVersion(String version);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select terms from TermsOfServiceEntity terms where terms.id = :id")
+    Optional<TermsOfServiceEntity> findByIdForUpdate(@Param("id") String id);
+
     Optional<TermsOfServiceEntity> findByStatus(TermsOfServiceStatus status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/customer/src/main/java/com/kartoush/customer/service/TermsOfServiceManagementService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/TermsOfServiceManagementService.java
@@ -1,0 +1,28 @@
+package com.kartoush.customer.service;
+
+import com.kartoush.customer.persistence.entity.TermsOfServiceEntity;
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import java.time.Instant;
+
+public interface TermsOfServiceManagementService {
+
+    TermsOfServiceEntity createDraft(
+        String version,
+        String content,
+        TermsOfServiceContentType contentType);
+
+    TermsOfServiceEntity updateDraft(
+        String termsOfServiceId,
+        String content,
+        TermsOfServiceContentType contentType);
+
+    TermsOfServiceEntity schedule(
+        String termsOfServiceId,
+        Instant effectiveAt);
+
+    TermsOfServiceEntity unschedule(String termsOfServiceId);
+
+    TermsOfServiceEntity activateNow(String termsOfServiceId);
+
+    TermsOfServiceEntity promoteDueScheduledTerms();
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultTermsOfServiceManagementService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultTermsOfServiceManagementService.java
@@ -1,0 +1,174 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.exception.InvalidTermsOfServiceScheduleException;
+import com.kartoush.customer.exception.InvalidTermsOfServiceTransitionException;
+import com.kartoush.customer.exception.NoDueScheduledTermsOfServiceException;
+import com.kartoush.customer.exception.TermsOfServiceNotFoundException;
+import com.kartoush.customer.exception.TermsOfServiceVersionAlreadyExistsException;
+import com.kartoush.customer.exception.TermsOfServiceVersionAlreadyScheduledException;
+import com.kartoush.customer.persistence.entity.TermsOfServiceEntity;
+import com.kartoush.customer.persistence.repository.TermsOfServiceRepository;
+import com.kartoush.customer.service.TermsOfServiceManagementService;
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
+import com.kartoush.platform.ulid.UlidGenerator;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DefaultTermsOfServiceManagementService implements TermsOfServiceManagementService {
+
+    private final TermsOfServiceRepository termsOfServiceRepository;
+    private final UlidGenerator ulidGenerator;
+    private final Clock clock;
+
+    public DefaultTermsOfServiceManagementService(
+        final TermsOfServiceRepository termsOfServiceRepository,
+        final UlidGenerator ulidGenerator,
+        final Clock clock) {
+        this.termsOfServiceRepository = termsOfServiceRepository;
+        this.ulidGenerator = ulidGenerator;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional
+    public TermsOfServiceEntity createDraft(
+        final String version,
+        final String content,
+        final TermsOfServiceContentType contentType) {
+        if (termsOfServiceRepository.findByVersion(version).isPresent()) {
+            throw new TermsOfServiceVersionAlreadyExistsException(version);
+        }
+
+        final TermsOfServiceEntity termsOfService = TermsOfServiceEntity.draft(
+            ulidGenerator.next(),
+            version,
+            content,
+            contentType
+        );
+
+        return termsOfServiceRepository.save(termsOfService);
+    }
+
+    @Override
+    @Transactional
+    public TermsOfServiceEntity updateDraft(
+        final String termsOfServiceId,
+        final String content,
+        final TermsOfServiceContentType contentType) {
+        final TermsOfServiceEntity termsOfService = findByIdForUpdate(termsOfServiceId);
+
+        try {
+            termsOfService.updateDraftContent(content, contentType);
+        } catch (final IllegalStateException exception) {
+            throw new InvalidTermsOfServiceTransitionException(exception.getMessage());
+        }
+
+        return termsOfServiceRepository.save(termsOfService);
+    }
+
+    @Override
+    @Transactional
+    public TermsOfServiceEntity schedule(
+        final String termsOfServiceId,
+        final Instant effectiveAt) {
+        final Instant now = Instant.now(clock);
+
+        if (!effectiveAt.isAfter(now)) {
+            throw new InvalidTermsOfServiceScheduleException(effectiveAt);
+        }
+
+        final TermsOfServiceEntity termsOfService = findByIdForUpdate(termsOfServiceId);
+        ensureNoOtherScheduledTerms(termsOfServiceId);
+
+        try {
+            termsOfService.schedule(effectiveAt);
+        } catch (final IllegalStateException exception) {
+            throw new InvalidTermsOfServiceTransitionException(exception.getMessage());
+        }
+
+        return termsOfServiceRepository.save(termsOfService);
+    }
+
+    @Override
+    @Transactional
+    public TermsOfServiceEntity unschedule(final String termsOfServiceId) {
+        final TermsOfServiceEntity termsOfService = findByIdForUpdate(termsOfServiceId);
+
+        try {
+            termsOfService.unschedule();
+        } catch (final IllegalStateException exception) {
+            throw new InvalidTermsOfServiceTransitionException(exception.getMessage());
+        }
+
+        return termsOfServiceRepository.save(termsOfService);
+    }
+
+    @Override
+    @Transactional
+    public TermsOfServiceEntity activateNow(final String termsOfServiceId) {
+        final Instant now = Instant.now(clock);
+        final TermsOfServiceEntity termsOfService = findByIdForUpdate(termsOfServiceId);
+        final Optional<TermsOfServiceEntity> activeTermsOfService =
+            termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE);
+
+        activeTermsOfService.ifPresent(active -> supersedeIfDifferent(active, termsOfService, now));
+
+        try {
+            termsOfService.activate(now);
+        } catch (final IllegalStateException exception) {
+            throw new InvalidTermsOfServiceTransitionException(exception.getMessage());
+        }
+
+        return termsOfServiceRepository.save(termsOfService);
+    }
+
+    @Override
+    @Transactional
+    public TermsOfServiceEntity promoteDueScheduledTerms() {
+        final Instant now = Instant.now(clock);
+        final TermsOfServiceEntity dueScheduledTerms = termsOfServiceRepository
+            .findDueScheduledTermsOfServiceForUpdate(now)
+            .orElseThrow(NoDueScheduledTermsOfServiceException::new);
+        final Optional<TermsOfServiceEntity> activeTermsOfService =
+            termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE);
+
+        activeTermsOfService.ifPresent(active -> supersedeIfDifferent(active, dueScheduledTerms, now));
+
+        try {
+            dueScheduledTerms.activate(dueScheduledTerms.getEffectiveAt());
+        } catch (final IllegalStateException exception) {
+            throw new InvalidTermsOfServiceTransitionException(exception.getMessage());
+        }
+
+        return termsOfServiceRepository.save(dueScheduledTerms);
+    }
+
+    private TermsOfServiceEntity findByIdForUpdate(final String termsOfServiceId) {
+        return termsOfServiceRepository.findByIdForUpdate(termsOfServiceId)
+            .orElseThrow(() -> new TermsOfServiceNotFoundException(termsOfServiceId));
+    }
+
+    private void ensureNoOtherScheduledTerms(final String termsOfServiceId) {
+        termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.SCHEDULED)
+            .filter(scheduled -> !Objects.equals(scheduled.getId(), termsOfServiceId))
+            .ifPresent(scheduled -> {
+                throw new TermsOfServiceVersionAlreadyScheduledException(scheduled.getId());
+            });
+    }
+
+    private void supersedeIfDifferent(
+        final TermsOfServiceEntity activeTermsOfService,
+        final TermsOfServiceEntity nextTermsOfService,
+        final Instant now) {
+        if (!Objects.equals(activeTermsOfService.getId(), nextTermsOfService.getId())) {
+            activeTermsOfService.supersede(now);
+            termsOfServiceRepository.save(activeTermsOfService);
+        }
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultTermsOfServiceManagementService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultTermsOfServiceManagementService.java
@@ -113,9 +113,9 @@ public class DefaultTermsOfServiceManagementService implements TermsOfServiceMan
     @Transactional
     public TermsOfServiceEntity activateNow(final String termsOfServiceId) {
         final Instant now = Instant.now(clock);
-        final TermsOfServiceEntity termsOfService = findByIdForUpdate(termsOfServiceId);
         final Optional<TermsOfServiceEntity> activeTermsOfService =
             termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE);
+        final TermsOfServiceEntity termsOfService = findByIdForUpdate(termsOfServiceId);
 
         activeTermsOfService.ifPresent(active -> supersedeIfDifferent(active, termsOfService, now));
 
@@ -132,11 +132,11 @@ public class DefaultTermsOfServiceManagementService implements TermsOfServiceMan
     @Transactional
     public TermsOfServiceEntity promoteDueScheduledTerms() {
         final Instant now = Instant.now(clock);
+        final Optional<TermsOfServiceEntity> activeTermsOfService =
+            termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE);
         final TermsOfServiceEntity dueScheduledTerms = termsOfServiceRepository
             .findDueScheduledTermsOfServiceForUpdate(now)
             .orElseThrow(NoDueScheduledTermsOfServiceException::new);
-        final Optional<TermsOfServiceEntity> activeTermsOfService =
-            termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE);
 
         activeTermsOfService.ifPresent(active -> supersedeIfDifferent(active, dueScheduledTerms, now));
 

--- a/customer/src/test/java/com/kartoush/customer/persistence/entity/TermsOfServiceEntityTest.java
+++ b/customer/src/test/java/com/kartoush/customer/persistence/entity/TermsOfServiceEntityTest.java
@@ -74,6 +74,25 @@ class TermsOfServiceEntityTest {
     }
 
     @Test
+    void shouldUnscheduleScheduledTermsOfService() {
+        // given
+        final TermsOfServiceEntity terms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+        terms.schedule(EFFECTIVE_AT);
+
+        // when
+        terms.unschedule();
+
+        // then
+        assertThat(terms.getStatus()).isEqualTo(TermsOfServiceStatus.DRAFT);
+        assertThat(terms.getEffectiveAt()).isNull();
+    }
+
+    @Test
     void shouldActivateScheduledTermsOfService() {
         // given
         final TermsOfServiceEntity terms = TermsOfServiceEntity.draft(

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultTermsOfServiceManagementServiceTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultTermsOfServiceManagementServiceTest.java
@@ -1,0 +1,419 @@
+package com.kartoush.customer.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.kartoush.customer.exception.InvalidTermsOfServiceScheduleException;
+import com.kartoush.customer.exception.InvalidTermsOfServiceTransitionException;
+import com.kartoush.customer.exception.NoDueScheduledTermsOfServiceException;
+import com.kartoush.customer.exception.TermsOfServiceNotFoundException;
+import com.kartoush.customer.exception.TermsOfServiceVersionAlreadyExistsException;
+import com.kartoush.customer.exception.TermsOfServiceVersionAlreadyScheduledException;
+import com.kartoush.customer.persistence.entity.TermsOfServiceEntity;
+import com.kartoush.customer.persistence.repository.TermsOfServiceRepository;
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
+import com.kartoush.platform.ulid.UlidGenerator;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultTermsOfServiceManagementServiceTest {
+
+    private static final String TERMS_ID = "01JV00MANAGEDTERMS00000001";
+    private static final String ACTIVE_TERMS_ID = "01JV00MANAGEDTERMS00000002";
+    private static final String SCHEDULED_TERMS_ID = "01JV00MANAGEDTERMS00000003";
+    private static final String VERSION = "2026.06.01";
+    private static final String ACTIVE_VERSION = "2026.04.01";
+    private static final String CONTENT = "Draft terms";
+    private static final Instant NOW = Instant.parse("2026-05-01T12:00:00Z");
+    private static final Instant FUTURE_EFFECTIVE_AT = Instant.parse("2026-05-10T00:00:00Z");
+    private static final Instant DUE_EFFECTIVE_AT = Instant.parse("2026-05-01T00:00:00Z");
+
+    @Mock
+    private TermsOfServiceRepository termsOfServiceRepository;
+
+    @Mock
+    private UlidGenerator ulidGenerator;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private DefaultTermsOfServiceManagementService termsOfServiceManagementService;
+
+    @Test
+    void shouldCreateDraftTermsOfService() {
+        // given
+        given(ulidGenerator.next()).willReturn(TERMS_ID);
+        given(termsOfServiceRepository.findByVersion(VERSION)).willReturn(Optional.empty());
+        given(termsOfServiceRepository.save(any(TermsOfServiceEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        final TermsOfServiceEntity terms = termsOfServiceManagementService.createDraft(
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.MARKDOWN
+        );
+
+        // then
+        assertThat(terms.getId()).isEqualTo(TERMS_ID);
+        assertThat(terms.getVersion()).isEqualTo(VERSION);
+        assertThat(terms.getStatus()).isEqualTo(TermsOfServiceStatus.DRAFT);
+        verify(termsOfServiceRepository).save(any(TermsOfServiceEntity.class));
+    }
+
+    @Test
+    void shouldRejectDuplicateDraftVersion() {
+        // given
+        final TermsOfServiceEntity existingTerms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+        given(termsOfServiceRepository.findByVersion(VERSION)).willReturn(Optional.of(existingTerms));
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.createDraft(
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.MARKDOWN
+        ))
+            .isInstanceOf(TermsOfServiceVersionAlreadyExistsException.class)
+            .hasMessage("Terms of Service already exists for version: " + VERSION);
+
+        verify(termsOfServiceRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldUpdateDraftContent() {
+        // given
+        final TermsOfServiceEntity draftTerms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(draftTerms));
+        given(termsOfServiceRepository.save(draftTerms)).willReturn(draftTerms);
+
+        // when
+        final TermsOfServiceEntity updatedTerms = termsOfServiceManagementService.updateDraft(
+            TERMS_ID,
+            "Updated terms",
+            TermsOfServiceContentType.MARKDOWN
+        );
+
+        // then
+        assertThat(updatedTerms.getContent()).isEqualTo("Updated terms");
+        assertThat(updatedTerms.getContentType()).isEqualTo(TermsOfServiceContentType.MARKDOWN);
+        verify(termsOfServiceRepository).save(draftTerms);
+    }
+
+    @Test
+    void shouldRejectDraftUpdateWhenTermsAreNotDraft() {
+        // given
+        final TermsOfServiceEntity activeTerms = activeTerms(ACTIVE_TERMS_ID, ACTIVE_VERSION);
+        given(termsOfServiceRepository.findByIdForUpdate(ACTIVE_TERMS_ID)).willReturn(Optional.of(activeTerms));
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.updateDraft(
+            ACTIVE_TERMS_ID,
+            "Updated terms",
+            TermsOfServiceContentType.MARKDOWN
+        ))
+            .isInstanceOf(InvalidTermsOfServiceTransitionException.class)
+            .hasMessage("Terms of Service content can only be modified while in DRAFT");
+
+        verify(termsOfServiceRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldScheduleDraftTermsOfService() {
+        // given
+        final TermsOfServiceEntity draftTerms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(draftTerms));
+        given(termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.SCHEDULED)).willReturn(Optional.empty());
+        given(termsOfServiceRepository.save(draftTerms)).willReturn(draftTerms);
+
+        // when
+        final TermsOfServiceEntity scheduledTerms =
+            termsOfServiceManagementService.schedule(TERMS_ID, FUTURE_EFFECTIVE_AT);
+
+        // then
+        assertThat(scheduledTerms.getStatus()).isEqualTo(TermsOfServiceStatus.SCHEDULED);
+        assertThat(scheduledTerms.getEffectiveAt()).isEqualTo(FUTURE_EFFECTIVE_AT);
+    }
+
+    @Test
+    void shouldRejectScheduleWhenEffectiveAtIsNotFuture() {
+        // given
+        given(clock.instant()).willReturn(NOW);
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.schedule(TERMS_ID, NOW))
+            .isInstanceOf(InvalidTermsOfServiceScheduleException.class)
+            .hasMessage("Terms of Service can only be scheduled for a future effectiveAt: " + NOW);
+    }
+
+    @Test
+    void shouldRejectScheduleWhenAnotherTermsVersionIsAlreadyScheduled() {
+        // given
+        final TermsOfServiceEntity draftTerms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+        final TermsOfServiceEntity scheduledTerms = TermsOfServiceEntity.rehydrate(
+            SCHEDULED_TERMS_ID,
+            "2026.07.01",
+            "Scheduled",
+            TermsOfServiceContentType.PLAIN_TEXT,
+            TermsOfServiceStatus.SCHEDULED,
+            FUTURE_EFFECTIVE_AT,
+            null,
+            NOW,
+            NOW
+        );
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(draftTerms));
+        given(termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.SCHEDULED))
+            .willReturn(Optional.of(scheduledTerms));
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.schedule(TERMS_ID, FUTURE_EFFECTIVE_AT))
+            .isInstanceOf(TermsOfServiceVersionAlreadyScheduledException.class)
+            .hasMessage("Another Terms of Service version is already scheduled: " + SCHEDULED_TERMS_ID);
+
+        verify(termsOfServiceRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldUnscheduleScheduledTermsOfService() {
+        // given
+        final TermsOfServiceEntity scheduledTerms = TermsOfServiceEntity.rehydrate(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT,
+            TermsOfServiceStatus.SCHEDULED,
+            FUTURE_EFFECTIVE_AT,
+            null,
+            NOW,
+            NOW
+        );
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(scheduledTerms));
+        given(termsOfServiceRepository.save(scheduledTerms)).willReturn(scheduledTerms);
+
+        // when
+        final TermsOfServiceEntity unscheduledTerms = termsOfServiceManagementService.unschedule(TERMS_ID);
+
+        // then
+        assertThat(unscheduledTerms.getStatus()).isEqualTo(TermsOfServiceStatus.DRAFT);
+        assertThat(unscheduledTerms.getEffectiveAt()).isNull();
+    }
+
+    @Test
+    void shouldRejectUnscheduleWhenTermsAreNotScheduled() {
+        // given
+        final TermsOfServiceEntity draftTerms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(draftTerms));
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.unschedule(TERMS_ID))
+            .isInstanceOf(InvalidTermsOfServiceTransitionException.class)
+            .hasMessage("Terms of Service can only be unscheduled from SCHEDULED");
+    }
+
+    @Test
+    void shouldActivateDraftTermsImmediatelyAndSupersedeCurrentActiveTerms() {
+        // given
+        final TermsOfServiceEntity draftTerms = TermsOfServiceEntity.draft(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.MARKDOWN
+        );
+        final TermsOfServiceEntity activeTerms = activeTerms(ACTIVE_TERMS_ID, ACTIVE_VERSION);
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(draftTerms));
+        given(termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE)).willReturn(Optional.of(activeTerms));
+        given(termsOfServiceRepository.save(any(TermsOfServiceEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        final TermsOfServiceEntity activatedTerms = termsOfServiceManagementService.activateNow(TERMS_ID);
+
+        // then
+        assertThat(activatedTerms.getStatus()).isEqualTo(TermsOfServiceStatus.ACTIVE);
+        assertThat(activatedTerms.getEffectiveAt()).isEqualTo(NOW);
+        assertThat(activeTerms.getStatus()).isEqualTo(TermsOfServiceStatus.SUPERSEDED);
+        assertThat(activeTerms.getSupersededAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldRejectImmediateActivationWhenTermsCannotTransitionToActive() {
+        // given
+        final TermsOfServiceEntity supersededTerms = TermsOfServiceEntity.rehydrate(
+            TERMS_ID,
+            VERSION,
+            CONTENT,
+            TermsOfServiceContentType.MARKDOWN,
+            TermsOfServiceStatus.SUPERSEDED,
+            DUE_EFFECTIVE_AT,
+            NOW,
+            DUE_EFFECTIVE_AT,
+            NOW
+        );
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(supersededTerms));
+        given(termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.activateNow(TERMS_ID))
+            .isInstanceOf(InvalidTermsOfServiceTransitionException.class)
+            .hasMessage("Terms of Service can only be activated from DRAFT or SCHEDULED");
+    }
+
+    @Test
+    void shouldPromoteDueScheduledTerms() {
+        // given
+        final TermsOfServiceEntity dueScheduledTerms = TermsOfServiceEntity.rehydrate(
+            SCHEDULED_TERMS_ID,
+            "2026.07.01",
+            "Scheduled",
+            TermsOfServiceContentType.PLAIN_TEXT,
+            TermsOfServiceStatus.SCHEDULED,
+            DUE_EFFECTIVE_AT,
+            null,
+            DUE_EFFECTIVE_AT,
+            DUE_EFFECTIVE_AT
+        );
+        final TermsOfServiceEntity activeTerms = activeTerms(ACTIVE_TERMS_ID, ACTIVE_VERSION);
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findDueScheduledTermsOfServiceForUpdate(NOW))
+            .willReturn(Optional.of(dueScheduledTerms));
+        given(termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE)).willReturn(Optional.of(activeTerms));
+        given(termsOfServiceRepository.save(any(TermsOfServiceEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        final TermsOfServiceEntity promotedTerms = termsOfServiceManagementService.promoteDueScheduledTerms();
+
+        // then
+        assertThat(promotedTerms.getStatus()).isEqualTo(TermsOfServiceStatus.ACTIVE);
+        assertThat(promotedTerms.getEffectiveAt()).isEqualTo(DUE_EFFECTIVE_AT);
+        assertThat(activeTerms.getStatus()).isEqualTo(TermsOfServiceStatus.SUPERSEDED);
+        assertThat(activeTerms.getSupersededAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldThrowWhenPromotingWithoutDueScheduledTerms() {
+        // given
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findDueScheduledTermsOfServiceForUpdate(NOW)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.promoteDueScheduledTerms())
+            .isInstanceOf(NoDueScheduledTermsOfServiceException.class)
+            .hasMessage("No due scheduled Terms of Service found");
+    }
+
+    @Test
+    void shouldThrowWhenTermsOfServiceIsMissing() {
+        // given
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.updateDraft(
+            TERMS_ID,
+            CONTENT,
+            TermsOfServiceContentType.PLAIN_TEXT
+        ))
+            .isInstanceOf(TermsOfServiceNotFoundException.class)
+            .hasMessage("Terms of Service not found for id: " + TERMS_ID);
+    }
+
+    @Test
+    void shouldThrowWhenSchedulingMissingTermsOfService() {
+        // given
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.schedule(TERMS_ID, FUTURE_EFFECTIVE_AT))
+            .isInstanceOf(TermsOfServiceNotFoundException.class)
+            .hasMessage("Terms of Service not found for id: " + TERMS_ID);
+    }
+
+    @Test
+    void shouldThrowWhenUnschedulingMissingTermsOfService() {
+        // given
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.unschedule(TERMS_ID))
+            .isInstanceOf(TermsOfServiceNotFoundException.class)
+            .hasMessage("Terms of Service not found for id: " + TERMS_ID);
+    }
+
+    @Test
+    void shouldThrowWhenActivatingMissingTermsOfService() {
+        // given
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.activateNow(TERMS_ID))
+            .isInstanceOf(TermsOfServiceNotFoundException.class)
+            .hasMessage("Terms of Service not found for id: " + TERMS_ID);
+    }
+
+    @Test
+    void shouldRejectImmediateActivationWhenTermsAreAlreadyActive() {
+        // given
+        final TermsOfServiceEntity activeTerms = activeTerms(TERMS_ID, VERSION);
+        given(clock.instant()).willReturn(NOW);
+        given(termsOfServiceRepository.findByIdForUpdate(TERMS_ID)).willReturn(Optional.of(activeTerms));
+        given(termsOfServiceRepository.findByStatusForUpdate(TermsOfServiceStatus.ACTIVE)).willReturn(Optional.of(activeTerms));
+
+        // when / then
+        assertThatThrownBy(() -> termsOfServiceManagementService.activateNow(TERMS_ID))
+            .isInstanceOf(InvalidTermsOfServiceTransitionException.class)
+            .hasMessage("Terms of Service can only be activated from DRAFT or SCHEDULED");
+    }
+
+    private static TermsOfServiceEntity activeTerms(final String id, final String version) {
+        return TermsOfServiceEntity.rehydrate(
+            id,
+            version,
+            "Active terms",
+            TermsOfServiceContentType.PLAIN_TEXT,
+            TermsOfServiceStatus.ACTIVE,
+            DUE_EFFECTIVE_AT,
+            null,
+            DUE_EFFECTIVE_AT,
+            DUE_EFFECTIVE_AT
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds internal Terms of Service management operations so canonical Terms records can be created, updated while still in draft, scheduled, unscheduled, activated, and promoted through the supported lifecycle.

## Scope

- add an internal TermsOfServiceManagementService and default implementation
- add support for draft creation and draft content updates
- add support for scheduling and unscheduling Terms versions
- add support for immediate activation and due scheduled promotion
- supersede the previous active Terms version during activation and promotion
- add Terms-specific exceptions for invalid transitions, missing records, duplicate versions, and scheduling conflicts
- add repository locking support needed by the management service
- extend Terms entity lifecycle support with unschedule behavior
- add unit tests for lifecycle operations, failure paths, and unschedule behavior

## Notes

- This task stops at the internal service boundary and does not add admin HTTP endpoints.
- Public or internal controller work is deferred to #221.
- The lifecycle remains limited to `DRAFT`, `SCHEDULED`, `ACTIVE`, and `SUPERSEDED`.

## Testing

- `./gradlew :customer:test --tests com.kartoush.customer.service.impl.DefaultTermsOfServiceManagementServiceTest`
- `./gradlew :customer:test --tests com.kartoush.customer.persistence.entity.TermsOfServiceEntityTest`
- `./gradlew :customer:integrationTest --tests com.kartoush.customer.persistence.repository.TermsOfServiceRepositoryTest`

Closes #219
