### PR TITLE
Add Terms of Service metadata endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
             test-class: com.kartoush.api.customer.CustomerDuplicateEmailRestAssuredIntegrationTest
           - name: customer-activation-contract
             test-class: com.kartoush.api.customer.CustomerActivationIntegrationTest
+          - name: terms-of-service-metadata-contract
+            test-class: com.kartoush.api.terms.TermsOfServiceMetadataIntegrationTest
 
     name: App integration tests (${{ matrix.name }})
 

--- a/app/src/main/java/com/kartoush/api/error/ApiExceptionHandler.java
+++ b/app/src/main/java/com/kartoush/api/error/ApiExceptionHandler.java
@@ -12,6 +12,8 @@ import com.kartoush.customer.exception.InvalidCustomerActivationException;
 import com.kartoush.customer.exception.InvalidCustomerReactivationException;
 import com.kartoush.customer.exception.InvalidCustomerStatusForUpdateException;
 import com.kartoush.customer.exception.InvalidCustomerStatusTransitionException;
+import com.kartoush.customer.exception.CurrentTermsOfServiceNotFoundException;
+import com.kartoush.customer.exception.TermsOfServiceVersionNotFoundException;
 import com.kartoush.platform.validation.RequestValidationException;
 import com.kartoush.platform.validation.ValidationError;
 import jakarta.servlet.http.HttpServletRequest;
@@ -235,6 +237,30 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
             "Invalid Customer Activation",
             ex.getMessage(),
             ErrorCode.INVALID_CUSTOMER_ACTIVATION,
+            request);
+    }
+
+    @ExceptionHandler(CurrentTermsOfServiceNotFoundException.class)
+    public ProblemDetail handleCurrentTermsOfServiceNotFoundException(
+        final CurrentTermsOfServiceNotFoundException ex,
+        final HttpServletRequest request) {
+        return apiProblemFactory.create(
+            HttpStatus.NOT_FOUND,
+            "Terms of Service Not Found",
+            ex.getMessage(),
+            ErrorCode.TERMS_OF_SERVICE_NOT_FOUND,
+            request);
+    }
+
+    @ExceptionHandler(TermsOfServiceVersionNotFoundException.class)
+    public ProblemDetail handleTermsOfServiceVersionNotFoundException(
+        final TermsOfServiceVersionNotFoundException ex,
+        final HttpServletRequest request) {
+        return apiProblemFactory.create(
+            HttpStatus.NOT_FOUND,
+            "Terms of Service Not Found",
+            ex.getMessage(),
+            ErrorCode.TERMS_OF_SERVICE_NOT_FOUND,
             request);
     }
 

--- a/app/src/main/java/com/kartoush/api/error/ErrorCode.java
+++ b/app/src/main/java/com/kartoush/api/error/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     INVALID_CUSTOMER_STATUS_TRANSITION,
     INVALID_CUSTOMER_REACTIVATION,
 
+    // Terms of Service
+    TERMS_OF_SERVICE_NOT_FOUND,
+
     // Validation
     VALIDATION_FAILED,
 

--- a/app/src/main/java/com/kartoush/api/terms/TermsOfServiceController.java
+++ b/app/src/main/java/com/kartoush/api/terms/TermsOfServiceController.java
@@ -1,0 +1,43 @@
+package com.kartoush.api.terms;
+
+import com.kartoush.customer.facade.TermsOfServiceFacade;
+import com.kartoush.customer.facade.model.TermsOfServiceView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/terms-of-service")
+public class TermsOfServiceController {
+
+    private final TermsOfServiceFacade termsOfServiceFacade;
+
+    public TermsOfServiceController(final TermsOfServiceFacade termsOfServiceFacade) {
+        this.termsOfServiceFacade = termsOfServiceFacade;
+    }
+
+    @Operation(summary = "Get current Terms of Service metadata")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Current Terms of Service retrieved successfully"),
+        @ApiResponse(responseCode = "404", description = "Current Terms of Service not found")
+    })
+    @GetMapping("/current")
+    public ResponseEntity<TermsOfServiceView> getCurrentTermsOfService() {
+        return ResponseEntity.ok(termsOfServiceFacade.getCurrentTermsOfService());
+    }
+
+    @Operation(summary = "Get Terms of Service metadata by version")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Terms of Service retrieved successfully"),
+        @ApiResponse(responseCode = "404", description = "Terms of Service not found for version")
+    })
+    @GetMapping("/{version}")
+    public ResponseEntity<TermsOfServiceView> getTermsOfServiceByVersion(@PathVariable final String version) {
+        return ResponseEntity.ok(termsOfServiceFacade.getTermsOfServiceByVersion(version));
+    }
+}

