### PR TITLE
Validate documented API success contracts at runtime

### DIFF
--- a/app/src/test/java/com/kartoush/api/customer/CustomerApiContractWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerApiContractWebMvcTest.java
@@ -6,6 +6,8 @@ import com.kartoush.api.error.ErrorCode;
 import com.kartoush.config.OpenApiConfiguration;
 import com.kartoush.customer.exception.CustomerNotFoundException;
 import com.kartoush.customer.facade.CustomerFacade;
+import com.kartoush.customer.facade.model.CustomerView;
+import com.kartoush.platform.types.CustomerStatus;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
@@ -52,6 +54,14 @@ class CustomerApiContractWebMvcTest {
 
     private static final String CUSTOMER_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
 
+    private static final String FIRST_NAME = "Jack";
+
+    private static final String LAST_NAME = "Kartoush";
+
+    private static final String EMAIL = "jack@kartoush.test";
+
+    private static final String PHONE_NUMBER = "+13125551234";
+
     private static final String CUSTOMER_PATH = "/api/customers";
 
     private static final String CUSTOMER_BY_ID_PATH = CUSTOMER_PATH + "/{customerId}";
@@ -67,6 +77,9 @@ class CustomerApiContractWebMvcTest {
 
     private static final String API_PROBLEM_RESPONSE_REF =
         "#/components/schemas/ApiProblemResponse";
+
+    private static final String CUSTOMER_VIEW_REF =
+        "#/components/schemas/CustomerView";
 
     private static final String VALIDATION_PROBLEM_RESPONSE_REF =
         "#/components/schemas/ValidationProblemResponse";
@@ -90,6 +103,29 @@ class CustomerApiContractWebMvcTest {
 
     @MockitoBean
     private CustomerFacade customerFacade;
+
+    @Test
+    void shouldMatchDocumentedCustomerSuccessResponse() throws Exception {
+        when(customerFacade.getCustomer(CUSTOMER_ID)).thenReturn(customerView());
+
+        mockMvc.perform(get(API_DOCS_PATH))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(schemaRefPath(
+                CUSTOMER_BY_ID_PATH,
+                "get",
+                HttpStatus.OK.value()
+            )).value(CUSTOMER_VIEW_REF));
+
+        mockMvc.perform(get(CUSTOMER_BY_ID_PATH, CUSTOMER_ID))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+            .andExpect(jsonPath("$.customerId").value(CUSTOMER_ID))
+            .andExpect(jsonPath("$.firstName").value(FIRST_NAME))
+            .andExpect(jsonPath("$.lastName").value(LAST_NAME))
+            .andExpect(jsonPath("$.email").value(EMAIL))
+            .andExpect(jsonPath("$.phoneNumber").value(PHONE_NUMBER))
+            .andExpect(jsonPath("$.status").value(CustomerStatus.ACTIVE.name()));
+    }
 
     @Test
     void shouldMatchDocumentedValidationProblemForCustomerActivation() throws Exception {
@@ -162,11 +198,36 @@ class CustomerApiContractWebMvcTest {
         );
     }
 
+    private static String schemaRefPath(
+        final String endpoint,
+        final String method,
+        final int statusCode
+    ) {
+        return operationPath(
+            endpoint,
+            method,
+            "responses['" + statusCode + "']"
+                + ".content['application/json']"
+                + ".schema['$ref']"
+        );
+    }
+
     private static String operationPath(
         final String endpoint,
         final String method,
         final String suffix
     ) {
         return "$.paths['" + endpoint + "']." + method + "." + suffix;
+    }
+
+    private static CustomerView customerView() {
+        return new CustomerView(
+            CUSTOMER_ID,
+            FIRST_NAME,
+            LAST_NAME,
+            EMAIL,
+            PHONE_NUMBER,
+            CustomerStatus.ACTIVE
+        );
     }
 }

--- a/app/src/test/java/com/kartoush/api/terms/TermsApiContractWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/terms/TermsApiContractWebMvcTest.java
@@ -8,6 +8,9 @@ import com.kartoush.customer.exception.InvalidTermsOfServiceScheduleException;
 import com.kartoush.customer.exception.TermsOfServiceVersionNotFoundException;
 import com.kartoush.customer.facade.TermsOfServiceFacade;
 import com.kartoush.customer.facade.TermsOfServiceManagementFacade;
+import com.kartoush.customer.facade.model.TermsOfServiceView;
+import com.kartoush.customer.termsofservice.TermsOfServiceContentType;
+import com.kartoush.customer.termsofservice.TermsOfServiceStatus;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.configuration.SpringDocSpecPropertiesConfiguration;
@@ -75,6 +78,9 @@ class TermsApiContractWebMvcTest {
     private static final String API_PROBLEM_RESPONSE_REF =
         "#/components/schemas/ApiProblemResponse";
 
+    private static final String TERMS_OF_SERVICE_VIEW_REF =
+        "#/components/schemas/TermsOfServiceView";
+
     private static final String VALIDATION_PROBLEM_RESPONSE_REF =
         "#/components/schemas/ValidationProblemResponse";
 
@@ -118,6 +124,29 @@ class TermsApiContractWebMvcTest {
 
     @MockitoBean
     private TermsOfServiceManagementFacade termsOfServiceManagementFacade;
+
+    @Test
+    void shouldMatchDocumentedTermsSuccessResponse() throws Exception {
+        when(termsOfServiceFacade.getTermsOfServiceByVersion(VERSION))
+            .thenReturn(termsOfServiceView());
+
+        mockMvc.perform(get(API_DOCS_PATH))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(schemaRefPath(
+                TERMS_BY_VERSION_PATH,
+                "get",
+                HttpStatus.OK.value()
+            )).value(TERMS_OF_SERVICE_VIEW_REF));
+
+        mockMvc.perform(get(TERMS_BY_VERSION_PATH, VERSION))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+            .andExpect(jsonPath("$.version").value(VERSION))
+            .andExpect(jsonPath("$.content").value("Terms content"))
+            .andExpect(jsonPath("$.contentType").value(TermsOfServiceContentType.PLAIN_TEXT.name()))
+            .andExpect(jsonPath("$.status").value(TermsOfServiceStatus.ACTIVE.name()))
+            .andExpect(jsonPath("$.effectiveAt").value("2026-04-01T00:00:00Z"));
+    }
 
     @Test
     void shouldMatchDocumentedApiProblemForMissingTermsVersion() throws Exception {
@@ -204,6 +233,20 @@ class TermsApiContractWebMvcTest {
         return problemSchemaPath(endpoint, method, statusCode) + "['$ref']";
     }
 
+    private static String schemaRefPath(
+        final String endpoint,
+        final String method,
+        final int statusCode
+    ) {
+        return operationPath(
+            endpoint,
+            method,
+            "responses['" + statusCode + "']"
+                + ".content['application/json']"
+                + ".schema['$ref']"
+        );
+    }
+
     private static String problemSchemaPath(
         final String endpoint,
         final String method,
@@ -224,5 +267,16 @@ class TermsApiContractWebMvcTest {
         final String suffix
     ) {
         return "$.paths['" + endpoint + "']." + method + "." + suffix;
+    }
+
+    private static TermsOfServiceView termsOfServiceView() {
+        return new TermsOfServiceView(
+            VERSION,
+            "Terms content",
+            TermsOfServiceContentType.PLAIN_TEXT,
+            TermsOfServiceStatus.ACTIVE,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            null
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Extend the customer API contract tests to validate a representative documented success response against runtime JSON.
- Extend the Terms of Service API contract tests to validate a representative documented success response against runtime JSON.
- Keep the new success checks alongside the existing runtime error-contract coverage.

## Scope
- Cover a representative `200` customer response at runtime.
- Cover a representative `200` Terms of Service response at runtime.
- Verify the published OpenAPI `application/json` schema references match the runtime response payloads.
- Keep this PR limited to success-response contract validation.

## Notes
- This PR completes follow-up task `#247`.
- No production code changed; this work adds contract-focused test coverage only.
- Error-response contract validation was completed separately in `#204`.

## Testing
- `GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :app:test --tests com.kartoush.api.customer.CustomerApiContractWebMvcTest --tests com.kartoush.api.terms.TermsApiContractWebMvcTest`
- `GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :app:test --tests com.kartoush.api.customer.CustomerApiContractWebMvcTest`

Closes #247