### PR TITLE
Document customer and terms OpenAPI error contracts

### DIFF
--- a/app/src/main/java/com/kartoush/api/customer/CustomerController.java
+++ b/app/src/main/java/com/kartoush/api/customer/CustomerController.java
@@ -1,12 +1,21 @@
 package com.kartoush.api.customer;
 
+import com.kartoush.api.docs.ApiProblemResponse;
+import com.kartoush.api.docs.CustomerIdParameter;
+import com.kartoush.api.docs.CustomerNotFoundApiResponse;
+import com.kartoush.api.docs.InternalServerErrorApiResponse;
+import com.kartoush.api.docs.ValidationFailedApiResponse;
 import com.kartoush.customer.facade.CustomerFacade;
 import com.kartoush.customer.facade.model.CreateCustomerInput;
 import com.kartoush.customer.facade.model.CustomerView;
 import com.kartoush.customer.facade.model.UpdateCustomerInput;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +34,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/customers")
+@Tag(name = "Customers", description = "Public customer registration and lifecycle operations.")
 public class CustomerController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CustomerController.class);
@@ -35,33 +45,82 @@ public class CustomerController {
         this.customerFacade = customerFacade;
     }
 
-    @Operation(summary = "Get all customers")
+    @Operation(
+        summary = "List customers",
+        description = "Returns all customers currently visible through the customer API."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Customers retrieved successfully")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Customers retrieved successfully",
+            content = @Content(
+                mediaType = "application/json",
+                array = @ArraySchema(schema = @Schema(implementation = CustomerView.class))
+            )
+        )
     })
+    @InternalServerErrorApiResponse
     @GetMapping
     public ResponseEntity<List<CustomerView>> getCustomers() {
         return ResponseEntity.ok(customerFacade.getCustomers());
     }
 
-    @Operation(summary = "Get customer by id")
+    @Operation(
+        summary = "Get a customer",
+        description = "Returns the current customer profile for the provided customer identifier."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Customer retrieved successfully"),
-        @ApiResponse(responseCode = "404", description = "Customer not found")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Customer retrieved successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CustomerView.class)
+            )
+        )
     })
+    @CustomerNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @GetMapping("/{customerId}")
-    public ResponseEntity<CustomerView> getCustomer(@PathVariable final String customerId) {
+    public ResponseEntity<CustomerView> getCustomer(
+        @CustomerIdParameter @PathVariable final String customerId) {
         return ResponseEntity.ok(customerFacade.getCustomer(customerId));
     }
 
-    @Operation(summary = "Create customer")
+    @Operation(
+        summary = "Create a customer",
+        description = "Registers a new customer in pending activation state and sends an activation token."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "Customer created successfully"),
-        @ApiResponse(responseCode = "400", description = "Request validation failed"),
-        @ApiResponse(responseCode = "409", description = "Customer already exists or pending activation")
+        @ApiResponse(
+            responseCode = "201",
+            description = "Customer created successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CustomerView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Customer already exists or a previous registration is still pending activation",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @ValidationFailedApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping
     public ResponseEntity<CustomerView> createCustomer(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "Customer registration payload",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CreateCustomerInput.class)
+            )
+        )
         @Valid @RequestBody final CreateCustomerInput request) {
 
         LOG.info("Received create customer request for email={}", request.email());
@@ -75,54 +134,131 @@ public class CustomerController {
             .body(createdCustomer);
     }
 
-    @Operation(summary = "Update customer profile")
+    @Operation(
+        summary = "Update a customer",
+        description = "Updates mutable customer profile fields for an existing customer."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Customer updated successfully"),
-        @ApiResponse(responseCode = "400", description = "Request validation failed"),
-        @ApiResponse(responseCode = "404", description = "Customer not found")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Customer updated successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CustomerView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Customer cannot be updated in its current lifecycle state",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @ValidationFailedApiResponse
+    @CustomerNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @PutMapping("/{customerId}")
     public ResponseEntity<CustomerView> updateCustomer(
-        @PathVariable final String customerId,
+        @CustomerIdParameter @PathVariable final String customerId,
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "Customer profile update payload",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = UpdateCustomerInput.class)
+            )
+        )
         @Valid @RequestBody final UpdateCustomerInput request) {
 
         return ResponseEntity.ok(customerFacade.updateCustomer(customerId, request));
     }
 
-    @Operation(summary = "Activate customer by token")
+    @Operation(
+        summary = "Activate a customer",
+        description = "Consumes an activation token and moves a pending customer into active state."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Customer activated successfully"),
-        @ApiResponse(responseCode = "400", description = "Request validation failed"),
-        @ApiResponse(responseCode = "404", description = "Customer or activation token not found"),
-        @ApiResponse(responseCode = "409", description = "Activation token is expired, consumed, or customer cannot be activated")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Customer activated successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CustomerView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Customer or activation token not found",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Activation token is expired, already consumed, or the customer cannot be activated",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @ValidationFailedApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping("/{customerId}/activation")
     public ResponseEntity<CustomerView> activateCustomer(
-        @PathVariable final String customerId,
+        @CustomerIdParameter @PathVariable final String customerId,
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "Activation payload containing the token issued during registration",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ActivateCustomerRequest.class)
+            )
+        )
         @Valid @RequestBody final ActivateCustomerRequest request) {
 
         return ResponseEntity.ok(customerFacade.activateCustomer(customerId, request.token()));
     }
 
