### PR TITLE
Add configurable customer password policy

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -33,3 +33,13 @@ logging:
     org.springframework.transaction: TRACE
     org.springframework.orm.jpa: DEBUG
     root: info
+
+kartoush:
+  auth:
+    password-policy:
+      min-length: 12
+      max-length: 255
+      require-uppercase: true
+      require-lowercase: true
+      require-digit: true
+      require-special-character: true

--- a/app/src/test/java/com/kartoush/api/customer/CustomerActivationAndPasswordSetupIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerActivationAndPasswordSetupIntegrationTest.java
@@ -338,6 +338,29 @@ class CustomerActivationAndPasswordSetupIntegrationTest extends PostgresSpringIn
             .andExpect(jsonPath("$.errorCode").value(ErrorCode.PASSWORD_SETUP_TOKEN_CONSUMED.name()));
     }
 
+    @Test
+    void shouldRejectInitialPasswordThatDoesNotMeetConfiguredPolicy() throws Exception {
+        final CreatedCustomer createdCustomer = createPendingCustomer();
+
+        final String activationResponseBody = activateCustomer(createdCustomer.customerId(), createdCustomer.rawToken())
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        final String passwordSetupToken = objectMapper.readTree(activationResponseBody)
+            .get("passwordSetupToken")
+            .asText();
+
+        mockMvc.perform(post(BASE_URL + INITIAL_PASSWORD_PATH, createdCustomer.customerId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new InitialCustomerPasswordInput(passwordSetupToken, "short1!", "short1!"))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errorCode").value(ErrorCode.VALIDATION_FAILED.name()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
+    }
+
     private CreatedCustomer createPendingCustomer() throws Exception {
         // Use a ULID-based suffix so each test customer email remains unique.
         final String email = EMAIL_LOCAL_PART_PREFIX + ulidGenerator.next().toLowerCase() + EMAIL_DOMAIN;

--- a/app/src/test/java/com/kartoush/config/CustomerPasswordPolicyConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/CustomerPasswordPolicyConfigurationTest.java
@@ -1,0 +1,80 @@
+package com.kartoush.config;
+
+import com.kartoush.auth.config.CustomerPasswordPolicyProperties;
+import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
+import com.kartoush.customer.internal.validation.SetInitialCustomerPasswordInputValidator;
+import com.kartoush.platform.validation.RequestValidationException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CustomerPasswordPolicyConfigurationTest {
+
+    private static final String SETUP_TOKEN = "setup-token";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class))
+        .withUserConfiguration(
+            CustomerPasswordPolicyProperties.class,
+            SetInitialCustomerPasswordInputValidator.class
+        );
+
+    @Test
+    void shouldApplyOverriddenPasswordPolicyValues() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.auth.password-policy.min-length=8",
+                "kartoush.auth.password-policy.require-special-character=false"
+            )
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+
+                final CustomerPasswordPolicyProperties properties =
+                    context.getBean(CustomerPasswordPolicyProperties.class);
+                final SetInitialCustomerPasswordInputValidator validator =
+                    context.getBean(SetInitialCustomerPasswordInputValidator.class);
+
+                assertThat(properties.getMinLength()).isEqualTo(8);
+                assertThat(properties.isRequireSpecialCharacter()).isFalse();
+
+                assertThatCode(() -> validator.validate(
+                    new InitialCustomerPasswordInput(SETUP_TOKEN, "Password12", "Password12")))
+                    .doesNotThrowAnyException();
+            });
+    }
+
+    @Test
+    void shouldFailContextStartupWhenPasswordPolicyRangeIsInvalid() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.auth.password-policy.min-length=20",
+                "kartoush.auth.password-policy.max-length=8"
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseMessage("kartoush.auth.password-policy.min-length must be less than or equal to max-length");
+            });
+    }
+
+    @Test
+    void shouldRejectPasswordWhenOverriddenPolicyStillRequiresSpecialCharacter() {
+        contextRunner
+            .withPropertyValues("kartoush.auth.password-policy.min-length=8")
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+
+                final SetInitialCustomerPasswordInputValidator validator =
+                    context.getBean(SetInitialCustomerPasswordInputValidator.class);
+
+                assertThatThrownBy(() -> validator.validate(
+                    new InitialCustomerPasswordInput(SETUP_TOKEN, "Password12", "Password12")))
+                    .isInstanceOf(RequestValidationException.class);
+            });
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/config/CustomerPasswordPolicyProperties.java
+++ b/auth/src/main/java/com/kartoush/auth/config/CustomerPasswordPolicyProperties.java
@@ -1,0 +1,81 @@
+package com.kartoush.auth.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kartoush.auth.password-policy")
+public class CustomerPasswordPolicyProperties {
+
+    private int minLength = 12;
+    private int maxLength = 255;
+    private boolean requireUppercase = true;
+    private boolean requireLowercase = true;
+    private boolean requireDigit = true;
+    private boolean requireSpecialCharacter = true;
+
+    public int getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(final int minLength) {
+        this.minLength = minLength;
+    }
+
+    public int getMaxLength() {
+        return maxLength;
+    }
+
+    public void setMaxLength(final int maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    public boolean isRequireUppercase() {
+        return requireUppercase;
+    }
+
+    public void setRequireUppercase(final boolean requireUppercase) {
+        this.requireUppercase = requireUppercase;
+    }
+
+    public boolean isRequireLowercase() {
+        return requireLowercase;
+    }
+
+    public void setRequireLowercase(final boolean requireLowercase) {
+        this.requireLowercase = requireLowercase;
+    }
+
+    public boolean isRequireDigit() {
+        return requireDigit;
+    }
+
+    public void setRequireDigit(final boolean requireDigit) {
+        this.requireDigit = requireDigit;
+    }
+
+    public boolean isRequireSpecialCharacter() {
+        return requireSpecialCharacter;
+    }
+
+    public void setRequireSpecialCharacter(final boolean requireSpecialCharacter) {
+        this.requireSpecialCharacter = requireSpecialCharacter;
+    }
+
+    @PostConstruct
+    void validate() {
+        if (minLength < 1) {
+            throw new IllegalStateException("kartoush.auth.password-policy.min-length must be at least 1");
+        }
+
+        if (maxLength < 1) {
+            throw new IllegalStateException("kartoush.auth.password-policy.max-length must be at least 1");
+        }
+
+        if (minLength > maxLength) {
+            throw new IllegalStateException(
+                "kartoush.auth.password-policy.min-length must be less than or equal to max-length");
+        }
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/internal/validation/SetInitialCustomerPasswordInputValidator.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/validation/SetInitialCustomerPasswordInputValidator.java
@@ -1,5 +1,6 @@
 package com.kartoush.customer.internal.validation;
 
+import com.kartoush.auth.config.CustomerPasswordPolicyProperties;
 import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
 import com.kartoush.platform.validation.RequestValidationException;
 import com.kartoush.platform.validation.RequestValidationSupport;
@@ -11,8 +12,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class SetInitialCustomerPasswordInputValidator {
 
-    private static final int PASSWORD_MAX_LENGTH = 255;
     private static final String VALIDATION_MESSAGE = "Request validation failed";
+    private final CustomerPasswordPolicyProperties passwordPolicy;
+
+    public SetInitialCustomerPasswordInputValidator(final CustomerPasswordPolicyProperties passwordPolicy) {
+        this.passwordPolicy = passwordPolicy;
+    }
 
     public void validate(final InitialCustomerPasswordInput input) {
         final List<ValidationError> errors = new ArrayList<>();
@@ -24,8 +29,10 @@ public class SetInitialCustomerPasswordInputValidator {
         }
 
         RequestValidationSupport.validateRequiredText("setupToken", input.setupToken(), 512, errors);
-        RequestValidationSupport.validateRequiredText("password", input.password(), PASSWORD_MAX_LENGTH, errors);
-        RequestValidationSupport.validateRequiredText("confirmPassword", input.confirmPassword(), PASSWORD_MAX_LENGTH, errors);
+        RequestValidationSupport.validateRequiredText("password", input.password(), passwordPolicy.getMaxLength(), errors);
+        RequestValidationSupport.validateRequiredText("confirmPassword", input.confirmPassword(), passwordPolicy.getMaxLength(), errors);
+
+        validatePasswordPolicy(input.password(), errors);
 
         if (input.password() != null
             && input.confirmPassword() != null
@@ -34,6 +41,34 @@ public class SetInitialCustomerPasswordInputValidator {
         }
 
         throwIfErrors(errors);
+    }
+
+    private void validatePasswordPolicy(final String password, final List<ValidationError> errors) {
+        if (password == null || password.isBlank()) {
+            return;
+        }
+
+        if (password.length() < passwordPolicy.getMinLength()) {
+            errors.add(new ValidationError(
+                "password",
+                "password must be at least " + passwordPolicy.getMinLength() + " characters"));
+        }
+
+        if (passwordPolicy.isRequireUppercase() && password.chars().noneMatch(Character::isUpperCase)) {
+            errors.add(new ValidationError("password", "password must contain at least one uppercase letter"));
+        }
+
+        if (passwordPolicy.isRequireLowercase() && password.chars().noneMatch(Character::isLowerCase)) {
+            errors.add(new ValidationError("password", "password must contain at least one lowercase letter"));
+        }
+
+        if (passwordPolicy.isRequireDigit() && password.chars().noneMatch(Character::isDigit)) {
+            errors.add(new ValidationError("password", "password must contain at least one digit"));
+        }
+
+        if (passwordPolicy.isRequireSpecialCharacter() && password.chars().allMatch(Character::isLetterOrDigit)) {
+            errors.add(new ValidationError("password", "password must contain at least one special character"));
+        }
     }
 
     private void throwIfErrors(final List<ValidationError> errors) {

--- a/customer/src/test/java/com/kartoush/customer/internal/validation/SetInitialCustomerPasswordInputValidatorTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/validation/SetInitialCustomerPasswordInputValidatorTest.java
@@ -1,0 +1,94 @@
+package com.kartoush.customer.internal.validation;
+
+import com.kartoush.auth.config.CustomerPasswordPolicyProperties;
+import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
+import com.kartoush.platform.validation.RequestValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SetInitialCustomerPasswordInputValidatorTest {
+
+    private static final String VALID_SETUP_TOKEN = "setup-token";
+    private static final String VALID_PASSWORD = "Password123!";
+
+    private final SetInitialCustomerPasswordInputValidator validator =
+        new SetInitialCustomerPasswordInputValidator(defaultPolicy());
+
+    @Test
+    void shouldAllowPasswordThatMatchesDefaultPolicy() {
+        final InitialCustomerPasswordInput input =
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, VALID_PASSWORD, VALID_PASSWORD);
+
+        assertThatCode(() -> validator.validate(input)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectPasswordThatIsTooShort() {
+        assertValidationError(
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, "Pass1!", "Pass1!"),
+            "password",
+            "password must be at least 12 characters");
+    }
+
+    @Test
+    void shouldRejectPasswordWithoutUppercaseLetter() {
+        assertValidationError(
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, "password123!", "password123!"),
+            "password",
+            "password must contain at least one uppercase letter");
+    }
+
+    @Test
+    void shouldRejectPasswordWithoutLowercaseLetter() {
+        assertValidationError(
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, "PASSWORD123!", "PASSWORD123!"),
+            "password",
+            "password must contain at least one lowercase letter");
+    }
+
+    @Test
+    void shouldRejectPasswordWithoutDigit() {
+        assertValidationError(
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, "PasswordOnly!", "PasswordOnly!"),
+            "password",
+            "password must contain at least one digit");
+    }
+
+    @Test
+    void shouldRejectPasswordWithoutSpecialCharacter() {
+        assertValidationError(
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, "Password1234", "Password1234"),
+            "password",
+            "password must contain at least one special character");
+    }
+
+    @Test
+    void shouldRejectConfirmPasswordThatDoesNotMatch() {
+        assertValidationError(
+            new InitialCustomerPasswordInput(VALID_SETUP_TOKEN, VALID_PASSWORD, "Password1234!"),
+            "confirmPassword",
+            "confirmPassword must match password");
+    }
+
+    private void assertValidationError(
+        final InitialCustomerPasswordInput input,
+        final String field,
+        final String message) {
+
+        assertThatThrownBy(() -> validator.validate(input))
+            .isInstanceOfSatisfying(RequestValidationException.class, exception -> {
+                assertThat(exception.getErrors())
+                    .anySatisfy(error -> {
+                        assertThat(error.field()).isEqualTo(field);
+                        assertThat(error.message()).isEqualTo(message);
+                    });
+            });
+    }
+
+    private static CustomerPasswordPolicyProperties defaultPolicy() {
+        return new CustomerPasswordPolicyProperties();
+    }
+}

--- a/docs/customer/customer-lifecycle-and-api-behavior.md
+++ b/docs/customer/customer-lifecycle-and-api-behavior.md
@@ -202,7 +202,7 @@ Error scenarios:
 `POST /api/customers/{customerId}/activation`
 
 Activates a pending customer using a valid activation token and returns the
-updated customer plus a one-time credential setup token.
+updated customer plus a one-time password setup token.
 
 Activation behavior:
 
@@ -212,8 +212,8 @@ Activation behavior:
 - the activation token must exist, be unexpired, and not already be consumed
 - a successful activation moves the customer to `ACTIVE`
 - a successful activation consumes the activation token so it cannot be reused
-- a successful activation also returns a one-time credential setup token for
-  establishing the first sign-in credential
+- a successful activation also returns a one-time password setup token for
+  establishing the first usable sign-in password
 
 Error scenarios:
 
@@ -238,15 +238,20 @@ Password setup behavior:
 - the setup token must belong to the target customer
 - the setup token must exist, be unexpired, and not already be consumed
 - password confirmation must match
+- the password must satisfy the configured password policy
+- the default password policy requires at least 12 characters, one uppercase
+  letter, one lowercase letter, one digit, and one special character
+- password policy is supplied through application configuration under
+  `kartoush.auth.password-policy`
 - a successful setup consumes the setup token so it cannot be reused
 
 Error scenarios:
 
 - 400 Bad Request for validation failures, such as blank token or password
   mismatch
-- 404 Not Found if the customer or credential setup token does not exist
-- 409 Conflict if the token is expired, already consumed, the credential
-  already exists, or the customer is not eligible for setup
+- 404 Not Found if the customer or password setup token does not exist
+- 409 Conflict if the token is expired, already consumed, the password already
+  exists, or the customer is not eligible for setup
 
 ---
 


### PR DESCRIPTION
## Summary

Add configurable customer password policy rules so first-time customer password setup enforces explicit requirements through typed application configuration instead of hardcoded validation.

## Scope

- Introduce typed password policy configuration under `kartoush.auth.password-policy`
- Enforce password policy in the initial customer password setup validator
- Add startup guardrails for invalid password policy configuration
- Add focused tests for validator behavior, config override binding, and runtime rejection of invalid passwords
- Document the default password policy and configuration source in the customer lifecycle documentation

## Notes

Password policy is modeled as application configuration rather than database-backed runtime data.

The default policy now requires at least 12 characters, one uppercase letter, one lowercase letter, one digit, and one special character.

The configuration test also verifies that invalid policy ranges, such as `min-length > max-length`, fail startup.

## Testing

- `GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :app:test --tests com.kartoush.config.CustomerPasswordPolicyConfigurationTest :customer:test --tests com.kartoush.customer.internal.validation.SetInitialCustomerPasswordInputValidatorTest :app:integrationTest --tests com.kartoush.api.customer.CustomerActivationAndPasswordSetupIntegrationTest`

Closes #267