--- a/app/src/test/java/com/kartoush/api/terms/TermsOfServiceControllerWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsOfServiceControllerWebMvcTest.java
@@ -1,0 +1,100 @@
+package com.kartoush.api.terms;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kartoush.api.error.ApiProblemFactory;
+import com.kartoush.api.error.ErrorCode;
+import com.kartoush.customer.exception.TermsOfServiceVersionNotFoundException;
+import com.kartoush.customer.facade.TermsOfServiceFacade;
+import com.kartoush.customer.facade.model.TermsOfServiceView;
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TermsOfServiceController.class)
+class TermsOfServiceControllerWebMvcTest {
+
+    private static final String BASE_URL = "/api/terms-of-service";
+    private static final String VERSION = "2026.04.01";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApiProblemFactory apiProblemFactory;
+
+    @MockitoBean
+    private TermsOfServiceFacade termsOfServiceFacade;
+
+    @Test
+    void shouldGetCurrentTermsOfService() throws Exception {
+        when(termsOfServiceFacade.getCurrentTermsOfService()).thenReturn(termsView());
+
+        mockMvc.perform(get(BASE_URL + "/current"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.version").value(VERSION))
+            .andExpect(jsonPath("$.status").value(TermsOfServiceStatus.ACTIVE.name()));
+
+        verify(termsOfServiceFacade).getCurrentTermsOfService();
+    }
+
+    @Test
+    void shouldGetTermsOfServiceByVersion() throws Exception {
+        when(termsOfServiceFacade.getTermsOfServiceByVersion(VERSION)).thenReturn(termsView());
+
+        mockMvc.perform(get(BASE_URL + "/{version}", VERSION))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.version").value(VERSION))
+            .andExpect(jsonPath("$.contentType").value(TermsOfServiceContentType.PLAIN_TEXT.name()));
+
+        verify(termsOfServiceFacade).getTermsOfServiceByVersion(VERSION);
+    }
+
+    @Test
+    void shouldReturnNotFoundForMissingTermsVersion() throws Exception {
+        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+            HttpStatus.NOT_FOUND,
+            "Terms of Service not found for version: " + VERSION
+        );
+        problemDetail.setTitle("Terms of Service Not Found");
+        problemDetail.setProperty("errorCode", ErrorCode.TERMS_OF_SERVICE_NOT_FOUND.name());
+
+        when(termsOfServiceFacade.getTermsOfServiceByVersion(VERSION))
+            .thenThrow(new TermsOfServiceVersionNotFoundException(VERSION));
+        when(apiProblemFactory.create(
+            any(),
+            any(),
+            any(),
+            any(),
+            any()
+        )).thenReturn(problemDetail);
+
+        mockMvc.perform(get(BASE_URL + "/{version}", VERSION))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.title").value("Terms of Service Not Found"))
+            .andExpect(jsonPath("$.errorCode").value(ErrorCode.TERMS_OF_SERVICE_NOT_FOUND.name()));
+    }
+
+    private TermsOfServiceView termsView() {
+        return new TermsOfServiceView(
+            VERSION,
+            "Terms content",
+            TermsOfServiceContentType.PLAIN_TEXT,
+            TermsOfServiceStatus.ACTIVE,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            null
+        );
+    }
+}

--- a/app/src/test/java/com/kartoush/api/terms/TermsOfServiceMetadataIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsOfServiceMetadataIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.kartoush.api.terms;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kartoush.customer.persistence.entity.TermsOfServiceEntity;
+import com.kartoush.customer.persistence.repository.TermsOfServiceRepository;
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
+import com.kartoush.platform.ulid.UlidGenerator;
+import com.kartoush.testsupport.PostgresSpringIntegrationTest;
+import com.kartoush.testsupport.SpringIntegrationTest;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringIntegrationTest
+@AutoConfigureMockMvc
+class TermsOfServiceMetadataIntegrationTest extends PostgresSpringIntegrationTest {
+
+    private static final String BASE_URL = "/api/terms-of-service";
+    private static final String CURRENT_VERSION = "2026.04.01";
+    private static final String HISTORICAL_VERSION = "2026.03.01";
+    private static final String DRAFT_VERSION = "2026.05.01";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TermsOfServiceRepository termsOfServiceRepository;
+
+    @Autowired
+    private UlidGenerator ulidGenerator;
+
+    @BeforeEach
+    void setUp() {
+        termsOfServiceRepository.findByVersion(HISTORICAL_VERSION)
+            .ifPresent(termsOfServiceRepository::delete);
+        termsOfServiceRepository.findByVersion(DRAFT_VERSION)
+            .ifPresent(termsOfServiceRepository::delete);
+
+        final TermsOfServiceEntity historicalTerms = TermsOfServiceEntity.rehydrate(
+            ulidGenerator.next(),
+            HISTORICAL_VERSION,
+            "Historical terms content",
+            TermsOfServiceContentType.MARKDOWN,
+            TermsOfServiceStatus.SUPERSEDED,
+            Instant.parse("2026-03-01T00:00:00Z"),
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-03-01T00:00:00Z"),
+            Instant.parse("2026-04-01T00:00:00Z")
+        );
+        final TermsOfServiceEntity draftTerms = TermsOfServiceEntity.draft(
+            ulidGenerator.next(),
+            DRAFT_VERSION,
+            "Draft terms content",
+            TermsOfServiceContentType.PLAIN_TEXT
+        );
+
+        termsOfServiceRepository.save(historicalTerms);
+        termsOfServiceRepository.save(draftTerms);
+    }
+
+    @Test
+    void shouldReturnCurrentTermsOfServiceMetadata() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/current"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.version").value(CURRENT_VERSION))
+            .andExpect(jsonPath("$.status").value(TermsOfServiceStatus.ACTIVE.name()))
+            .andExpect(jsonPath("$.content").isNotEmpty())
+            .andExpect(jsonPath("$.contentType").value(TermsOfServiceContentType.PLAIN_TEXT.name()))
+            .andExpect(jsonPath("$.effectiveAt").exists());
+    }
+
+    @Test
+    void shouldReturnHistoricalTermsOfServiceMetadataByVersion() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{version}", HISTORICAL_VERSION))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.version").value(HISTORICAL_VERSION))
+            .andExpect(jsonPath("$.status").value(TermsOfServiceStatus.SUPERSEDED.name()))
+            .andExpect(jsonPath("$.content").value("Historical terms content"))
+            .andExpect(jsonPath("$.contentType").value(TermsOfServiceContentType.MARKDOWN.name()))
+            .andExpect(jsonPath("$.supersededAt").exists());
+    }
+
+    @Test
+    void shouldReturnNotFoundForDraftTermsVersion() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/{version}", DRAFT_VERSION))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.title").value("Terms of Service Not Found"));
+    }
+}

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -18,6 +18,8 @@ Kartoush HTTP API during local development.
   Local environment variables for the running application
 - `customers/`
   Customer API requests, including both happy-path and failure scenarios