-    @Operation(summary = "Resend activation token")
+    @Operation(
+        summary = "Resend an activation token",
+        description = "Issues a fresh activation token for a customer that is still eligible for activation."
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Activation token resent successfully"),
-        @ApiResponse(responseCode = "404", description = "Customer not found"),
-        @ApiResponse(responseCode = "409", description = "Activation token cannot be resent for the current customer state")
+        @ApiResponse(
+            responseCode = "409",
+            description = "Activation token cannot be resent for the current customer state",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @CustomerNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping("/{customerId}/activation/resend")
-    public ResponseEntity<Void> resendActivationToken(@PathVariable final String customerId) {
+    public ResponseEntity<Void> resendActivationToken(
+        @CustomerIdParameter @PathVariable final String customerId) {
         customerFacade.resendActivationToken(customerId);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Delete customer")
+    @Operation(
+        summary = "Delete a customer",
+        description = "Deletes a customer record by identifier."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "204", description = "Customer deleted successfully"),
-        @ApiResponse(responseCode = "404", description = "Customer not found")
+        @ApiResponse(responseCode = "204", description = "Customer deleted successfully")
     })
+    @CustomerNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @DeleteMapping("/{customerId}")
-    public ResponseEntity<Void> deleteCustomer(@PathVariable final String customerId) {
+    public ResponseEntity<Void> deleteCustomer(
+        @CustomerIdParameter @PathVariable final String customerId) {
         customerFacade.deleteCustomer(customerId);
         return ResponseEntity.noContent().build();
     }

--- a/app/src/main/java/com/kartoush/api/docs/ApiProblemResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/ApiProblemResponse.java
@@ -1,0 +1,51 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(name = "ApiProblemResponse", description = "RFC 7807 problem response returned when the API cannot complete a request")
+public record ApiProblemResponse(
+    @Schema(
+        description = "Problem type URI",
+        example = "urn:kartoush:error:customer-not-found"
+    )
+    String type,
+
+    @Schema(
+        description = "Short human-readable problem title",
+        example = "Customer Not Found"
+    )
+    String title,
+
+    @Schema(
+        description = "HTTP status code associated with the problem",
+        example = "404"
+    )
+    Integer status,
+
+    @Schema(
+        description = "Detailed explanation of the error",
+        example = "Customer with id 01ARZ3NDEKTSV4RRFFQ69G5FAV was not found"
+    )
+    String detail,
+
+    @Schema(
+        description = "Request path that produced the problem",
+        example = "/api/customers/01ARZ3NDEKTSV4RRFFQ69G5FAV"
+    )
+    String instance,
+
+    @Schema(
+        description = "Stable application-specific error code",
+        example = "CUSTOMER_NOT_FOUND"
+    )
+    String errorCode,
+
+    @Schema(
+        description = "Timestamp when the problem response was generated",
+        example = "2026-04-24T18:42:13.511Z"
+    )
+    Instant timestamp
+) {
+}

--- a/app/src/main/java/com/kartoush/api/docs/CustomerIdParameter.java
+++ b/app/src/main/java/com/kartoush/api/docs/CustomerIdParameter.java
@@ -1,0 +1,19 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+    name = "customerId",
+    description = "Customer ULID identifier",
+    example = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    required = true
+)
+public @interface CustomerIdParameter {
+}

--- a/app/src/main/java/com/kartoush/api/docs/CustomerNotFoundApiResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/CustomerNotFoundApiResponse.java
@@ -1,0 +1,23 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "Customer not found",
+    content = @Content(
+        mediaType = "application/problem+json",
+        schema = @Schema(implementation = ApiProblemResponse.class)
+    )
+)
+public @interface CustomerNotFoundApiResponse {
+}

--- a/app/src/main/java/com/kartoush/api/docs/InternalServerErrorApiResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/InternalServerErrorApiResponse.java
@@ -1,0 +1,23 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "500",
+    description = "Unexpected server error",
+    content = @Content(
+        mediaType = "application/problem+json",
+        schema = @Schema(implementation = ApiProblemResponse.class)
+    )
+)
+public @interface InternalServerErrorApiResponse {
+}

--- a/app/src/main/java/com/kartoush/api/docs/TermsOfServiceIdParameter.java
+++ b/app/src/main/java/com/kartoush/api/docs/TermsOfServiceIdParameter.java
@@ -1,0 +1,19 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+    name = "termsOfServiceId",
+    description = "Terms of Service ULID identifier",
+    example = "01KQ0INTERNALTERMS000000001",
+    required = true
+)
+public @interface TermsOfServiceIdParameter {
+}

--- a/app/src/main/java/com/kartoush/api/docs/TermsOfServiceNotFoundApiResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/TermsOfServiceNotFoundApiResponse.java
@@ -1,0 +1,23 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "Terms of Service not found",
+    content = @Content(
+        mediaType = "application/problem+json",
+        schema = @Schema(implementation = ApiProblemResponse.class)
+    )
+)
+public @interface TermsOfServiceNotFoundApiResponse {
+}

--- a/app/src/main/java/com/kartoush/api/docs/TermsVersionParameter.java
+++ b/app/src/main/java/com/kartoush/api/docs/TermsVersionParameter.java
@@ -1,0 +1,19 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+    name = "version",
+    description = "Human-readable Terms of Service version",
+    example = "2026.04.01",
+    required = true
+)
+public @interface TermsVersionParameter {
+}

--- a/app/src/main/java/com/kartoush/api/docs/ValidationErrorResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/ValidationErrorResponse.java
@@ -1,0 +1,32 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ValidationErrorResponse", description = "Single validation failure for a request field")
+public record ValidationErrorResponse(
+    @Schema(
+        description = "Field that failed validation",
+        example = "token"
+    )
+    String field,
+
+    @Schema(
+        description = "Human-readable validation message",
+        example = "token must not be blank"
+    )
+    String message,
+
+    @Schema(
+        description = "Machine-readable validation code when available",
+        example = "NotBlank"
+    )
+    String code,
+
+    @Schema(
+        description = "Rejected value when it is safe to expose",
+        nullable = true,
+        example = ""
+    )
+    Object rejectedValue
+) {
+}

--- a/app/src/main/java/com/kartoush/api/docs/ValidationFailedApiResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/ValidationFailedApiResponse.java
@@ -1,0 +1,23 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "Request validation failed",
+    content = @Content(
+        mediaType = "application/problem+json",
+        schema = @Schema(implementation = ValidationProblemResponse.class)
+    )
+)
+public @interface ValidationFailedApiResponse {
+}

