### PR TITLE
Replace nominal MapStruct customer mappers

### DIFF
--- a/customer/src/main/java/com/kartoush/customer/persistence/mapper/ActivationTokenMapper.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/mapper/ActivationTokenMapper.java
@@ -6,12 +6,12 @@ import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import com.kartoush.platform.types.ActivationTokenId;
 import com.kartoush.platform.types.CustomerId;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
-@Mapper(componentModel = "spring")
-public interface ActivationTokenMapper {
+@Component
+public class ActivationTokenMapper {
 
-    default ActivationToken toDomain(ActivationTokenEntity entity) {
+    public ActivationToken toDomain(final ActivationTokenEntity entity) {
         if (entity == null) {
             return null;
         }
@@ -26,21 +26,22 @@ public interface ActivationTokenMapper {
         );
     }
 
-    default ActivationTokenEntity toEntity(ActivationToken domain) {
+    public ActivationTokenEntity toEntity(final ActivationToken domain) {
         if (domain == null) {
             return null;
         }
 
         return ActivationTokenEntity.of(
-            toEmbeddableId(domain.getId()),
-            toEmbeddableId(domain.getCustomerId()),
+            toEmbeddableActivationTokenId(domain.getId()),
+            toEmbeddableCustomerId(domain.getCustomerId()),
             domain.getTokenHash(),
             domain.getExpiresAt(),
             domain.getConsumedAt(),
-            domain.getCreatedAt());
+            domain.getCreatedAt()
+        );
     }
 
-    default ActivationTokenIdEmbeddable toEmbeddableId(ActivationTokenId activationTokenId) {
+    ActivationTokenIdEmbeddable toEmbeddableActivationTokenId(final ActivationTokenId activationTokenId) {
         if (activationTokenId == null) {
             return null;
         }
@@ -48,7 +49,7 @@ public interface ActivationTokenMapper {
         return ActivationTokenIdEmbeddable.from(activationTokenId);
     }
 
-    default CustomerIdEmbeddable toEmbeddableId(CustomerId customerId) {
+    CustomerIdEmbeddable toEmbeddableCustomerId(final CustomerId customerId) {
         if (customerId == null) {
             return null;
         }

--- a/customer/src/main/java/com/kartoush/customer/persistence/mapper/CustomerAddressMapper.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/mapper/CustomerAddressMapper.java
@@ -5,59 +5,55 @@ import com.kartoush.customer.persistence.entity.CustomerAddressEntity;
 import com.kartoush.customer.persistence.entity.CustomerEntity;
 import com.kartoush.customer.persistence.model.AddressIdEmbeddable;
 import com.kartoush.platform.types.AddressId;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
-@Mapper(componentModel = "spring")
-public interface CustomerAddressMapper {
+@Component
+public class CustomerAddressMapper {
 
-    // Entity -> Domain
-    default CustomerAddress toDomain(final CustomerAddressEntity entity) {
+    public CustomerAddress toDomain(final CustomerAddressEntity entity) {
         if (entity == null) {
             return null;
         }
 
         return CustomerAddress.fromPersistence(
-                toDomainAddressId(entity.getId()),
-                entity.getLabel(),
-                entity.getLine1(),
-                entity.getLine2(),
-                entity.getCity(),
-                entity.getStateOrProvince(),
-                entity.getPostalCode(),
-                entity.getCountryCode(),
-                entity.isDefaultShipping(),
-                entity.isDefaultBilling());
+            toDomainAddressId(entity.getId()),
+            entity.getLabel(),
+            entity.getLine1(),
+            entity.getLine2(),
+            entity.getCity(),
+            entity.getStateOrProvince(),
+            entity.getPostalCode(),
+            entity.getCountryCode(),
+            entity.isDefaultShipping(),
+            entity.isDefaultBilling()
+        );
     }
 
-    // Domain -> Entity
-    default CustomerAddressEntity toEntity(
-            final CustomerAddress domain,
-            final CustomerEntity customer)
-    {
+    public CustomerAddressEntity toEntity(final CustomerAddress domain, final CustomerEntity customer) {
         if (domain == null) {
             return null;
         }
 
         return CustomerAddressEntity.of(
-                toEmbeddableAddressId(domain.getId()),
-                customer,
-                domain.getLabel(),
-                domain.getLine1(),
-                domain.getLine2(),
-                domain.getCity(),
-                domain.getStateOrProvince(),
-                domain.getPostalCode(),
-                domain.getCountryCode(),
-                domain.isDefaultShipping(),
-                domain.isDefaultBilling()
+            toEmbeddableAddressId(domain.getId()),
+            customer,
+            domain.getLabel(),
+            domain.getLine1(),
+            domain.getLine2(),
+            domain.getCity(),
+            domain.getStateOrProvince(),
+            domain.getPostalCode(),
+            domain.getCountryCode(),
+            domain.isDefaultShipping(),
+            domain.isDefaultBilling()
         );
     }
 
-    default AddressIdEmbeddable toEmbeddableAddressId(AddressId id) {
+    AddressIdEmbeddable toEmbeddableAddressId(final AddressId id) {
         return id == null ? null : AddressIdEmbeddable.from(id);
     }
 
-    default AddressId toDomainAddressId(AddressIdEmbeddable id) {
+    AddressId toDomainAddressId(final AddressIdEmbeddable id) {
         return id == null ? null : id.toAddressId();
     }
 }


### PR DESCRIPTION
## Summary
- replace CustomerAddressMapper and ActivationTokenMapper MapStruct interfaces with plain Spring components
- keep the handwritten mapping behavior unchanged while removing generated bean indirection
- preserve customer and activation-token flow behavior without API or schema changes

## Testing
- ./gradlew :customer:test --tests com.kartoush.customer.service.impl.DefaultCustomerServiceTest --tests com.kartoush.customer.service.impl.DefaultActivationTokenServiceTest --tests com.kartoush.customer.internal.facade.DefaultCustomerFacadeTest
- ./gradlew :app:integrationTest --tests com.kartoush.api.customer.CustomerCreationRestAssuredIntegrationTest --tests com.kartoush.api.customer.CustomerActivationIntegrationTest

Closes #232