+- `terms-of-service/`
+  Read-only Terms of Service metadata requests
 
 ## How To Use
 
@@ -27,6 +29,8 @@ Kartoush HTTP API during local development.
    capture `customerId` into the environment.
 4. Use the remaining customer requests to inspect success and error
    behavior.
+5. Use the `terms-of-service/` requests to inspect the current supported
+   Terms version and retrieve published historical Terms metadata.
 
 The create request also refreshes the `email` environment variable with a
 timestamp-based value so repeated runs stay usable without manual cleanup.

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -30,7 +30,8 @@ Kartoush HTTP API during local development.
 4. Use the remaining customer requests to inspect success and error
    behavior.
 5. Use the `terms-of-service/` requests to inspect the current supported
-   Terms version and retrieve published historical Terms metadata.
+   Terms version, retrieve a published Terms document by version, and
+   inspect the not-found response for an unpublished or missing version.
 
 The create request also refreshes the `email` environment variable with a
 timestamp-based value so repeated runs stay usable without manual cleanup.

--- a/bruno/customers/02-create-customer.bru
+++ b/bruno/customers/02-create-customer.bru
@@ -19,7 +19,9 @@ body {
     "firstName": "{{firstName}}",
     "lastName": "{{lastName}}",
     "email": "{{email}}",
-    "phoneNumber": "{{phoneNumber}}"
+    "phoneNumber": "{{phoneNumber}}",
+    "termsAccepted": true,
+    "termsVersion": "{{currentTermsVersion}}"
   }
 }
 

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -12,5 +12,6 @@ vars {
   updatedPhoneNumber: +13125550101
   activationToken: N7o09al5ldRf1hPTDHMYfwAOhAKvlDntLnQYLhyW5MI
   invalidActivationToken: invalid-activation-token
-  termsVersion: 2026.03.01
+  currentTermsVersion: 2026.04.01
+  missingTermsVersion: 2026.03.01
 }

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -12,4 +12,5 @@ vars {
   updatedPhoneNumber: +13125550101
   activationToken: N7o09al5ldRf1hPTDHMYfwAOhAKvlDntLnQYLhyW5MI
   invalidActivationToken: invalid-activation-token
+  termsVersion: 2026.03.01
 }

