### PR TITLE
Reduce app integration test CI maintenance overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: customer-creation-contract
-            test-class: com.kartoush.api.customer.CustomerCreationRestAssuredIntegrationTest
-          - name: customer-duplicate-email-contract
-            test-class: com.kartoush.api.customer.CustomerDuplicateEmailRestAssuredIntegrationTest
-          - name: customer-activation-contract
-            test-class: com.kartoush.api.customer.CustomerActivationIntegrationTest
-          - name: terms-of-service-metadata-contract
-            test-class: com.kartoush.api.terms.TermsOfServiceMetadataIntegrationTest
+          - name: customer-api-contracts
+            test-filter: com.kartoush.api.customer.*
+          - name: terms-of-service-api-contracts
+            test-filter: com.kartoush.api.terms.*
 
     name: App integration tests (${{ matrix.name }})
 
@@ -63,8 +59,8 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
-      - name: Run app integration test class
-        run: ./gradlew --no-daemon :app:integrationTest --tests ${{ matrix.test-class }}
+      - name: Run app integration test group
+        run: ./gradlew --no-daemon :app:integrationTest --tests '${{ matrix.test-filter }}'
 
   customer-integration-tests:
     runs-on: ubuntu-latest

--- a/docs/testing/api-testing-strategy.md
+++ b/docs/testing/api-testing-strategy.md
@@ -237,8 +237,20 @@ The customer create endpoint is a good example of the intended workflow.
 4. let CI enforce the contract
 
    Once the REST Assured coverage is in place, CI runs the app integration
-   test classes and fails the pull request if the contract changes
-   unexpectedly.
+   test groups by stable API package boundaries and fails the pull request if
+   the contract changes unexpectedly.
+
+   App integration CI should not require a workflow edit for each new test
+   class. Grouping by stable package boundaries keeps the workflow
+   maintainable while still allowing parallel execution across API domains.
+
+   Today that means:
+
+   - `com.kartoush.api.customer.*`
+   - `com.kartoush.api.terms.*`
+
+   New integration tests should be added under the correct API package so CI
+   picks them up automatically.
 
 This example is the intended pattern for future endpoints:
 


### PR DESCRIPTION
## Summary
- replace per-class app integration CI entries with stable package-based groups
- keep app integration jobs parallelized by API domain instead of individual test class
- document the CI grouping strategy in the API testing strategy doc

## Testing
- ./gradlew --no-daemon :app:integrationTest --tests 'com.kartoush.api.customer.*'
- ./gradlew --no-daemon :app:integrationTest --tests 'com.kartoush.api.terms.*'

Closes #227