### PR TITLE
Add importer status and project config support

### DIFF
--- a/.github/issue-import/.gitignore
+++ b/.github/issue-import/.gitignore
@@ -1,6 +1,8 @@
 *
 !.gitkeep
 !README.md
+!config.env
+!config.local.env.example
 !pending/
 !pending/.gitkeep
 !imported/
@@ -9,3 +11,4 @@
 !failed/.gitkeep
 !templates/
 !templates/*.md
+config.local.env

--- a/.github/issue-import/README.md
+++ b/.github/issue-import/README.md
@@ -5,6 +5,24 @@ It is designed for importing pre-written issue definitions from markdown files,
 creating the issues in GitHub, linking sub-issues to parent issues, and keeping
 the file lifecycle visible in the repository.
 
+## Configuration
+
+Importer settings are loaded in this precedence order:
+
+- shell environment variables
+- `.github/issue-import/config.local.env`
+- `.github/issue-import/config.env`
+- script fallback defaults for supported settings
+
+Use this pattern:
+
+- keep shared repo defaults in `config.env`
+- copy `config.local.env.example` to `config.local.env` for machine-specific overrides
+- do not commit `config.local.env`
+- treat the default imported status as a fixed importer rule: `Backlog`
+
+This avoids editing tracked project settings locally and accidentally overwriting them in Git.
+
 ## Directory Layout
 
 - `pending/`
@@ -51,6 +69,7 @@ Optional metadata:
 
 - `Parent:`
 - `Labels:`
+- `Status:`
 
 Rules:
 
@@ -62,6 +81,7 @@ Rules:
 - `Title:` is required
 - `Parent:` is optional
 - `Labels:` is optional and accepts comma-separated label names
+- `Status:` is optional and defaults to `Backlog`
 - dependency references belong in a markdown `Dependencies` section in the body,
   not in the metadata header
 
@@ -89,6 +109,7 @@ Example child task:
 Title: Task: Validate sub-issue linking during import
 Parent: Epic: Issue Import and Workflow Tooling
 Labels: enhancement, application
+Status: Backlog
 
 ### Summary
 
@@ -132,6 +153,7 @@ The task template also shows:
 - how to use `Parent: #123` when the parent issue number is already known
 - where to list `Dependencies` using source file names or GitHub issue numbers that the importer can resolve
 - how to provide optional comma-separated `Labels:` metadata
+- how to provide optional `Status:` metadata, with `Backlog` used when omitted
 
 Recommended workflow:
 
@@ -156,6 +178,99 @@ You can also print a template directly from the importer:
 
 Template files must remain outside `pending/` so they are not imported
 accidentally.
+
+## AI Prompt Snippets
+
+If you want ChatGPT or Codex to generate import-ready markdown, give it one of
+these prompts and tell it to output raw markdown only.
+
+Prompt for a standalone task:
+
+```text
+Generate a GitHub issue import task file for the Kartoush importer.
+
+Requirements:
+- Output raw markdown only
+- Use this exact metadata header order:
+  Title:
+  Labels:
+  Status:
+- Leave a single blank line after metadata
+- Use these sections in this exact order:
+  ## Summary
+  ## Scope
+  ## Acceptance Criteria
+  ## Dependencies
+  ## Notes
+- Use flat bullet lists only
+- Do not include YAML front matter
+- Do not include commentary before or after the markdown
+- Do not wrap prose early unless needed for a list item
+- When status is unknown, use: Status: Backlog
+- When there are no dependencies, use:
+  ## Dependencies
+  - None
+
+Task details:
+[PASTE TASK DETAILS HERE]
+```
+
+Prompt for an epic-linked task:
+
+```text
+Generate a GitHub issue import task file for the Kartoush importer.
+
+Requirements:
+- Output raw markdown only
+- Use this exact metadata header order:
+  Title:
+  Parent:
+  Labels:
+  Status:
+- Leave a single blank line after metadata
+- Use these sections in this exact order:
+  ## Summary
+  ## Scope
+  ## Acceptance Criteria
+  ## Dependencies
+  ## Notes
+- Use flat bullet lists only
+- Do not include YAML front matter
+- Do not include commentary before or after the markdown
+- Do not wrap prose early unless needed for a list item
+- Use `Parent: #<issue-number>` when the epic number is known
+- When status is unknown, use: Status: Backlog
+- When there are no dependencies, use:
+  ## Dependencies
+  - None
+
+Task details:
+[PASTE TASK DETAILS HERE]
+```
+
+Prompt to review an existing task file for importer compatibility:
+
+```text
+Review this markdown file for compatibility with the Kartoush GitHub issue importer.
+
+Check:
+1. Metadata header contains only supported keys at the top of the file
+2. Metadata header is followed by exactly one blank line
+3. Required metadata is present
+4. `Labels:` is comma-separated if present
+5. `Status:` is a valid Kartoush project status if present
+6. Sections are present and ordered correctly
+7. `Dependencies` uses bullet list entries
+8. No YAML front matter or extra prose appears before metadata ends
+
+Output:
+- Valid
+- Problems
+- Corrected raw markdown
+
+Markdown to review:
+[PASTE MARKDOWN HERE]
+```
 
 ## Parent Resolution
 
@@ -200,6 +315,21 @@ existing GitHub labels.
 - ignored labels are reported as warnings in the importer output
 - when the title starts with `[Task]`, `Task:`, `[Epic]`, or `Epic:`, the importer automatically adds the corresponding `task` or `epic` label if it is not already present
 
+## Status Handling
+
+`Status:` can be defined as metadata, for example:
+
+```md
+Status: In Progress
+```
+
+During import, the script applies the effective status to the GitHub project item.
+
+- when `Status:` is omitted, the importer defaults to `Backlog`
+- when `Status:` is valid, that value is applied
+- when `Status:` is invalid, the importer warns and falls back to `Backlog`
+- dry-run output shows the effective status that would be applied
+
 ## Import Script
 
 The main import entrypoint is:
@@ -217,7 +347,11 @@ Optional flag:
 Environment variables supported by the script:
 
 - `REPO`
-  Defaults to `jbolous/kartoush`
+  Defaults to the resolved value from `config.local.env`, then `config.env`, then `jbolous/kartoush`
+- `PROJECT_ID`
+  Optional explicit GitHub ProjectV2 node id. When set, the importer uses this project directly.
+- `PROJECT_TITLE`
+  Defaults to the resolved value from `config.local.env`, then `config.env`, then `Kartoush - MVP`. When `PROJECT_ID` is not set, the importer resolves the target project by exact title match against the repository owner.
 - `IMPORT_ROOT`
   Defaults to `.github/issue-import`
 - `PENDING_DIR`
@@ -238,6 +372,8 @@ Pass 1: create issues
 - reads each `pending/*.md` file
 - parses `Title:` and optional `Parent:`
 - parses optional `Labels:`
+- parses optional `Status:` and resolves the effective project status
+- resolves the target project using `PROJECT_ID` when provided, otherwise by exact `PROJECT_TITLE` match
 - appends this footer to the GitHub issue body:
 
   ```html
@@ -255,6 +391,7 @@ Pass 1: create issues
 
 Pass 2: link sub-issues and move files
 
+- applies the effective project status to the GitHub project item
 - resolves each `Parent:` value
 - resolves dependency source-file references from any `Dependencies` section
 - updates issue bodies to replace resolved dependency references with GitHub
@@ -314,6 +451,24 @@ Import into a different repository:
 
 ```bash
 REPO=your-org/your-repo .github/scripts/import-issues.sh
+```
+
+Use a local override file for machine-specific settings:
+
+```bash
+cp .github/issue-import/config.local.env.example .github/issue-import/config.local.env
+```
+
+Import into a different project title owned by the repo owner:
+
+```bash
+PROJECT_TITLE="Kartoush - Roadmap" .github/scripts/import-issues.sh
+```
+
+Import into an explicit project id:
+
+```bash
+PROJECT_ID=PVT_xxxxxxxxxxxxxxxxxx .github/scripts/import-issues.sh
 ```
 
 ### Quick Start

--- a/.github/issue-import/config.env
+++ b/.github/issue-import/config.env
@@ -1,0 +1,2 @@
+REPO=jbolous/kartoush
+PROJECT_TITLE=Kartoush - MVP

--- a/.github/issue-import/config.local.env.example
+++ b/.github/issue-import/config.local.env.example
@@ -1,0 +1,6 @@
+# Copy this file to config.local.env for machine-specific overrides.
+# Values in your shell environment take precedence over this file.
+
+# REPO=jbolous/kartoush
+# PROJECT_TITLE=Kartoush - MVP
+# PROJECT_ID=PVT_xxxxxxxxxxxxxxxxxx

--- a/.github/issue-import/templates/task-template.md
+++ b/.github/issue-import/templates/task-template.md
@@ -1,6 +1,7 @@
 Title: [Task]: Replace with task title
 Parent: [Epic]: Replace with epic title
 Labels: enhancement, application
+Status: Backlog
 
 <!--
 Alternative parent format when the GitHub issue number is already known:
@@ -8,6 +9,7 @@ Parent: #123
 
 Remove the Parent line when creating a standalone task.
 Remove the Labels line when no labels should be applied.
+Remove the Status line to use the importer default of Backlog.
 Labels that do not exist in GitHub are ignored during import.
 -->
 

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -6,6 +6,14 @@ DRY_RUN="false"
 ASSIGN_TO_SELF="false"
 PRINT_TEMPLATE=""
 declare -A REPO_LABELS
+declare -A PROJECT_STATUS_OPTIONS
+
+DEFAULT_STATUS="Backlog"
+PROJECT_ID="${PROJECT_ID:-}"
+PROJECT_TITLE="${PROJECT_TITLE:-}"
+PROJECT_STATUS_FIELD_ID=""
+IMPORT_CONFIG_FILE=""
+IMPORT_LOCAL_CONFIG_FILE=""
 
 print_help() {
   cat <<'EOF'
@@ -101,6 +109,49 @@ AUTHENTICATED_USER=""
 
 setup_repo_paths
 
+load_import_config() {
+  local default_config_file
+  local local_config_file
+  local config_value
+
+  default_config_file="${IMPORT_ROOT}/config.env"
+  local_config_file="${IMPORT_ROOT}/config.local.env"
+
+  IMPORT_CONFIG_FILE="$default_config_file"
+  IMPORT_LOCAL_CONFIG_FILE="$local_config_file"
+
+  if [[ -z "${REPO:-}" ]]; then
+    if config_value="$(read_config_value "$local_config_file" "REPO" 2>/dev/null)"; then
+      REPO="$config_value"
+    elif config_value="$(read_config_value "$default_config_file" "REPO" 2>/dev/null)"; then
+      REPO="$config_value"
+    else
+      REPO="jbolous/kartoush"
+    fi
+  fi
+
+  if [[ -z "$PROJECT_TITLE" ]]; then
+    if config_value="$(read_config_value "$local_config_file" "PROJECT_TITLE" 2>/dev/null)"; then
+      PROJECT_TITLE="$config_value"
+    elif config_value="$(read_config_value "$default_config_file" "PROJECT_TITLE" 2>/dev/null)"; then
+      PROJECT_TITLE="$config_value"
+    else
+      PROJECT_TITLE="Kartoush - MVP"
+    fi
+  fi
+
+  if [[ -z "$PROJECT_ID" ]]; then
+    if config_value="$(read_config_value "$local_config_file" "PROJECT_ID" 2>/dev/null)"; then
+      PROJECT_ID="$config_value"
+    elif config_value="$(read_config_value "$default_config_file" "PROJECT_ID" 2>/dev/null)"; then
+      PROJECT_ID="$config_value"
+    fi
+  fi
+
+}
+
+load_import_config
+
 if [[ -n "$PRINT_TEMPLATE" ]]; then
   print_template "$PRINT_TEMPLATE"
   exit 0
@@ -108,6 +159,8 @@ fi
 
 declare -A FILE_PARENT
 declare -A FILE_LABELS
+declare -A FILE_STATUS
+declare -A FILE_EFFECTIVE_STATUS
 declare -A FILE_ISSUE_NUMBER
 declare -A FILE_ISSUE_ID
 declare -A FILE_ISSUE_URL
@@ -125,6 +178,7 @@ parse_metadata() {
   local title=""
   local parent=""
   local labels=""
+  local status=""
   local body_file
   local in_metadata="true"
 
@@ -141,6 +195,8 @@ parse_metadata() {
         parent="$(trim "${line#Parent:}")"
       elif [[ "$line" == Labels:* ]]; then
         labels="$(trim "${line#Labels:}")"
+      elif [[ "$line" == Status:* ]]; then
+        status="$(trim "${line#Status:}")"
       else
         print_verbose "Invalid metadata line in $(basename "$file"): $line"
         rm -f "$body_file"
@@ -160,6 +216,7 @@ parse_metadata() {
   PARSED_TITLE="$title"
   PARSED_PARENT="$parent"
   PARSED_LABELS="$labels"
+  PARSED_STATUS="$status"
   PARSED_BODY_FILE="$body_file"
 }
 
@@ -211,6 +268,259 @@ load_repo_labels() {
     [[ -n "$label_name" ]] || continue
     REPO_LABELS["$label_name"]="true"
   done <<< "$gh_output"
+}
+
+resolve_project_id() {
+  local owner_login
+  local owner_type
+  local project_nodes
+  local match_count
+  local resolved_project_id
+  local owner_type_output
+  local gh_exit_code
+
+  if [[ -n "$PROJECT_ID" ]]; then
+    return 0
+  fi
+
+  owner_login="${REPO%%/*}"
+
+  set +e
+  owner_type_output="$(
+    gh api "/users/$owner_login" --jq '.type' 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "project owner type lookup failed: $owner_type_output"
+    return 1
+  fi
+
+  owner_type="$owner_type_output"
+
+  case "$owner_type" in
+    User)
+      set +e
+      project_nodes="$(
+        gh api graphql \
+          -F owner="$owner_login" \
+          -f query='query($owner: String!) {
+            user(login: $owner) {
+              projectsV2(first: 100) {
+                nodes {
+                  id
+                  title
+                }
+              }
+            }
+          }' \
+          --jq '.data.user.projectsV2.nodes[]? | select(.title != null) | "\(.title)\t\(.id)"' 2>&1
+      )"
+      gh_exit_code=$?
+      set -e
+      ;;
+    Organization)
+      set +e
+      project_nodes="$(
+        gh api graphql \
+          -F owner="$owner_login" \
+          -f query='query($owner: String!) {
+            organization(login: $owner) {
+              projectsV2(first: 100) {
+                nodes {
+                  id
+                  title
+                }
+              }
+            }
+          }' \
+          --jq '.data.organization.projectsV2.nodes[]? | select(.title != null) | "\(.title)\t\(.id)"' 2>&1
+      )"
+      gh_exit_code=$?
+      set -e
+      ;;
+    *)
+      print_verbose "Unsupported project owner type '$owner_type' for '$owner_login'"
+      return 1
+      ;;
+  esac
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "project lookup by title failed: $project_nodes"
+    return 1
+  fi
+
+  match_count=0
+  resolved_project_id=""
+  while IFS=$'\t' read -r project_title project_id || [[ -n "$project_title" ]]; do
+    [[ -n "$project_title" && -n "$project_id" ]] || continue
+    if [[ "$project_title" == "$PROJECT_TITLE" ]]; then
+      match_count=$((match_count + 1))
+      resolved_project_id="$project_id"
+    fi
+  done <<< "$project_nodes"
+
+  if (( match_count == 1 )); then
+    PROJECT_ID="$resolved_project_id"
+    return 0
+  fi
+
+  if (( match_count > 1 )); then
+    print_verbose "Multiple projects matched title '$PROJECT_TITLE' for owner '$owner_login'"
+    return 1
+  fi
+
+  print_verbose "No project matched title '$PROJECT_TITLE' for owner '$owner_login'"
+  return 1
+}
+
+load_project_status_options() {
+  local field_id
+  local status_options_output
+  local gh_exit_code
+  local status_name
+  local option_id
+
+  set +e
+  field_id="$(
+    gh api graphql \
+      -F id="$PROJECT_ID" \
+      -f query='query($id: ID!) { node(id: $id) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name } } } } } }' \
+      --jq '.data.node.fields.nodes[] | select(.name=="Status") | .id' 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 || -z "$field_id" ]]; then
+    print_verbose "project status field lookup failed: $field_id"
+    return 1
+  fi
+
+  PROJECT_STATUS_FIELD_ID="$field_id"
+
+  set +e
+  status_options_output="$(
+    gh api graphql \
+      -F id="$PROJECT_ID" \
+      -f query='query($id: ID!) { node(id: $id) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }' \
+      --jq '.data.node.fields.nodes[] | select(.name=="Status") | .options[] | "\(.name)\t\(.id)"' 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    print_verbose "project status option lookup failed: $status_options_output"
+    return 1
+  fi
+
+  while IFS=$'\t' read -r status_name option_id || [[ -n "$status_name" ]]; do
+    [[ -n "$status_name" && -n "$option_id" ]] || continue
+    PROJECT_STATUS_OPTIONS["$status_name"]="$option_id"
+  done <<< "$status_options_output"
+
+  [[ -n "${PROJECT_STATUS_OPTIONS[$DEFAULT_STATUS]:-}" ]]
+}
+
+resolve_effective_status() {
+  local requested_status="$1"
+
+  if [[ -z "$requested_status" ]]; then
+    EFFECTIVE_STATUS="$DEFAULT_STATUS"
+    STATUS_FALLBACK_REASON=""
+    return 0
+  fi
+
+  if [[ -n "${PROJECT_STATUS_OPTIONS[$requested_status]:-}" ]]; then
+    EFFECTIVE_STATUS="$requested_status"
+    STATUS_FALLBACK_REASON=""
+    return 0
+  fi
+
+  EFFECTIVE_STATUS="$DEFAULT_STATUS"
+  STATUS_FALLBACK_REASON="invalid"
+}
+
+lookup_project_item_id() {
+  local issue_number="$1"
+  local item_id
+  local gh_exit_code
+
+  set +e
+  item_id="$(
+    gh api graphql \
+      -F owner="${REPO%%/*}" \
+      -F repo="${REPO##*/}" \
+      -F number="$issue_number" \
+      -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { issue(number: $number) { projectItems(first: 20) { nodes { id project { id } } } } } }' \
+      --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id" 2>&1
+  )"
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 || -z "$item_id" ]]; then
+    return 1
+  fi
+
+  LOOKED_UP_PROJECT_ITEM_ID="$item_id"
+}
+
+lookup_project_item_id_with_retry() {
+  local issue_number="$1"
+  local max_attempts="${2:-5}"
+  local sleep_seconds="${3:-1}"
+  local attempt=1
+
+  while (( attempt <= max_attempts )); do
+    if lookup_project_item_id "$issue_number"; then
+      return 0
+    fi
+
+    if (( attempt == max_attempts )); then
+      return 1
+    fi
+
+    sleep "$sleep_seconds"
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
+apply_project_status() {
+  local issue_number="$1"
+  local status_name="$2"
+  local option_id
+
+  option_id="${PROJECT_STATUS_OPTIONS[$status_name]}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    print_info "  [DRY RUN] Status: $status_name"
+    return 0
+  fi
+
+  if ! lookup_project_item_id_with_retry "$issue_number"; then
+    return 1
+  fi
+
+  print_verbose "Executing: gh api graphql updateProjectV2ItemFieldValue for issue #$issue_number status '$status_name'"
+
+  set +e
+  gh api graphql \
+    -f query='mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) { updateProjectV2ItemFieldValue(input: { projectId: $project, itemId: $item, fieldId: $field, value: { singleSelectOptionId: $option } }) { projectV2Item { id } } }' \
+    -F project="$PROJECT_ID" \
+    -F item="$LOOKED_UP_PROJECT_ITEM_ID" \
+    -F field="$PROJECT_STATUS_FIELD_ID" \
+    -F option="$option_id" >/dev/null 2>&1
+  local gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    return 1
+  fi
+
+  print_success "  Status"
+  printf '    %s\n' "$status_name"
 }
 
 parse_label_list() {
@@ -286,6 +596,17 @@ if ! load_repo_labels; then
   exit 1
 fi
 
+if ! resolve_project_id; then
+  print_error "✗ Unable to resolve project '$PROJECT_TITLE'"
+  print_info "  Set PROJECT_ID explicitly or update PROJECT_TITLE"
+  exit 1
+fi
+
+if ! load_project_status_options; then
+  print_error "✗ Unable to load project status options"
+  exit 1
+fi
+
 if [[ "$ASSIGN_TO_SELF" == "true" ]]; then
   if ! lookup_authenticated_user; then
     print_error "✗ Unable to determine authenticated GitHub user"
@@ -304,6 +625,12 @@ print_verbose "ASSIGN_TO_SELF=$ASSIGN_TO_SELF"
 if [[ -n "$AUTHENTICATED_USER" ]]; then
   print_verbose "AUTHENTICATED_USER=$AUTHENTICATED_USER"
 fi
+print_verbose "IMPORT_CONFIG_FILE=$IMPORT_CONFIG_FILE"
+print_verbose "IMPORT_LOCAL_CONFIG_FILE=$IMPORT_LOCAL_CONFIG_FILE"
+print_verbose "PROJECT_TITLE=$PROJECT_TITLE"
+print_verbose "PROJECT_ID=$PROJECT_ID"
+print_verbose "DEFAULT_STATUS=$DEFAULT_STATUS"
+print_verbose "PROJECT_STATUS_FIELD_ID=$PROJECT_STATUS_FIELD_ID"
 
 append_footer() {
   local body_file="$1"
@@ -822,9 +1149,22 @@ for file in "${files[@]}"; do
   else
     print_verbose "Parsed labels: <none>"
   fi
+  if [[ -n "$PARSED_STATUS" ]]; then
+    print_verbose "Parsed status: $PARSED_STATUS"
+  else
+    print_verbose "Parsed status: <default>"
+  fi
 
   FILE_PARENT["$file"]="$PARSED_PARENT"
   FILE_LABELS["$file"]="$PARSED_LABELS"
+  FILE_STATUS["$file"]="$PARSED_STATUS"
+
+  resolve_effective_status "$PARSED_STATUS"
+  FILE_EFFECTIVE_STATUS["$file"]="$EFFECTIVE_STATUS"
+
+  if [[ -n "$STATUS_FALLBACK_REASON" ]]; then
+    emit_warning "  Warning: invalid status '$PARSED_STATUS'; defaulting to '$DEFAULT_STATUS'"
+  fi
 
   parse_label_list "$PARSED_LABELS"
   add_inferred_type_label "$PARSED_TITLE"
@@ -843,6 +1183,13 @@ for file in "${files[@]}"; do
     for invalid_label in "${FILTERED_INVALID_LABELS[@]}"; do
       emit_warning "  Warning: ignoring unknown label '$invalid_label'"
     done
+  fi
+
+  printf '  Status\n'
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf '    [DRY RUN] %s\n' "${FILE_EFFECTIVE_STATUS[$file]}"
+  else
+    printf '    %s\n' "${FILE_EFFECTIVE_STATUS[$file]}"
   fi
 
   parse_existing_issue_metadata "$file"
@@ -902,6 +1249,7 @@ for file in "${files[@]}"; do
   num="${FILE_ISSUE_NUMBER[$file]}"
   id="${FILE_ISSUE_ID[$file]}"
   url="${FILE_ISSUE_URL[$file]}"
+  effective_status="${FILE_EFFECTIVE_STATUS[$file]}"
 
   parse_metadata "$file"
   rewrite_dependencies_in_body_file "$PARSED_BODY_FILE"
@@ -934,6 +1282,13 @@ for file in "${files[@]}"; do
   fi
 
   rm -f "$PARSED_BODY_FILE" "$REWRITTEN_BODY_FILE"
+
+  if ! apply_project_status "$num" "$effective_status"; then
+    move_to_failed "$file" "Project status update failed" "true" "$num" "$url"
+    print_warning "  Issue #$num was created but project status update failed"
+    printf '\n'
+    continue
+  fi
 
   if [[ -n "$parent" ]]; then
     if resolve_parent_issue_number "$parent"; then

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -443,26 +443,50 @@ resolve_effective_status() {
 
 lookup_project_item_id() {
   local issue_number="$1"
+  local cursor=""
   local item_id
+  local response
+  local has_next_page
+  local end_cursor
   local gh_exit_code
 
-  set +e
-  item_id="$(
-    gh api graphql \
-      -F owner="${REPO%%/*}" \
-      -F repo="${REPO##*/}" \
-      -F number="$issue_number" \
-      -f query='query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { issue(number: $number) { projectItems(first: 20) { nodes { id project { id } } } } } }' \
-      --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id" 2>&1
-  )"
-  gh_exit_code=$?
-  set -e
+  while true; do
+    set +e
+    response="$(
+      gh api graphql \
+        -F owner="${REPO%%/*}" \
+        -F repo="${REPO##*/}" \
+        -F number="$issue_number" \
+        -F cursor="$cursor" \
+        -f query='query($owner: String!, $repo: String!, $number: Int!, $cursor: String) { repository(owner: $owner, name: $repo) { issue(number: $number) { projectItems(first: 100, after: $cursor) { nodes { id project { id } } pageInfo { hasNextPage endCursor } } } } }' 2>&1
+    )"
+    gh_exit_code=$?
+    set -e
 
-  if [[ $gh_exit_code -ne 0 || -z "$item_id" ]]; then
-    return 1
-  fi
+    if [[ $gh_exit_code -ne 0 ]]; then
+      return 1
+    fi
 
-  LOOKED_UP_PROJECT_ITEM_ID="$item_id"
+    item_id="$(jq -r --arg project_id "$PROJECT_ID" '.data.repository.issue.projectItems.nodes[]? | select(.project.id == $project_id) | .id' <<<"$response")"
+    if [[ -n "$item_id" ]]; then
+      LOOKED_UP_PROJECT_ITEM_ID="$item_id"
+      return 0
+    fi
+
+    has_next_page="$(jq -r '.data.repository.issue.projectItems.pageInfo.hasNextPage // false' <<<"$response")"
+    if [[ "$has_next_page" != "true" ]]; then
+      return 1
+    fi
+
+    end_cursor="$(jq -r '.data.repository.issue.projectItems.pageInfo.endCursor // empty' <<<"$response")"
+    if [[ -z "$end_cursor" ]]; then
+      return 1
+    fi
+
+    cursor="$end_cursor"
+  done
+
+  return 1
 }
 
 lookup_project_item_id_with_retry() {
@@ -487,9 +511,48 @@ lookup_project_item_id_with_retry() {
   return 1
 }
 
+add_issue_to_project() {
+  local issue_id="$1"
+  local gh_exit_code
+
+  print_verbose "Executing: gh api graphql addProjectV2ItemById for issue id '$issue_id'"
+
+  set +e
+  gh api graphql \
+    -f query='mutation($project: ID!, $content: ID!) { addProjectV2ItemById(input: { projectId: $project, contentId: $content }) { item { id } } }' \
+    -F project="$PROJECT_ID" \
+    -F content="$issue_id" >/dev/null 2>&1
+  gh_exit_code=$?
+  set -e
+
+  if [[ $gh_exit_code -ne 0 ]]; then
+    return 1
+  fi
+}
+
+ensure_project_item_id() {
+  local issue_number="$1"
+  local issue_id="$2"
+
+  if lookup_project_item_id_with_retry "$issue_number"; then
+    return 0
+  fi
+
+  if [[ -z "$issue_id" ]]; then
+    return 1
+  fi
+
+  if ! add_issue_to_project "$issue_id"; then
+    return 1
+  fi
+
+  lookup_project_item_id_with_retry "$issue_number"
+}
+
 apply_project_status() {
   local issue_number="$1"
   local status_name="$2"
+  local issue_id="$3"
   local option_id
 
   option_id="${PROJECT_STATUS_OPTIONS[$status_name]}"
@@ -499,7 +562,7 @@ apply_project_status() {
     return 0
   fi
 
-  if ! lookup_project_item_id_with_retry "$issue_number"; then
+  if ! ensure_project_item_id "$issue_number" "$issue_id"; then
     return 1
   fi
 
@@ -1283,7 +1346,7 @@ for file in "${files[@]}"; do
 
   rm -f "$PARSED_BODY_FILE" "$REWRITTEN_BODY_FILE"
 
-  if ! apply_project_status "$num" "$effective_status"; then
+  if ! apply_project_status "$num" "$effective_status" "$id"; then
     move_to_failed "$file" "Project status update failed" "true" "$num" "$url"
     print_warning "  Issue #$num was created but project status update failed"
     printf '\n'

--- a/.github/scripts/issue-import-common.sh
+++ b/.github/scripts/issue-import-common.sh
@@ -62,13 +62,48 @@ setup_repo_paths() {
   SCRIPT_DIR="$(cd -P "$(dirname "$source")" && pwd)"
   REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-  REPO="${REPO:-jbolous/kartoush}"
+  REPO="${REPO:-}"
   IMPORT_ROOT="${IMPORT_ROOT:-$REPO_ROOT/.github/issue-import}"
   PENDING_DIR="${PENDING_DIR:-$IMPORT_ROOT/pending}"
   IMPORTED_DIR="${IMPORTED_DIR:-$IMPORT_ROOT/imported}"
   FAILED_DIR="${FAILED_DIR:-$IMPORT_ROOT/failed}"
 
   mkdir -p "$PENDING_DIR" "$IMPORTED_DIR" "$FAILED_DIR"
+}
+
+read_config_value() {
+  local file="$1"
+  local key="$2"
+  local line
+  local parsed_key
+  local parsed_value
+
+  [[ -f "$file" ]] || return 1
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -n "$line" ]] || continue
+    [[ "$line" == \#* ]] && continue
+    [[ "$line" == *"="* ]] || continue
+
+    parsed_key="${line%%=*}"
+    parsed_value="${line#*=}"
+    parsed_key="$(trim "$parsed_key")"
+    parsed_value="$(trim "$parsed_value")"
+
+    if [[ "$parsed_value" =~ ^\"(.*)\"$ ]]; then
+      parsed_value="${BASH_REMATCH[1]}"
+    elif [[ "$parsed_value" =~ ^\'(.*)\'$ ]]; then
+      parsed_value="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ "$parsed_key" == "$key" ]]; then
+      printf '%s\n' "$parsed_value"
+      return 0
+    fi
+  done < "$file"
+
+  return 1
 }
 
 preflight_common() {


### PR DESCRIPTION
## Summary
- add `Status:` support to imported issue metadata with `Backlog` as the fixed default
- resolve the target project from config using `PROJECT_TITLE`, with `PROJECT_ID` as an explicit override
- add tracked importer defaults plus ignored local override config files and document the workflow

## Verification
- `bash -n .github/scripts/import-issues.sh .github/scripts/issue-import-common.sh`
- `.github/scripts/import-issues.sh --dry-run --verbose`
- `.github/scripts/import-issues.sh --verbose`

Closes #243"