--- a/app/src/main/java/com/kartoush/api/docs/ValidationProblemResponse.java
+++ b/app/src/main/java/com/kartoush/api/docs/ValidationProblemResponse.java
@@ -1,0 +1,59 @@
+package com.kartoush.api.docs;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.util.List;
+
+@Schema(name = "ValidationProblemResponse", description = "Problem response returned when request validation fails")
+public record ValidationProblemResponse(
+    @Schema(
+        description = "Problem type URI",
+        example = "urn:kartoush:error:validation-failed"
+    )
+    String type,
+
+    @Schema(
+        description = "Short human-readable problem title",
+        example = "Validation Failed"
+    )
+    String title,
+
+    @Schema(
+        description = "HTTP status code associated with the problem",
+        example = "400"
+    )
+    Integer status,
+
+    @Schema(
+        description = "Detailed explanation of the validation failure",
+        example = "One or more validation errors occurred."
+    )
+    String detail,
+
+    @Schema(
+        description = "Request path that produced the problem",
+        example = "/api/customers/01ARZ3NDEKTSV4RRFFQ69G5FAV/activation"
+    )
+    String instance,
+
+    @Schema(
+        description = "Stable application-specific error code",
+        example = "VALIDATION_FAILED"
+    )
+    String errorCode,
+
+    @Schema(
+        description = "Timestamp when the problem response was generated",
+        example = "2026-04-24T18:42:13.511Z"
+    )
+    Instant timestamp,
+
+    @ArraySchema(
+        arraySchema = @Schema(description = "Field-level validation errors"),
+        schema = @Schema(implementation = ValidationErrorResponse.class)
+    )
+    List<ValidationErrorResponse> errors
+) {
+}

--- a/app/src/main/java/com/kartoush/api/terms/InternalTermsOfServiceManagementController.java
+++ b/app/src/main/java/com/kartoush/api/terms/InternalTermsOfServiceManagementController.java
@@ -1,10 +1,18 @@
 package com.kartoush.api.terms;
 
+import com.kartoush.api.docs.ApiProblemResponse;
+import com.kartoush.api.docs.InternalServerErrorApiResponse;
+import com.kartoush.api.docs.TermsOfServiceIdParameter;
+import com.kartoush.api.docs.TermsOfServiceNotFoundApiResponse;
+import com.kartoush.api.docs.ValidationFailedApiResponse;
 import com.kartoush.customer.facade.TermsOfServiceManagementFacade;
 import com.kartoush.customer.facade.model.TermsOfServiceManagementView;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/internal/terms-of-service")
+@Tag(name = "Internal Terms Of Service", description = "Internal Terms of Service drafting and lifecycle management operations.")
 public class InternalTermsOfServiceManagementController {
 
     private final TermsOfServiceManagementFacade termsOfServiceManagementFacade;
@@ -26,14 +35,40 @@ public class InternalTermsOfServiceManagementController {
         this.termsOfServiceManagementFacade = termsOfServiceManagementFacade;
     }
 
-    @Operation(summary = "Create an internal Terms of Service draft")
+    @Operation(
+        summary = "Create an internal Terms of Service draft",
+        description = "Creates a new draft Terms of Service version for internal management workflows."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "Draft Terms of Service created successfully"),
-        @ApiResponse(responseCode = "400", description = "Request validation failed"),
-        @ApiResponse(responseCode = "409", description = "Terms of Service version already exists")
+        @ApiResponse(
+            responseCode = "201",
+            description = "Draft Terms of Service created successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceManagementView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Terms of Service version already exists",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @ValidationFailedApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping("/drafts")
     public ResponseEntity<TermsOfServiceManagementView> createDraft(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "Draft creation payload",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CreateTermsOfServiceDraftRequest.class)
+            )
+        )
         @Valid @RequestBody final CreateTermsOfServiceDraftRequest request) {
         final TermsOfServiceManagementView createdDraft = termsOfServiceManagementFacade.createDraft(
             request.version(),
@@ -46,16 +81,42 @@ public class InternalTermsOfServiceManagementController {
             .body(createdDraft);
     }
 
-    @Operation(summary = "Update an internal Terms of Service draft")
+    @Operation(
+        summary = "Update an internal Terms of Service draft",
+        description = "Updates the content of an existing draft Terms of Service version."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Draft Terms of Service updated successfully"),
-        @ApiResponse(responseCode = "400", description = "Request validation failed"),
-        @ApiResponse(responseCode = "404", description = "Terms of Service not found"),
-        @ApiResponse(responseCode = "409", description = "Terms of Service cannot be updated in the current state")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Draft Terms of Service updated successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceManagementView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Terms of Service cannot be updated in the current state",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @ValidationFailedApiResponse
+    @TermsOfServiceNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @PutMapping("/drafts/{termsOfServiceId}")
     public ResponseEntity<TermsOfServiceManagementView> updateDraft(
-        @PathVariable final String termsOfServiceId,
+        @TermsOfServiceIdParameter @PathVariable final String termsOfServiceId,
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "Draft update payload",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = UpdateTermsOfServiceDraftRequest.class)
+            )
+        )
         @Valid @RequestBody final UpdateTermsOfServiceDraftRequest request) {
         return ResponseEntity.ok(termsOfServiceManagementFacade.updateDraft(
             termsOfServiceId,
@@ -64,47 +125,139 @@ public class InternalTermsOfServiceManagementController {
         ));
     }
 
-    @Operation(summary = "Schedule internal Terms of Service activation")
+    @Operation(
+        summary = "Schedule internal Terms of Service activation",
+        description = "Schedules a Terms of Service version to become active at a future time."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Terms of Service scheduled successfully"),
-        @ApiResponse(responseCode = "400", description = "Request validation failed or schedule is invalid"),
-        @ApiResponse(responseCode = "404", description = "Terms of Service not found"),
-        @ApiResponse(responseCode = "409", description = "Terms of Service cannot be scheduled in the current state")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Terms of Service scheduled successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceManagementView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed or schedule is invalid",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(oneOf = {
+                    com.kartoush.api.docs.ValidationProblemResponse.class,
+                    ApiProblemResponse.class
+                })
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Terms of Service cannot be scheduled in the current state",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @TermsOfServiceNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping("/{termsOfServiceId}/schedule")
     public ResponseEntity<TermsOfServiceManagementView> schedule(
-        @PathVariable final String termsOfServiceId,
+        @TermsOfServiceIdParameter @PathVariable final String termsOfServiceId,
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            description = "Scheduling payload",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ScheduleTermsOfServiceRequest.class)
+            )
+        )
         @Valid @RequestBody final ScheduleTermsOfServiceRequest request) {
         return ResponseEntity.ok(termsOfServiceManagementFacade.schedule(termsOfServiceId, request.effectiveAt()));
     }
 
