### PR TITLE
Document authentication contracts and security behavior

### DIFF
--- a/app/src/test/java/com/kartoush/api/auth/CustomerAuthenticationOpenApiWebMvcTest.java
+++ b/app/src/test/java/com/kartoush/api/auth/CustomerAuthenticationOpenApiWebMvcTest.java
@@ -42,6 +42,7 @@ class CustomerAuthenticationOpenApiWebMvcTest {
     private static final String API_DOCS_PATH = "/v3/api-docs";
     private static final String SIGN_IN_PATH = "/api/auth/sign-in";
     private static final String API_PROBLEM_RESPONSE_REF = "#/components/schemas/ApiProblemResponse";
+    private static final String VALIDATION_PROBLEM_RESPONSE_REF = "#/components/schemas/ValidationProblemResponse";
 
     @Autowired
     private MockMvc mockMvc;
@@ -58,6 +59,8 @@ class CustomerAuthenticationOpenApiWebMvcTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath(operationPath(SIGN_IN_PATH, "post", "summary"))
                 .value("Sign in a customer"))
+            .andExpect(jsonPath(problemSchemaRefPath(SIGN_IN_PATH, "post", HttpStatus.BAD_REQUEST.value()))
+                .value(VALIDATION_PROBLEM_RESPONSE_REF))
             .andExpect(jsonPath(problemSchemaRefPath(SIGN_IN_PATH, "post", HttpStatus.UNAUTHORIZED.value()))
                 .value(API_PROBLEM_RESPONSE_REF))
             .andExpect(jsonPath("$.components.schemas.CustomerSignInView.properties.accessToken.type")

--- a/app/src/test/java/com/kartoush/api/auth/CustomerSignInIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/auth/CustomerSignInIntegrationTest.java
@@ -114,6 +114,8 @@ class CustomerSignInIntegrationTest extends PostgresSpringIntegrationTest {
                     new CustomerSignInRequest(createdCustomer.email(), "WrongPassword123!"))))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_CUSTOMER_CREDENTIALS.name()));
+
+        assertThat(customerAuthSessionRepository.findAll()).isEmpty();
     }
 
     @Test
@@ -126,6 +128,21 @@ class CustomerSignInIntegrationTest extends PostgresSpringIntegrationTest {
                     new CustomerSignInRequest(createdCustomer.email(), PASSWORD))))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_CUSTOMER_CREDENTIALS.name()));
