### PR TITLE
Clarify customer request boundary and validation ownership

### DIFF
--- a/app/src/main/java/com/kartoush/api/customer/CustomerController.java
+++ b/app/src/main/java/com/kartoush/api/customer/CustomerController.java
@@ -62,7 +62,7 @@ public class CustomerController {
     })
     @PostMapping
     public ResponseEntity<CustomerView> createCustomer(
-        @Valid @RequestBody final CreateCustomerRequest request) {
+        @RequestBody final CreateCustomerRequest request) {
 
         LOG.info("Received create customer request for email={}", request.email());
 
@@ -84,7 +84,7 @@ public class CustomerController {
     @PutMapping("/{customerId}")
     public ResponseEntity<CustomerView> updateCustomer(
         @PathVariable final String customerId,
-        @Valid @RequestBody final UpdateCustomerRequest request) {
+        @RequestBody final UpdateCustomerRequest request) {
 
         return ResponseEntity.ok(customerFacade.updateCustomer(customerId, request));
     }

--- a/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/facade/model/CreateCustomerRequest.java
@@ -2,7 +2,10 @@ package com.kartoush.customer.facade.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CreateCustomerRequest", description = "Request payload for creating a customer")
+@Schema(
+    name = "CreateCustomerRequest",
+    description = "Shared API and facade request payload for creating a customer; validated by the customer facade layer"
+)
 public record CreateCustomerRequest(
 
     @Schema(

--- a/customer/src/main/java/com/kartoush/customer/facade/model/UpdateCustomerRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/facade/model/UpdateCustomerRequest.java
@@ -2,7 +2,10 @@ package com.kartoush.customer.facade.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "UpdateCustomerRequest", description = "Request payload for updating customer profile fields")
+@Schema(
+    name = "UpdateCustomerRequest",
+    description = "Shared API and facade request payload for updating customer profile fields; validated by the customer facade layer"
+)
 public record UpdateCustomerRequest(
 
     @Schema(

--- a/docs/architecture/decisions/0020-use-dedicated-contract-models-for-public-module-facades.md
+++ b/docs/architecture/decisions/0020-use-dedicated-contract-models-for-public-module-facades.md
@@ -48,3 +48,22 @@ public interface CustomerFacade {
 
     Optional<CustomerView> getCustomerById(CustomerId customerId);
 }
+
+## Current Customer Boundary
+
+The current Customer module uses `CreateCustomerRequest` and
+`UpdateCustomerRequest` as shared contracts between the `app` module and the
+customer facade.
+
+This means:
+
+- the request models live in the customer facade contract package
+- the controller binds HTTP JSON directly into those shared request models
+- create and update validation is owned by `CreateCustomerRequestValidator`
+  and `UpdateCustomerRequestValidator` in the customer facade layer
+- controller-level Jakarta Bean Validation should only be used where the
+  request type actually declares Jakarta validation constraints
+
+This is an intentional current-state boundary, not an app-layer request-model
+split. If that boundary changes later, it should be handled by a separate
+architectural decision rather than inferred from controller annotations.


### PR DESCRIPTION
## Summary
- remove misleading controller-level @Valid usage from create and update customer endpoints
- document that customer create and update request models are shared API and facade contracts
- make facade-level validation ownership explicit in the request-boundary ADR

## Testing
- ./gradlew :app:test --tests com.kartoush.api.customer.CustomerControllerWebMvcTest
- ./gradlew :customer:test --tests com.kartoush.customer.internal.validation.CreateCustomerRequestValidatorTest --tests com.kartoush.customer.internal.validation.UpdateCustomerRequestValidatorTest --tests com.kartoush.customer.internal.facade.DefaultCustomerFacadeTest

Closes #233