-    @Operation(summary = "Unschedule internal Terms of Service activation")
+    @Operation(
+        summary = "Unschedule internal Terms of Service activation",
+        description = "Removes a previously scheduled activation from a Terms of Service version."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Terms of Service unscheduled successfully"),
-        @ApiResponse(responseCode = "404", description = "Terms of Service not found"),
-        @ApiResponse(responseCode = "409", description = "Terms of Service cannot be unscheduled in the current state")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Terms of Service unscheduled successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceManagementView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Terms of Service cannot be unscheduled in the current state",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @TermsOfServiceNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping("/{termsOfServiceId}/unschedule")
-    public ResponseEntity<TermsOfServiceManagementView> unschedule(@PathVariable final String termsOfServiceId) {
+    public ResponseEntity<TermsOfServiceManagementView> unschedule(
+        @TermsOfServiceIdParameter @PathVariable final String termsOfServiceId) {
         return ResponseEntity.ok(termsOfServiceManagementFacade.unschedule(termsOfServiceId));
     }
 
-    @Operation(summary = "Activate internal Terms of Service immediately")
+    @Operation(
+        summary = "Activate internal Terms of Service immediately",
+        description = "Immediately promotes a Terms of Service version to active status."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Terms of Service activated successfully"),
-        @ApiResponse(responseCode = "404", description = "Terms of Service not found"),
-        @ApiResponse(responseCode = "409", description = "Terms of Service cannot be activated in the current state")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Terms of Service activated successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceManagementView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Terms of Service cannot be activated in the current state",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @TermsOfServiceNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @PostMapping("/{termsOfServiceId}/activate")
-    public ResponseEntity<TermsOfServiceManagementView> activateNow(@PathVariable final String termsOfServiceId) {
+    public ResponseEntity<TermsOfServiceManagementView> activateNow(
+        @TermsOfServiceIdParameter @PathVariable final String termsOfServiceId) {
         return ResponseEntity.ok(termsOfServiceManagementFacade.activateNow(termsOfServiceId));
     }
 
-    @Operation(summary = "Promote due scheduled internal Terms of Service")
+    @Operation(
+        summary = "Promote due scheduled internal Terms of Service",
+        description = "Promotes the next scheduled Terms of Service version whose effective time has arrived."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Due scheduled Terms of Service promoted successfully"),
-        @ApiResponse(responseCode = "409", description = "No due scheduled Terms of Service is available")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Due scheduled Terms of Service promoted successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceManagementView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "No due scheduled Terms of Service is available",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = ApiProblemResponse.class)
+            )
+        )
     })
+    @InternalServerErrorApiResponse
     @PostMapping("/promote-due")
     public ResponseEntity<TermsOfServiceManagementView> promoteDueScheduledTerms() {
         return ResponseEntity.ok(termsOfServiceManagementFacade.promoteDueScheduledTerms());

--- a/app/src/main/java/com/kartoush/api/terms/TermsOfServiceController.java
+++ b/app/src/main/java/com/kartoush/api/terms/TermsOfServiceController.java
@@ -1,10 +1,16 @@
 package com.kartoush.api.terms;
 
+import com.kartoush.api.docs.InternalServerErrorApiResponse;
+import com.kartoush.api.docs.TermsOfServiceNotFoundApiResponse;
+import com.kartoush.api.docs.TermsVersionParameter;
 import com.kartoush.customer.facade.TermsOfServiceFacade;
 import com.kartoush.customer.facade.model.TermsOfServiceView;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/terms-of-service")
+@Tag(name = "Terms Of Service", description = "Public Terms of Service retrieval endpoints.")
 public class TermsOfServiceController {
 
     private final TermsOfServiceFacade termsOfServiceFacade;
@@ -21,23 +28,53 @@ public class TermsOfServiceController {
         this.termsOfServiceFacade = termsOfServiceFacade;
     }
 
-    @Operation(summary = "Get current Terms of Service metadata")
+    @Operation(
+        summary = "Get current Terms of Service metadata",
+        description = "Returns the currently active Terms of Service version that customers are expected to accept."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Current Terms of Service retrieved successfully"),
-        @ApiResponse(responseCode = "404", description = "Current Terms of Service not found")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Current Terms of Service retrieved successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceView.class)
+            )
+        )
     })
+    @TermsOfServiceNotFoundApiResponse
+    @InternalServerErrorApiResponse
     @GetMapping("/current")
     public ResponseEntity<TermsOfServiceView> getCurrentTermsOfService() {
         return ResponseEntity.ok(termsOfServiceFacade.getCurrentTermsOfService());
     }
 
-    @Operation(summary = "Get Terms of Service metadata by version")
+    @Operation(
+        summary = "Get Terms of Service metadata by version",
+        description = "Returns a specific Terms of Service version, including its content and lifecycle metadata."
+    )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Terms of Service retrieved successfully"),
-        @ApiResponse(responseCode = "404", description = "Terms of Service not found for version")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Terms of Service retrieved successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = TermsOfServiceView.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Terms of Service not found for version",
+            content = @Content(
+                mediaType = "application/problem+json",
+                schema = @Schema(implementation = com.kartoush.api.docs.ApiProblemResponse.class)
+            )
+        )
     })