+
+        assertThat(customerAuthSessionRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectSignInForMalformedEmailWithoutCreatingAuthSession() throws Exception {
+        mockMvc.perform(post(SIGN_IN_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new CustomerSignInRequest("not-an-email", PASSWORD))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errorCode").value(ErrorCode.VALIDATION_FAILED.name()))
+            .andExpect(jsonPath("$.errors[0].field").value("email"));
+
+        assertThat(customerAuthSessionRepository.findAll()).isEmpty();
     }
 
     private CreatedCustomer createActiveCustomerWithPassword() throws Exception {

--- a/docs/auth/authentication-contracts-and-security-behavior.md
+++ b/docs/auth/authentication-contracts-and-security-behavior.md
@@ -1,0 +1,117 @@
+# Authentication Contracts and Security Behavior
+
+## Purpose
+
+This document describes the current customer-facing authentication surface in
+Kartoush and the current security behavior.
+
+The auth ADRs explain why the architecture is shaped this way. This document
+explains what the current API actually does.
+
+## Current Auth Surface
+
+Kartoush currently exposes the following customer-facing auth flow:
+
+1. `POST /api/customers`
+   Creates a `PENDING` customer and issues an activation token through the
+   configured activation email service
+2. `POST /api/customers/{customerId}/activation`
+   Activates the customer and returns a one-time password setup token
+3. `POST /api/customers/{customerId}/initial-password`
+   Consumes the setup token and establishes the first usable customer password
+4. `POST /api/auth/sign-in`
+   Authenticates the customer with email and password and returns an opaque
+   bearer token
+
+## Current Security Behavior
+
+### Public vs authenticated routes
+
+The registration, activation, initial password setup, and sign-in routes are
+currently public entry points by design.
+
+Kartoush now issues opaque bearer tokens, but it does not yet use those
+tokens to protect customer or internal routes. Runtime token validation and
+authenticated route enforcement remain follow-up work under the API security
+track.
+
+### Customer eligibility rules
+
+Current customer sign-in requires all of the following:
+
+- The customer must exist
+- The customer must be in `ACTIVE` status
+- The customer must already have an established password
+- The supplied password must match the stored password hash
+
+If any of those checks fail after request validation, the runtime API returns
+the same `401 Unauthorized` auth failure response.
+
+### Session behavior
+
+Successful sign-in creates a server-side auth session and returns an opaque
+`Bearer` access token to the client.
+
+Failed sign-in attempts do not create auth-session records. That is part of
+the tested runtime contract, not just an implementation detail.
+
+### Token behavior
+
+Kartoush currently uses three token types with distinct responsibilities:
+
+- Activation tokens
+  Used to move a customer from `PENDING` to `ACTIVE`
+- Password setup tokens
+  One-time tokens used to establish the first password after activation
+- Access tokens
+  Opaque bearer tokens returned by sign-in and backed by server-side auth
+  session state
+
+Activation tokens and password setup tokens are one-time use. Successful use
+consumes the token so it cannot be reused.
+
+## Error Contract Notes
+
+The current auth-related API contract follows these rules:
+
+- Validation failures return `400 Bad Request` with the shared validation
+  problem schema
+- Authentication failures return `401 Unauthorized` with
+  `INVALID_CUSTOMER_CREDENTIALS`
+- Password setup lifecycle and duplicate-password failures return
+  `409 Conflict`
+- Missing activation or password setup tokens return `404 Not Found`
+
+These contracts are reflected in OpenAPI and verified by MVC and integration
+tests.
+
+## Current Automated Coverage
+
+The current auth behavior is covered by:
+
+- MVC tests for auth request and response shape
+- OpenAPI tests for sign-in documentation
+- Integration tests for activation, password setup, and sign-in flows
+- Auth module unit and repository tests for password and auth-session behavior
+
+Representative tests include:
+
+- `CustomerAuthenticationControllerWebMvcTest`
+- `CustomerAuthenticationOpenApiWebMvcTest`
+- `CustomerActivationAndPasswordSetupIntegrationTest`
+- `CustomerSignInIntegrationTest`
+- `DefaultCustomerSignInFacadeTest`
+- `DefaultCustomerAuthSessionServiceTest`
+- `CustomerAuthSessionRepositoryTest`
+
+## What Is Not Covered Yet
+
+The following are intentionally not implemented yet:
+
+- Password reset and password history enforcement
+- External authentication providers such as Google or Facebook
+- Runtime token validation for protected customer routes
+- Runtime authorization for internal management APIs
+
+Those concerns are tracked separately and should not be inferred from the
+current bearer token issuance alone.

--- a/docs/customer/customer-lifecycle-and-api-behavior.md
+++ b/docs/customer/customer-lifecycle-and-api-behavior.md
@@ -270,6 +270,7 @@ Sign-in behavior:
 - the supplied password must match the stored password hash
 - a successful sign-in returns an opaque `Bearer` token backed by server-side
   auth-session state
+- failed sign-in attempts do not create authenticated sessions
 
 Error scenarios:
 
@@ -277,6 +278,10 @@ Error scenarios:
   email input
 - 401 Unauthorized if authentication fails because the customer does not exist,
   is not eligible to sign in, or the password is invalid
+
+See also:
+
+- `docs/auth/authentication-contracts-and-security-behavior.md`
 
 ---
 

--- a/docs/testing/api-testing-strategy.md
+++ b/docs/testing/api-testing-strategy.md
@@ -246,6 +246,7 @@ The customer create endpoint is a good example of the intended workflow.
 
    Today that means:
 
+   - `com.kartoush.api.auth.*`
    - `com.kartoush.api.customer.*`
    - `com.kartoush.api.terms.*`
 


### PR DESCRIPTION
## Summary
Document the current authentication contracts and tighten the auth tests that prove the implemented security behavior.

## Scope
- Add a dedicated authentication behavior reference covering registration, activation, initial password setup, and sign-in
- Update customer lifecycle documentation to point at the auth behavior reference and clarify sign-in side effects
- Update the API testing strategy to reflect auth integration test package coverage in CI
- Tighten auth OpenAPI and integration tests around validation behavior and failed sign-in session side effects

## Notes
- This PR documents and verifies the auth behavior that already exists today
- Protected-route token enforcement remains separate follow-up work under the API security track

## Testing
- `./gradlew :app:test --tests com.kartoush.api.auth.CustomerAuthenticationOpenApiWebMvcTest`
- `./gradlew :app:integrationTest --tests com.kartoush.api.auth.CustomerSignInIntegrationTest`

Closes #256