--- a/bruno/terms-of-service/01-get-current-terms-of-service.bru
+++ b/bruno/terms-of-service/01-get-current-terms-of-service.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get current Terms of Service
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/api/terms-of-service/current
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/terms-of-service/02-get-historical-terms-of-service-by-version.bru
+++ b/bruno/terms-of-service/02-get-historical-terms-of-service-by-version.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get historical Terms of Service by version
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{host}}/api/terms-of-service/{{termsVersion}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/terms-of-service/02-get-published-terms-of-service-by-version.bru
+++ b/bruno/terms-of-service/02-get-published-terms-of-service-by-version.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Get historical Terms of Service by version
+  name: Get published Terms of Service by version
   type: http
   seq: 2
 }
 
 get {
-  url: {{host}}/api/terms-of-service/{{termsVersion}}
+  url: {{host}}/api/terms-of-service/{{currentTermsVersion}}
   body: none
   auth: none
 }

--- a/bruno/terms-of-service/03-get-missing-terms-of-service-by-version.bru
+++ b/bruno/terms-of-service/03-get-missing-terms-of-service-by-version.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get missing Terms of Service by version
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{host}}/api/terms-of-service/{{missingTermsVersion}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/CurrentTermsOfServiceNotFoundException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/CurrentTermsOfServiceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class CurrentTermsOfServiceNotFoundException extends RuntimeException {
+
+    public CurrentTermsOfServiceNotFoundException() {
+        super("Current Terms of Service not found");
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceVersionNotFoundException.java
+++ b/customer/src/main/java/com/kartoush/customer/exception/TermsOfServiceVersionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.exception;
+
+public class TermsOfServiceVersionNotFoundException extends RuntimeException {
+
+    public TermsOfServiceVersionNotFoundException(final String version) {
+        super("Terms of Service not found for version: " + version);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/facade/TermsOfServiceFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/facade/TermsOfServiceFacade.java
@@ -1,0 +1,10 @@
+package com.kartoush.customer.facade;
+
+import com.kartoush.customer.facade.model.TermsOfServiceView;
+
+public interface TermsOfServiceFacade {
+
+    TermsOfServiceView getCurrentTermsOfService();
+
+    TermsOfServiceView getTermsOfServiceByVersion(String version);
+}

--- a/customer/src/main/java/com/kartoush/customer/facade/model/TermsOfServiceView.java
+++ b/customer/src/main/java/com/kartoush/customer/facade/model/TermsOfServiceView.java
@@ -1,0 +1,14 @@
+package com.kartoush.customer.facade.model;
+
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
+import java.time.Instant;
+
+public record TermsOfServiceView(
+    String version,
+    String content,
+    TermsOfServiceContentType contentType,
+    TermsOfServiceStatus status,
+    Instant effectiveAt,
+    Instant supersededAt) {
+}

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultTermsOfServiceFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultTermsOfServiceFacade.java
@@ -4,7 +4,6 @@ import com.kartoush.customer.exception.CurrentTermsOfServiceNotFoundException;
 import com.kartoush.customer.exception.TermsOfServiceVersionNotFoundException;
 import com.kartoush.customer.facade.TermsOfServiceFacade;
 import com.kartoush.customer.facade.model.TermsOfServiceView;
-import com.kartoush.customer.internal.registration.TermsOfServiceCatalog;
 import com.kartoush.customer.persistence.entity.TermsOfServiceEntity;
 import com.kartoush.customer.persistence.repository.TermsOfServiceRepository;
 import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
@@ -13,25 +12,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class DefaultTermsOfServiceFacade implements TermsOfServiceFacade {
 
-    private final TermsOfServiceCatalog termsOfServiceCatalog;
     private final TermsOfServiceRepository termsOfServiceRepository;
 
-    public DefaultTermsOfServiceFacade(
-        final TermsOfServiceCatalog termsOfServiceCatalog,
-        final TermsOfServiceRepository termsOfServiceRepository) {
-        this.termsOfServiceCatalog = termsOfServiceCatalog;
+    public DefaultTermsOfServiceFacade(final TermsOfServiceRepository termsOfServiceRepository) {
         this.termsOfServiceRepository = termsOfServiceRepository;
     }
 
     @Override
     public TermsOfServiceView getCurrentTermsOfService() {
-        final TermsOfServiceEntity termsOfService;
-
-        try {
-            termsOfService = termsOfServiceCatalog.currentTerms();
-        } catch (final IllegalStateException exception) {
-            throw new CurrentTermsOfServiceNotFoundException();
-        }
+        final TermsOfServiceEntity termsOfService = termsOfServiceRepository.findByStatus(TermsOfServiceStatus.ACTIVE)
+            .orElseThrow(CurrentTermsOfServiceNotFoundException::new);
 
         return toView(termsOfService);
     }

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultTermsOfServiceFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultTermsOfServiceFacade.java
@@ -1,0 +1,63 @@
+package com.kartoush.customer.internal.facade;
+
+import com.kartoush.customer.exception.CurrentTermsOfServiceNotFoundException;
+import com.kartoush.customer.exception.TermsOfServiceVersionNotFoundException;
+import com.kartoush.customer.facade.TermsOfServiceFacade;
+import com.kartoush.customer.facade.model.TermsOfServiceView;
+import com.kartoush.customer.internal.registration.TermsOfServiceCatalog;
+import com.kartoush.customer.persistence.entity.TermsOfServiceEntity;
+import com.kartoush.customer.persistence.repository.TermsOfServiceRepository;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultTermsOfServiceFacade implements TermsOfServiceFacade {
+
+    private final TermsOfServiceCatalog termsOfServiceCatalog;
+    private final TermsOfServiceRepository termsOfServiceRepository;
+
+    public DefaultTermsOfServiceFacade(
+        final TermsOfServiceCatalog termsOfServiceCatalog,
+        final TermsOfServiceRepository termsOfServiceRepository) {
+        this.termsOfServiceCatalog = termsOfServiceCatalog;
+        this.termsOfServiceRepository = termsOfServiceRepository;
+    }
+
+    @Override
+    public TermsOfServiceView getCurrentTermsOfService() {
+        final TermsOfServiceEntity termsOfService;
+
+        try {
+            termsOfService = termsOfServiceCatalog.currentTerms();
+        } catch (final IllegalStateException exception) {
+            throw new CurrentTermsOfServiceNotFoundException();
+        }
+
+        return toView(termsOfService);
+    }
+
+    @Override
+    public TermsOfServiceView getTermsOfServiceByVersion(final String version) {
+        final TermsOfServiceEntity termsOfService = termsOfServiceRepository.findByVersion(version)
+            .filter(this::isPublished)
+            .orElseThrow(() -> new TermsOfServiceVersionNotFoundException(version));
+
+        return toView(termsOfService);
+    }
+
+    private boolean isPublished(final TermsOfServiceEntity termsOfService) {
+        final TermsOfServiceStatus status = termsOfService.getStatus();
+        return status == TermsOfServiceStatus.ACTIVE || status == TermsOfServiceStatus.SUPERSEDED;
+    }
+
+    private TermsOfServiceView toView(final TermsOfServiceEntity termsOfService) {
+        return new TermsOfServiceView(
+            termsOfService.getVersion(),
+            termsOfService.getContent(),
+            termsOfService.getContentType(),
+            termsOfService.getStatus(),
+            termsOfService.getEffectiveAt(),
+            termsOfService.getSupersededAt()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add public read-only Terms of Service metadata endpoints
- expose current and historical published Terms through a customer facade
- add controller, error handling, integration coverage, and Bruno requests

## Testing
- ./gradlew :app:test --tests com.kartoush.api.terms.TermsOfServiceControllerWebMvcTest
- ./gradlew :app:integrationTest --tests com.kartoush.api.terms.TermsOfServiceMetadataIntegrationTest

Closes #214