+    @InternalServerErrorApiResponse
     @GetMapping("/{version}")
-    public ResponseEntity<TermsOfServiceView> getTermsOfServiceByVersion(@PathVariable final String version) {
+    public ResponseEntity<TermsOfServiceView> getTermsOfServiceByVersion(
+        @TermsVersionParameter @PathVariable final String version) {
         return ResponseEntity.ok(termsOfServiceFacade.getTermsOfServiceByVersion(version));
     }
 }

--- a/app/src/main/java/com/kartoush/config/OpenApiConfiguration.java
+++ b/app/src/main/java/com/kartoush/config/OpenApiConfiguration.java
@@ -1,6 +1,7 @@
 package com.kartoush.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,8 +12,10 @@ public class OpenApiConfiguration {
     @Bean
     public OpenAPI kartoushOpenApi() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("Kartoush API")
-                        .version("v1"));
+            .info(new Info()
+                .title("Kartoush API")
+                .version("v1")
+                .description("Public and internal HTTP APIs for customer registration, lifecycle management, and Terms of Service workflows.")
+                .contact(new Contact().name("Kartoush")));
     }
 }

--- a/app/src/test/java/com/kartoush/api/customer/CustomerControllerWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerControllerWebMvcTest.java
@@ -10,7 +10,12 @@ import com.kartoush.customer.facade.model.UpdateCustomerInput;
 import com.kartoush.platform.types.CustomerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -32,6 +37,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CustomerController.class)
+@ImportAutoConfiguration(exclude = {
+    SpringDocConfiguration.class,
+    SpringDocSpecPropertiesConfiguration.class,
+    SpringDocWebMvcConfiguration.class,
+    MultipleOpenApiSupportConfiguration.class
+})
 class CustomerControllerWebMvcTest {
     private static final String BASE_URL = "/api/customers";
 

--- a/app/src/test/java/com/kartoush/api/customer/CustomerOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerOpenApiWebMvcTest.java
@@ -1,0 +1,74 @@
+package com.kartoush.api.customer;
+
+import com.kartoush.api.error.ApiExceptionHandler;
+import com.kartoush.api.error.ApiProblemFactory;
+import com.kartoush.config.OpenApiConfiguration;
+import com.kartoush.customer.facade.CustomerFacade;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+    classes = CustomerOpenApiWebMvcTest.TestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK
+)
+@AutoConfigureMockMvc
+class CustomerOpenApiWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CustomerFacade customerFacade;
+
+    @MockitoBean
+    private ApiProblemFactory apiProblemFactory;
+
+    @Test
+    void shouldExposeCustomerOpenApiDocumentation() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.info.title").value("Kartoush API"))
+            .andExpect(jsonPath("$.paths['/api/customers'].post.summary").value("Create a customer"))
+            .andExpect(jsonPath("$.paths['/api/customers'].post.responses['400'].content['application/problem+json'].schema['$ref']")
+                .value("#/components/schemas/ValidationProblemResponse"))
+            .andExpect(jsonPath("$.paths['/api/customers/{customerId}'].put.responses['409'].content['application/problem+json'].schema['$ref']")
+                .value("#/components/schemas/ApiProblemResponse"))
+            .andExpect(jsonPath("$.paths['/api/customers/{customerId}'].get.parameters[0].description")
+                .value("Customer ULID identifier"))
+            .andExpect(jsonPath("$.components.schemas.ValidationProblemResponse.properties.errors.type").value("array"))
+            .andExpect(jsonPath("$.components.schemas.CustomerView.properties.status.description")
+                .value("Customer lifecycle status"));
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({
+        CustomerController.class,
+        ApiExceptionHandler.class,
+        OpenApiConfiguration.class
+    })
+    @ImportAutoConfiguration({
+        SpringDocConfiguration.class,
+        SpringDocSpecPropertiesConfiguration.class,
+        SpringDocWebMvcConfiguration.class,
+        MultipleOpenApiSupportConfiguration.class
+    })
+    static class TestApplication {
+    }
+}

--- a/app/src/test/java/com/kartoush/api/customer/CustomerOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerOpenApiWebMvcTest.java
@@ -7,14 +7,14 @@ import com.kartoush.customer.facade.CustomerFacade;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
 import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,11 +23,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(
-    classes = CustomerOpenApiWebMvcTest.TestApplication.class,
-    webEnvironment = SpringBootTest.WebEnvironment.MOCK
-)
+@WebMvcTest(CustomerController.class)
 @AutoConfigureMockMvc
+@EnableConfigurationProperties(SpringDocConfigProperties.class)
+@Import({
+    ApiExceptionHandler.class,
+    OpenApiConfiguration.class
+})
+@ImportAutoConfiguration({
+    SpringDocConfiguration.class,
+    SpringDocSpecPropertiesConfiguration.class,
+    SpringDocWebMvcConfiguration.class,
+    MultipleOpenApiSupportConfiguration.class
+})
 class CustomerOpenApiWebMvcTest {
 
     @Autowired
@@ -54,21 +62,5 @@ class CustomerOpenApiWebMvcTest {
             .andExpect(jsonPath("$.components.schemas.ValidationProblemResponse.properties.errors.type").value("array"))
             .andExpect(jsonPath("$.components.schemas.CustomerView.properties.status.description")
                 .value("Customer lifecycle status"));
-    }
-
-    @SpringBootConfiguration
-    @EnableAutoConfiguration
-    @Import({
-        CustomerController.class,
-        ApiExceptionHandler.class,
-        OpenApiConfiguration.class
-    })
-    @ImportAutoConfiguration({
-        SpringDocConfiguration.class,
-        SpringDocSpecPropertiesConfiguration.class,
-        SpringDocWebMvcConfiguration.class,
-        MultipleOpenApiSupportConfiguration.class
-    })
-    static class TestApplication {
     }
 }

