### PR TITLE
Clarify registration failure boundary in ADR 0026

### DIFF
--- a/docs/architecture/decisions/0026-registration-and-terms-acceptance-approach.md
+++ b/docs/architecture/decisions/0026-registration-and-terms-acceptance-approach.md
@@ -45,11 +45,16 @@ Successful registration will:
 - persist a separate Terms acceptance audit record
 - issue an activation token for subsequent account activation
 
-Failed registration will not create:
+If registration validation fails, Kartoush will not create:
 
 - a customer record
 - a Terms acceptance record
 - an activation token
+
+After customer and Terms acceptance persistence succeeds, downstream activation
+token issuance or delivery may still fail independently. In that case the API
+request may fail after the customer and Terms acceptance records have already
+been committed.
 
 ## Current Terms Version Strategy
 


### PR DESCRIPTION
## Summary

Clarifies ADR 0026 so the registration failure statement matches the actual transactional boundary between customer/Terms persistence and downstream activation token issuance or email delivery.

## Scope

- narrow the failed-registration guarantee to registration validation failures
- document that downstream token issuance or delivery may fail after customer and Terms acceptance persistence succeeds

## Notes

- Documentation-only follow-up after the post-merge review comment on PR #224

## Testing

- Documentation only; no tests run