--- a/app/src/test/java/com/kartoush/api/customer/CustomerOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerOpenApiWebMvcTest.java
@@ -16,9 +16,11 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,6 +40,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class CustomerOpenApiWebMvcTest {
 
+    private static final String API_DOCS_PATH = "/v3/api-docs";
+
+    private static final String CUSTOMER_PATH = "/api/customers";
+
+    private static final String CUSTOMER_BY_ID_PATH = CUSTOMER_PATH + "/{customerId}";
+
+    private static final String CUSTOMER_BY_ID_PARAMETER_DESCRIPTION_PATH =
+        operationPath(CUSTOMER_BY_ID_PATH, "get", "parameters[0].description");
+
+    private static final String API_PROBLEM_RESPONSE_REF = "#/components/schemas/ApiProblemResponse";
+
+    private static final String VALIDATION_PROBLEM_RESPONSE_REF = "#/components/schemas/ValidationProblemResponse";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -49,18 +64,48 @@ class CustomerOpenApiWebMvcTest {
 
     @Test
     void shouldExposeCustomerOpenApiDocumentation() throws Exception {
-        mockMvc.perform(get("/v3/api-docs"))
+        mockMvc.perform(get(API_DOCS_PATH))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.info.title").value("Kartoush API"))
-            .andExpect(jsonPath("$.paths['/api/customers'].post.summary").value("Create a customer"))
-            .andExpect(jsonPath("$.paths['/api/customers'].post.responses['400'].content['application/problem+json'].schema['$ref']")
-                .value("#/components/schemas/ValidationProblemResponse"))
-            .andExpect(jsonPath("$.paths['/api/customers/{customerId}'].put.responses['409'].content['application/problem+json'].schema['$ref']")
-                .value("#/components/schemas/ApiProblemResponse"))
-            .andExpect(jsonPath("$.paths['/api/customers/{customerId}'].get.parameters[0].description")
+            .andExpect(jsonPath(operationPath(CUSTOMER_PATH, "post", "summary")).value("Create a customer"))
+            .andExpect(jsonPath(problemSchemaRefPath(
+                CUSTOMER_PATH,
+                "post",
+                HttpStatus.BAD_REQUEST.value()
+            ))
+                .value(VALIDATION_PROBLEM_RESPONSE_REF))
+            .andExpect(jsonPath(problemSchemaRefPath(
+                CUSTOMER_BY_ID_PATH,
+                "put",
+                HttpStatus.CONFLICT.value()
+            ))
+                .value(API_PROBLEM_RESPONSE_REF))
+            .andExpect(jsonPath(CUSTOMER_BY_ID_PARAMETER_DESCRIPTION_PATH)
                 .value("Customer ULID identifier"))
             .andExpect(jsonPath("$.components.schemas.ValidationProblemResponse.properties.errors.type").value("array"))
             .andExpect(jsonPath("$.components.schemas.CustomerView.properties.status.description")
                 .value("Customer lifecycle status"));
+    }
+
+    private static String problemSchemaRefPath(
+        final String endpoint,
+        final String method,
+        final int statusCode
+    ) {
+        return operationPath(
+            endpoint,
+            method,
+            "responses['" + statusCode + "']"
+                + ".content['" + APPLICATION_PROBLEM_JSON_VALUE + "']"
+                + ".schema['$ref']"
+        );
+    }
+
+    private static String operationPath(
+        final String endpoint,
+        final String method,
+        final String suffix
+    ) {
+        return "$.paths['" + endpoint + "']." + method + "." + suffix;
     }
 }

--- a/app/src/test/java/com/kartoush/api/terms/InternalTermsOfServiceManagementControllerWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/InternalTermsOfServiceManagementControllerWebMvcTest.java
@@ -14,6 +14,7 @@ import com.kartoush.api.error.ApiProblemFactory;
 import com.kartoush.api.error.ErrorCode;
 import com.kartoush.customer.exception.InvalidTermsOfServiceScheduleException;
 import com.kartoush.customer.exception.TermsOfServiceNotFoundException;
+import com.kartoush.customer.facade.TermsOfServiceFacade;
 import com.kartoush.customer.exception.TermsOfServiceVersionAlreadyExistsException;
 import com.kartoush.customer.facade.TermsOfServiceManagementFacade;
 import com.kartoush.customer.facade.model.TermsOfServiceManagementView;
@@ -22,13 +23,24 @@ import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(InternalTermsOfServiceManagementController.class)
+@ImportAutoConfiguration(exclude = {
+    SpringDocConfiguration.class,
+    SpringDocSpecPropertiesConfiguration.class,
+    SpringDocWebMvcConfiguration.class,
+    MultipleOpenApiSupportConfiguration.class
+})
 class InternalTermsOfServiceManagementControllerWebMvcTest {
 
     private static final String BASE_URL = "/internal/terms-of-service";
@@ -45,6 +57,9 @@ class InternalTermsOfServiceManagementControllerWebMvcTest {
 
     @MockitoBean
     private TermsOfServiceManagementFacade termsOfServiceManagementFacade;
+
+    @MockitoBean
+    private TermsOfServiceFacade termsOfServiceFacade;
 
     @Test
     void shouldCreateDraft() throws Exception {

--- a/app/src/test/java/com/kartoush/api/terms/TermsOfServiceControllerWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsOfServiceControllerWebMvcTest.java
@@ -11,19 +11,31 @@ import com.kartoush.api.error.ApiProblemFactory;
 import com.kartoush.api.error.ErrorCode;
 import com.kartoush.customer.exception.TermsOfServiceVersionNotFoundException;
 import com.kartoush.customer.facade.TermsOfServiceFacade;
+import com.kartoush.customer.facade.TermsOfServiceManagementFacade;
 import com.kartoush.customer.facade.model.TermsOfServiceView;
 import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
 import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(TermsOfServiceController.class)
+@ImportAutoConfiguration(exclude = {
+    SpringDocConfiguration.class,
+    SpringDocSpecPropertiesConfiguration.class,
+    SpringDocWebMvcConfiguration.class,
+    MultipleOpenApiSupportConfiguration.class
+})
 class TermsOfServiceControllerWebMvcTest {
 
     private static final String BASE_URL = "/api/terms-of-service";
@@ -37,6 +49,9 @@ class TermsOfServiceControllerWebMvcTest {
 
     @MockitoBean
     private TermsOfServiceFacade termsOfServiceFacade;
+
+    @MockitoBean
+    private TermsOfServiceManagementFacade termsOfServiceManagementFacade;
 
     @Test
     void shouldGetCurrentTermsOfService() throws Exception {

--- a/app/src/test/java/com/kartoush/api/terms/TermsOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsOpenApiWebMvcTest.java
@@ -1,0 +1,80 @@
+package com.kartoush.api.terms;
+
+import com.kartoush.api.error.ApiExceptionHandler;
+import com.kartoush.api.error.ApiProblemFactory;
+import com.kartoush.config.OpenApiConfiguration;
+import com.kartoush.customer.facade.TermsOfServiceFacade;
+import com.kartoush.customer.facade.TermsOfServiceManagementFacade;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+    classes = TermsOpenApiWebMvcTest.TestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK
+)
+@AutoConfigureMockMvc
+class TermsOpenApiWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TermsOfServiceFacade termsOfServiceFacade;
+
+    @MockitoBean
+    private TermsOfServiceManagementFacade termsOfServiceManagementFacade;
+
+    @MockitoBean
+    private ApiProblemFactory apiProblemFactory;
+
+    @Test
+    void shouldExposeTermsProblemDetailDocumentation() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.paths['/api/terms-of-service/{version}'].get.responses['404'].content['application/problem+json'].schema['$ref']")
+                .value("#/components/schemas/ApiProblemResponse"))
+            .andExpect(jsonPath("$.paths['/api/terms-of-service/{version}'].get.parameters[0].description")
+                .value("Human-readable Terms of Service version"))
+            .andExpect(jsonPath("$.paths['/internal/terms-of-service/drafts'].post.responses['409'].content['application/problem+json'].schema['$ref']")
+                .value("#/components/schemas/ApiProblemResponse"))
+            .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/schedule'].post.responses['400'].content['application/problem+json'].schema.oneOf[0]['$ref']")
+                .value("#/components/schemas/ValidationProblemResponse"))
+            .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/schedule'].post.responses['400'].content['application/problem+json'].schema.oneOf[1]['$ref']")
+                .value("#/components/schemas/ApiProblemResponse"))
+            .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/activate'].post.parameters[0].description")
+                .value("Terms of Service ULID identifier"));
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({
+        TermsOfServiceController.class,
+        InternalTermsOfServiceManagementController.class,
+        ApiExceptionHandler.class,
+        OpenApiConfiguration.class
+    })
+    @ImportAutoConfiguration({
+        SpringDocConfiguration.class,
+        SpringDocSpecPropertiesConfiguration.class,
+        SpringDocWebMvcConfiguration.class,
+        MultipleOpenApiSupportConfiguration.class
+    })
+    static class TestApplication {
+    }
+}

--- a/app/src/test/java/com/kartoush/api/terms/TermsOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsOpenApiWebMvcTest.java
@@ -17,9 +17,11 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,6 +44,45 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class TermsOpenApiWebMvcTest {
 
+    private static final String API_DOCS_PATH = "/v3/api-docs";
+
+    private static final String PUBLIC_TERMS_PATH = "/api/terms-of-service";
+
+    private static final String TERMS_BY_VERSION_PATH = PUBLIC_TERMS_PATH + "/{version}";
+
+    private static final String INTERNAL_TERMS_PATH = "/internal/terms-of-service";
+
+    private static final String INTERNAL_DRAFTS_PATH = INTERNAL_TERMS_PATH + "/drafts";
+
+    private static final String INTERNAL_SCHEDULE_PATH =
+        INTERNAL_TERMS_PATH + "/{termsOfServiceId}/schedule";
+
+    private static final String INTERNAL_ACTIVATE_PATH =
+        INTERNAL_TERMS_PATH + "/{termsOfServiceId}/activate";
+
+    private static final String TERMS_BY_VERSION_PARAMETER_DESCRIPTION_PATH =
+        operationPath(TERMS_BY_VERSION_PATH, "get", "parameters[0].description");
+
+    private static final String INTERNAL_ACTIVATE_PARAMETER_DESCRIPTION_PATH =
+        operationPath(INTERNAL_ACTIVATE_PATH, "post", "parameters[0].description");
+
+    private static final String SCHEDULE_BAD_REQUEST_SCHEMA_PATH =
+        problemSchemaPath(
+            INTERNAL_SCHEDULE_PATH,
+            "post",
+            HttpStatus.BAD_REQUEST.value()
+        );
+
+    private static final String SCHEDULE_BAD_REQUEST_VALIDATION_REF_PATH =
+        SCHEDULE_BAD_REQUEST_SCHEMA_PATH + ".oneOf[0]['$ref']";
+
+    private static final String SCHEDULE_BAD_REQUEST_PROBLEM_REF_PATH =
+        SCHEDULE_BAD_REQUEST_SCHEMA_PATH + ".oneOf[1]['$ref']";
+
+    private static final String API_PROBLEM_RESPONSE_REF = "#/components/schemas/ApiProblemResponse";
+
+    private static final String VALIDATION_PROBLEM_RESPONSE_REF = "#/components/schemas/ValidationProblemResponse";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -56,19 +97,58 @@ class TermsOpenApiWebMvcTest {
 
     @Test
     void shouldExposeTermsProblemDetailDocumentation() throws Exception {
-        mockMvc.perform(get("/v3/api-docs"))
+        mockMvc.perform(get(API_DOCS_PATH))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.paths['/api/terms-of-service/{version}'].get.responses['404'].content['application/problem+json'].schema['$ref']")
-                .value("#/components/schemas/ApiProblemResponse"))
-            .andExpect(jsonPath("$.paths['/api/terms-of-service/{version}'].get.parameters[0].description")
+            .andExpect(jsonPath(problemSchemaRefPath(
+                TERMS_BY_VERSION_PATH,
+                "get",
+                HttpStatus.NOT_FOUND.value()
+            ))
+                .value(API_PROBLEM_RESPONSE_REF))
+            .andExpect(jsonPath(TERMS_BY_VERSION_PARAMETER_DESCRIPTION_PATH)
                 .value("Human-readable Terms of Service version"))
-            .andExpect(jsonPath("$.paths['/internal/terms-of-service/drafts'].post.responses['409'].content['application/problem+json'].schema['$ref']")
-                .value("#/components/schemas/ApiProblemResponse"))
-            .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/schedule'].post.responses['400'].content['application/problem+json'].schema.oneOf[0]['$ref']")
-                .value("#/components/schemas/ValidationProblemResponse"))
-            .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/schedule'].post.responses['400'].content['application/problem+json'].schema.oneOf[1]['$ref']")
-                .value("#/components/schemas/ApiProblemResponse"))
-            .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/activate'].post.parameters[0].description")
+            .andExpect(jsonPath(problemSchemaRefPath(
+                INTERNAL_DRAFTS_PATH,
+                "post",
+                HttpStatus.CONFLICT.value()
+            ))
+                .value(API_PROBLEM_RESPONSE_REF))
+            .andExpect(jsonPath(SCHEDULE_BAD_REQUEST_VALIDATION_REF_PATH)
+                .value(VALIDATION_PROBLEM_RESPONSE_REF))
+            .andExpect(jsonPath(SCHEDULE_BAD_REQUEST_PROBLEM_REF_PATH)
+                .value(API_PROBLEM_RESPONSE_REF))
+            .andExpect(jsonPath(INTERNAL_ACTIVATE_PARAMETER_DESCRIPTION_PATH)
                 .value("Terms of Service ULID identifier"));
+    }
+
+    private static String operationPath(
+        final String endpoint,
+        final String method,
+        final String suffix
+    ) {
+        return "$.paths['" + endpoint + "']." + method + "." + suffix;
+    }
+
+    private static String problemSchemaRefPath(
+        final String endpoint,
+        final String method,
+        final int statusCode
+    ) {
+        return problemSchemaRefPath(problemSchemaPath(endpoint, method, statusCode));
+    }
+
+    private static String problemSchemaPath(
+        final String endpoint,
+        final String method,
+        final int statusCode
+    ) {
+        return "$.paths['" + endpoint + "']." + method
+            + ".responses['" + statusCode + "']"
+            + ".content['" + APPLICATION_PROBLEM_JSON_VALUE + "']"
+            + ".schema";
+    }
+
+    private static String problemSchemaRefPath(final String problemSchemaPath) {
+        return problemSchemaPath + "['$ref']";
     }
 }

--- a/app/src/test/java/com/kartoush/api/terms/TermsOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsOpenApiWebMvcTest.java
@@ -8,14 +8,14 @@ import com.kartoush.customer.facade.TermsOfServiceManagementFacade;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
 import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,11 +24,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(
-    classes = TermsOpenApiWebMvcTest.TestApplication.class,
-    webEnvironment = SpringBootTest.WebEnvironment.MOCK
-)
+@WebMvcTest({
+    TermsOfServiceController.class,
+    InternalTermsOfServiceManagementController.class
+})
 @AutoConfigureMockMvc
+@EnableConfigurationProperties(SpringDocConfigProperties.class)
+@Import({
+    ApiExceptionHandler.class,
+    OpenApiConfiguration.class
+})
+@ImportAutoConfiguration({
+    SpringDocConfiguration.class,
+    SpringDocSpecPropertiesConfiguration.class,
+    SpringDocWebMvcConfiguration.class,
+    MultipleOpenApiSupportConfiguration.class
+})
 class TermsOpenApiWebMvcTest {
 
     @Autowired
@@ -59,22 +70,5 @@ class TermsOpenApiWebMvcTest {
                 .value("#/components/schemas/ApiProblemResponse"))
             .andExpect(jsonPath("$.paths['/internal/terms-of-service/{termsOfServiceId}/activate'].post.parameters[0].description")
                 .value("Terms of Service ULID identifier"));
-    }
-
-    @SpringBootConfiguration
-    @EnableAutoConfiguration
-    @Import({
-        TermsOfServiceController.class,
-        InternalTermsOfServiceManagementController.class,
-        ApiExceptionHandler.class,
-        OpenApiConfiguration.class
-    })
-    @ImportAutoConfiguration({
-        SpringDocConfiguration.class,
-        SpringDocSpecPropertiesConfiguration.class,
-        SpringDocWebMvcConfiguration.class,
-        MultipleOpenApiSupportConfiguration.class
-    })
-    static class TestApplication {
     }
 }


### PR DESCRIPTION
## Summary
- improve customer and terms Swagger/OpenAPI endpoint descriptions and response schemas
- document shared `ProblemDetail` and validation error payloads with reusable OpenAPI annotations and parameter docs
- add generated OpenAPI tests for customer and terms endpoints while keeping controller MVC slice tests isolated from springdoc

## Verification
- `./gradlew :app:test --tests com.kartoush.api.customer.CustomerControllerWebMvcTest --tests com.kartoush.api.customer.CustomerOpenApiWebMvcTest --tests com.kartoush.api.terms.TermsOfServiceControllerWebMvcTest --tests com.kartoush.api.terms.InternalTermsOfServiceManagementControllerWebMvcTest --tests com.kartoush.api.terms.TermsOpenApiWebMvcTest`

Closes #202
Closes #203