### PR TITLE
Add Transactional Email Provider Adapters and Profiled Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ For detailed testing conventions and design decisions, see:
 - `docs/architecture/decisions/0023-testing-strategy-and-conventions.md`
 - `docs/testing/api-testing-strategy.md`
 
+For transactional email provider and environment configuration, including the
+local Mailtrap-backed quick start, see:
+
+- `docs/auth/transactional-email-provider-configuration.md`
+
 ---
 
 ## API Documentation

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+kartoush:
+  email:
+    delivery:
+      provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:mailtrap}
+      enabled: ${KARTOUSH_EMAIL_DELIVERY_ENABLED:false}
+      mailtrap:
+        api-base-url: ${KARTOUSH_EMAIL_MAILTRAP_API_BASE_URL:https://sandbox.api.mailtrap.io/api/send}
+        api-token: ${KARTOUSH_EMAIL_MAILTRAP_API_TOKEN:}
+        inbox-id: ${KARTOUSH_EMAIL_MAILTRAP_INBOX_ID:0}

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+kartoush:
+  email:
+    delivery:
+      provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:brevo}
+      enabled: ${KARTOUSH_EMAIL_DELIVERY_ENABLED:true}
+      brevo:
+        api-base-url: ${KARTOUSH_EMAIL_BREVO_API_BASE_URL:https://api.brevo.com/v3}
+        api-key: ${KARTOUSH_EMAIL_BREVO_API_KEY:}

--- a/app/src/main/resources/application-test.yml
+++ b/app/src/main/resources/application-test.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+kartoush:
+  email:
+    delivery:
+      provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:noop}
+      enabled: ${KARTOUSH_EMAIL_DELIVERY_ENABLED:false}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -37,10 +37,13 @@ logging:
 kartoush:
   email:
     customer:
-      sender-name: Kartoush
-      sender-address: no-reply@kartoush.dev
-      activation-base-url: https://kartoush.dev/activate
-      password-reset-base-url: https://kartoush.dev/reset-password
+      sender-name: ${KARTOUSH_EMAIL_SENDER_NAME:Kartoush}
+      sender-address: ${KARTOUSH_EMAIL_SENDER_ADDRESS:no-reply@notify.kartoush.com}
+      activation-base-url: ${KARTOUSH_EMAIL_ACTIVATION_BASE_URL:https://kartoush.dev/activate}
+      password-reset-base-url: ${KARTOUSH_EMAIL_PASSWORD_RESET_BASE_URL:https://kartoush.dev/reset-password}
+    delivery:
+      provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:noop}
+      enabled: ${KARTOUSH_EMAIL_DELIVERY_ENABLED:false}
   auth:
     password-policy:
       min-length: 12

--- a/app/src/test/java/com/kartoush/config/CustomerEmailConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/CustomerEmailConfigurationTest.java
@@ -1,9 +1,11 @@
 package com.kartoush.config;
 
 import com.kartoush.auth.email.CustomerTransactionalEmailProperties;
+import com.kartoush.auth.email.BrevoEmailDeliveryService;
 import com.kartoush.auth.email.EmailDeliveryConfiguration;
+import com.kartoush.auth.email.EmailDeliveryProperties;
 import com.kartoush.auth.email.EmailDeliveryService;
-import com.kartoush.auth.email.EmailMessage;
+import com.kartoush.auth.email.MailtrapEmailDeliveryService;
 import com.kartoush.auth.email.NoOpEmailDeliveryService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -18,6 +20,7 @@ class CustomerEmailConfigurationTest {
         .withConfiguration(AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class))
         .withUserConfiguration(
             CustomerTransactionalEmailProperties.class,
+            EmailDeliveryProperties.class,
             EmailDeliveryConfiguration.class
         );
 
@@ -33,19 +36,40 @@ class CustomerEmailConfigurationTest {
     }
 
     @Test
-    void shouldBackOffNoOpEmailDeliveryServiceWhenConcreteBeanExists() {
+    void shouldProvideMailtrapEmailDeliveryServiceWhenMailtrapIsEnabled() {
         contextRunner
-            .withBean("stubEmailDeliveryService", EmailDeliveryService.class, StubEmailDeliveryService::new)
+            .withPropertyValues(
+                "kartoush.email.delivery.enabled=true",
+                "kartoush.email.delivery.provider=mailtrap",
+                "kartoush.email.delivery.mailtrap.api-base-url=https://sandbox.api.mailtrap.io/api/send",
+                "kartoush.email.delivery.mailtrap.api-token=mailtrap-api-token",
+                "kartoush.email.delivery.mailtrap.inbox-id=12345"
+            )
             .run(context -> {
                 assertThat(context).hasNotFailed();
                 assertThat(context).hasSingleBean(EmailDeliveryService.class);
-                assertThat(context.getBean(EmailDeliveryService.class)).isInstanceOf(StubEmailDeliveryService.class);
-                assertThat(context).doesNotHaveBean(NoOpEmailDeliveryService.class);
+                assertThat(context.getBean(EmailDeliveryService.class)).isInstanceOf(MailtrapEmailDeliveryService.class);
             });
     }
 
     @Test
-    void shouldProvideNoOpEmailDeliveryServiceWhenNoConcreteBeanExists() {
+    void shouldProvideBrevoEmailDeliveryServiceWhenBrevoIsEnabled() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.email.delivery.enabled=true",
+                "kartoush.email.delivery.provider=brevo",
+                "kartoush.email.delivery.brevo.api-base-url=https://api.brevo.com/v3",
+                "kartoush.email.delivery.brevo.api-key=test-brevo-key"
+            )
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).hasSingleBean(EmailDeliveryService.class);
+                assertThat(context.getBean(EmailDeliveryService.class)).isInstanceOf(BrevoEmailDeliveryService.class);
+            });
+    }
+
+    @Test
+    void shouldProvideNoOpEmailDeliveryServiceWhenDeliveryIsDisabled() {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(EmailDeliveryService.class);
@@ -53,10 +77,66 @@ class CustomerEmailConfigurationTest {
         });
     }
 
-    static class StubEmailDeliveryService implements EmailDeliveryService {
+    @Test
+    void shouldFailContextStartupWhenMailtrapCredentialsAreMissing() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.email.delivery.enabled=true",
+                "kartoush.email.delivery.provider=mailtrap",
+                "kartoush.email.delivery.mailtrap.api-base-url=https://sandbox.api.mailtrap.io/api/send",
+                "kartoush.email.delivery.mailtrap.inbox-id=12345"
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasStackTraceContaining("kartoush.email.delivery.mailtrap.api-token must not be blank");
+            });
+    }
 
-        @Override
-        public void send(final EmailMessage email) {
-        }
+    @Test
+    void shouldFailContextStartupWhenMailtrapInboxIdIsMissing() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.email.delivery.enabled=true",
+                "kartoush.email.delivery.provider=mailtrap",
+                "kartoush.email.delivery.mailtrap.api-base-url=https://sandbox.api.mailtrap.io/api/send",
+                "kartoush.email.delivery.mailtrap.api-token=mailtrap-api-token"
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasStackTraceContaining("kartoush.email.delivery.mailtrap.inbox-id must be greater than zero");
+            });
+    }
+
+    @Test
+    void shouldFailContextStartupWhenBrevoApiKeyIsMissing() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.email.delivery.enabled=true",
+                "kartoush.email.delivery.provider=brevo",
+                "kartoush.email.delivery.brevo.api-base-url=https://api.brevo.com/v3"
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasStackTraceContaining("kartoush.email.delivery.brevo.api-key must not be blank");
+            });
+    }
+
+    @Test
+    void shouldFailContextStartupWhenBrevoApiBaseUrlIsMalformed() {
+        contextRunner
+            .withPropertyValues(
+                "kartoush.email.delivery.enabled=true",
+                "kartoush.email.delivery.provider=brevo",
+                "kartoush.email.delivery.brevo.api-base-url=not a uri",
+                "kartoush.email.delivery.brevo.api-key=test-brevo-key"
+            )
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasStackTraceContaining("kartoush.email.delivery.brevo.api-base-url must be a valid URI");
+            });
     }
 }

--- a/auth/src/main/java/com/kartoush/auth/email/BrevoEmailApiClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/BrevoEmailApiClient.java
@@ -1,0 +1,8 @@
+package com.kartoush.auth.email;
+
+import java.util.Optional;
+
+public interface BrevoEmailApiClient {
+
+    Optional<String> send(EmailMessage email);
+}

--- a/auth/src/main/java/com/kartoush/auth/email/BrevoEmailDeliveryService.java
+++ b/auth/src/main/java/com/kartoush/auth/email/BrevoEmailDeliveryService.java
@@ -1,0 +1,47 @@
+package com.kartoush.auth.email;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class BrevoEmailDeliveryService implements EmailDeliveryService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BrevoEmailDeliveryService.class);
+
+    private final BrevoEmailApiClient brevoEmailApiClient;
+
+    public BrevoEmailDeliveryService(final BrevoEmailApiClient brevoEmailApiClient) {
+        this.brevoEmailApiClient = brevoEmailApiClient;
+    }
+
+    @Override
+    public void send(final EmailMessage email) {
+        try {
+            final Optional<String> providerMessageId = brevoEmailApiClient.send(email);
+            if (providerMessageId.isPresent()) {
+                LOG.info(
+                    "Brevo email sent for type={} recipient={} providerMessageId={}",
+                    email.type(),
+                    email.recipient().value(),
+                    providerMessageId.orElseThrow()
+                );
+                return;
+            }
+
+            LOG.info(
+                "Brevo email sent for type={} recipient={}",
+                email.type(),
+                email.recipient().value()
+            );
+        } catch (final EmailDeliveryException exception) {
+            LOG.error(
+                "Brevo email delivery failed for type={} recipient={}",
+                email.type(),
+                email.recipient().value(),
+                exception
+            );
+            throw exception;
+        }
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/BrevoHttpClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/BrevoHttpClient.java
@@ -1,0 +1,9 @@
+package com.kartoush.auth.email;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public interface BrevoHttpClient {
+
+    HttpResponse<String> send(HttpRequest request);
+}

--- a/auth/src/main/java/com/kartoush/auth/email/DefaultBrevoEmailApiClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/DefaultBrevoEmailApiClient.java
@@ -1,0 +1,101 @@
+package com.kartoush.auth.email;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DefaultBrevoEmailApiClient implements BrevoEmailApiClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultBrevoEmailApiClient.class);
+    private static final Pattern MESSAGE_ID_PATTERN = Pattern.compile("\"messageId\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern MESSAGE_IDS_PATTERN = Pattern.compile("\"messageIds\"\\s*:\\s*\\[\\s*\"([^\"]+)\"");
+
+    private final BrevoHttpClient brevoHttpClient;
+    private final EmailDeliveryProperties.Brevo properties;
+
+    public DefaultBrevoEmailApiClient(
+        final BrevoHttpClient brevoHttpClient,
+        final EmailDeliveryProperties.Brevo properties
+    ) {
+        this.brevoHttpClient = brevoHttpClient;
+        this.properties = properties;
+    }
+
+    @Override
+    public Optional<String> send(final EmailMessage email) {
+        final String endpoint = properties.getApiBaseUrl().replaceAll("/+$", "") + "/smtp/email";
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(endpoint))
+            .timeout(Duration.ofSeconds(10))
+            .header("accept", "application/json")
+            .header("content-type", "application/json")
+            .header("api-key", properties.getApiKey())
+            .POST(HttpRequest.BodyPublishers.ofString(toJson(email)))
+            .build();
+
+        final HttpResponse<String> response = brevoHttpClient.send(request);
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            LOG.error(
+                "Brevo email delivery failed with status={} body={}",
+                response.statusCode(),
+                response.body()
+            );
+            throw new EmailDeliveryException("Brevo email delivery failed with status " + response.statusCode());
+        }
+
+        return extractMessageId(response.body());
+    }
+
+    private String toJson(final EmailMessage email) {
+        return """
+            {
+              "sender": {
+                "name": "%s",
+                "email": "%s"
+              },
+              "to": [
+                {
+                  "email": "%s"
+                }
+              ],
+              "subject": "%s",
+              "textContent": "%s"
+            }
+            """.formatted(
+            escape(email.senderName()),
+            escape(email.senderAddress().value()),
+            escape(email.recipient().value()),
+            escape(email.subject()),
+            escape(email.textBody())
+        ).trim();
+    }
+
+    private Optional<String> extractMessageId(final String body) {
+        final Matcher messageIdMatcher = MESSAGE_ID_PATTERN.matcher(body);
+        if (messageIdMatcher.find()) {
+            return Optional.of(messageIdMatcher.group(1));
+        }
+
+        final Matcher messageIdsMatcher = MESSAGE_IDS_PATTERN.matcher(body);
+        if (messageIdsMatcher.find()) {
+            return Optional.of(messageIdsMatcher.group(1));
+        }
+
+        return Optional.empty();
+    }
+
+    private String escape(final String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n");
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/DefaultBrevoHttpClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/DefaultBrevoHttpClient.java
@@ -1,0 +1,28 @@
+package com.kartoush.auth.email;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class DefaultBrevoHttpClient implements BrevoHttpClient {
+
+    private final HttpClient httpClient;
+
+    public DefaultBrevoHttpClient(final HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public HttpResponse<String> send(final HttpRequest request) {
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (final IOException | InterruptedException exception) {
+            if (exception instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
+            throw new EmailDeliveryException("Brevo email delivery failed", exception);
+        }
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/DefaultMailtrapEmailApiClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/DefaultMailtrapEmailApiClient.java
@@ -1,0 +1,85 @@
+package com.kartoush.auth.email;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DefaultMailtrapEmailApiClient implements MailtrapEmailApiClient {
+
+    private static final Pattern MESSAGE_IDS_PATTERN = Pattern.compile("\"message_ids\"\\s*:\\s*\\[\\s*\"([^\"]+)\"");
+
+    private final MailtrapHttpClient mailtrapHttpClient;
+    private final EmailDeliveryProperties.Mailtrap properties;
+
+    public DefaultMailtrapEmailApiClient(
+        final MailtrapHttpClient mailtrapHttpClient,
+        final EmailDeliveryProperties.Mailtrap properties
+    ) {
+        this.mailtrapHttpClient = mailtrapHttpClient;
+        this.properties = properties;
+    }
+
+    @Override
+    public Optional<String> send(final EmailMessage email) {
+        final String endpoint = properties.getApiBaseUrl().replaceAll("/+$", "") + "/" + properties.getInboxId();
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(endpoint))
+            .timeout(Duration.ofSeconds(10))
+            .header("accept", "application/json")
+            .header("content-type", "application/json")
+            .header("Api-Token", properties.getApiToken())
+            .POST(HttpRequest.BodyPublishers.ofString(toJson(email)))
+            .build();
+
+        final HttpResponse<String> response = mailtrapHttpClient.send(request);
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new EmailDeliveryException("Mailtrap email delivery failed with status " + response.statusCode());
+        }
+
+        return extractMessageId(response.body());
+    }
+
+    private String toJson(final EmailMessage email) {
+        return """
+            {
+              "from": {
+                "email": "%s",
+                "name": "%s"
+              },
+              "to": [
+                {
+                  "email": "%s"
+                }
+              ],
+              "subject": "%s",
+              "text": "%s"
+            }
+            """.formatted(
+            escape(email.senderAddress().value()),
+            escape(email.senderName()),
+            escape(email.recipient().value()),
+            escape(email.subject()),
+            escape(email.textBody())
+        ).trim();
+    }
+
+    private Optional<String> extractMessageId(final String body) {
+        final Matcher matcher = MESSAGE_IDS_PATTERN.matcher(body);
+        if (matcher.find()) {
+            return Optional.of(matcher.group(1));
+        }
+
+        return Optional.empty();
+    }
+
+    private String escape(final String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n");
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/DefaultMailtrapHttpClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/DefaultMailtrapHttpClient.java
@@ -1,0 +1,28 @@
+package com.kartoush.auth.email;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class DefaultMailtrapHttpClient implements MailtrapHttpClient {
+
+    private final HttpClient httpClient;
+
+    public DefaultMailtrapHttpClient(final HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public HttpResponse<String> send(final HttpRequest request) {
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (final IOException | InterruptedException exception) {
+            if (exception instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
+            throw new EmailDeliveryException("Mailtrap email delivery failed", exception);
+        }
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryConfiguration.java
+++ b/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryConfiguration.java
@@ -1,15 +1,33 @@
 package com.kartoush.auth.email;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.net.http.HttpClient;
 
 @Configuration
 public class EmailDeliveryConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(EmailDeliveryService.class)
-    EmailDeliveryService emailDeliveryService() {
-        return new NoOpEmailDeliveryService();
+    EmailDeliveryService emailDeliveryService(final EmailDeliveryProperties properties) {
+        if (!properties.isEnabled() || properties.getProvider() == EmailDeliveryProvider.NOOP) {
+            return new NoOpEmailDeliveryService();
+        }
+
+        return switch (properties.getProvider()) {
+            case MAILTRAP -> new MailtrapEmailDeliveryService(
+                new DefaultMailtrapEmailApiClient(
+                    new DefaultMailtrapHttpClient(HttpClient.newHttpClient()),
+                    properties.getMailtrap()
+                )
+            );
+            case BREVO -> new BrevoEmailDeliveryService(
+                new DefaultBrevoEmailApiClient(
+                    new DefaultBrevoHttpClient(HttpClient.newHttpClient()),
+                    properties.getBrevo()
+                )
+            );
+            case NOOP -> new NoOpEmailDeliveryService();
+        };
     }
 }

--- a/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryException.java
+++ b/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryException.java
@@ -1,0 +1,12 @@
+package com.kartoush.auth.email;
+
+public class EmailDeliveryException extends RuntimeException {
+
+    public EmailDeliveryException(final String message) {
+        super(message);
+    }
+
+    public EmailDeliveryException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryProperties.java
+++ b/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryProperties.java
@@ -1,0 +1,145 @@
+package com.kartoush.auth.email;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+@ConfigurationProperties(prefix = "kartoush.email.delivery")
+public class EmailDeliveryProperties {
+
+    private boolean enabled = false;
+    private EmailDeliveryProvider provider = EmailDeliveryProvider.NOOP;
+    private final Mailtrap mailtrap = new Mailtrap();
+    private final Brevo brevo = new Brevo();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public EmailDeliveryProvider getProvider() {
+        return provider;
+    }
+
+    public void setProvider(final EmailDeliveryProvider provider) {
+        this.provider = provider;
+    }
+
+    public Mailtrap getMailtrap() {
+        return mailtrap;
+    }
+
+    public Brevo getBrevo() {
+        return brevo;
+    }
+
+    @PostConstruct
+    void validate() {
+        if (!enabled || provider == null || provider == EmailDeliveryProvider.NOOP) {
+            return;
+        }
+
+        switch (provider) {
+            case MAILTRAP -> mailtrap.validate();
+            case BREVO -> brevo.validate();
+            case NOOP -> {
+                return;
+            }
+        }
+    }
+
+    public static class Mailtrap {
+
+        private String apiBaseUrl = "https://sandbox.api.mailtrap.io/api/send";
+        private String apiToken = "";
+        private long inboxId;
+
+        public String getApiBaseUrl() {
+            return apiBaseUrl;
+        }
+
+        public void setApiBaseUrl(final String apiBaseUrl) {
+            this.apiBaseUrl = apiBaseUrl;
+        }
+
+        public String getApiToken() {
+            return apiToken;
+        }
+
+        public void setApiToken(final String apiToken) {
+            this.apiToken = apiToken;
+        }
+
+        public long getInboxId() {
+            return inboxId;
+        }
+
+        public void setInboxId(final long inboxId) {
+            this.inboxId = inboxId;
+        }
+
+        void validate() {
+            validateHttpUrl(apiBaseUrl, "kartoush.email.delivery.mailtrap.api-base-url");
+            validateRequiredText(apiToken, "kartoush.email.delivery.mailtrap.api-token");
+            if (inboxId <= 0) {
+                throw new IllegalStateException("kartoush.email.delivery.mailtrap.inbox-id must be greater than zero");
+            }
+        }
+    }
+
+    public static class Brevo {
+
+        private String apiBaseUrl = "https://api.brevo.com/v3";
+        private String apiKey = "";
+
+        public String getApiBaseUrl() {
+            return apiBaseUrl;
+        }
+
+        public void setApiBaseUrl(final String apiBaseUrl) {
+            this.apiBaseUrl = apiBaseUrl;
+        }
+
+        public String getApiKey() {
+            return apiKey;
+        }
+
+        public void setApiKey(final String apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        void validate() {
+            validateHttpUrl(apiBaseUrl, "kartoush.email.delivery.brevo.api-base-url");
+            validateRequiredText(apiKey, "kartoush.email.delivery.brevo.api-key");
+        }
+    }
+
+    private static void validateRequiredText(final String value, final String property) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(property + " must not be blank");
+        }
+    }
+
+    private static void validateHttpUrl(final String value, final String property) {
+        validateRequiredText(value, property);
+
+        final URI uri;
+        try {
+            uri = URI.create(value);
+        } catch (final IllegalArgumentException exception) {
+            throw new IllegalStateException(property + " must be a valid URI", exception);
+        }
+
+        final String scheme = uri.getScheme();
+        if (!uri.isAbsolute() || uri.getHost() == null || scheme == null
+            || (!scheme.equals("http") && !scheme.equals("https"))) {
+            throw new IllegalStateException(property + " must be an absolute http or https URI");
+        }
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryProvider.java
+++ b/auth/src/main/java/com/kartoush/auth/email/EmailDeliveryProvider.java
@@ -1,0 +1,7 @@
+package com.kartoush.auth.email;
+
+public enum EmailDeliveryProvider {
+    NOOP,
+    MAILTRAP,
+    BREVO
+}

--- a/auth/src/main/java/com/kartoush/auth/email/MailtrapEmailApiClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/MailtrapEmailApiClient.java
@@ -1,0 +1,8 @@
+package com.kartoush.auth.email;
+
+import java.util.Optional;
+
+public interface MailtrapEmailApiClient {
+
+    Optional<String> send(EmailMessage email);
+}

--- a/auth/src/main/java/com/kartoush/auth/email/MailtrapEmailDeliveryService.java
+++ b/auth/src/main/java/com/kartoush/auth/email/MailtrapEmailDeliveryService.java
@@ -1,0 +1,47 @@
+package com.kartoush.auth.email;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class MailtrapEmailDeliveryService implements EmailDeliveryService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MailtrapEmailDeliveryService.class);
+
+    private final MailtrapEmailApiClient mailtrapEmailApiClient;
+
+    public MailtrapEmailDeliveryService(final MailtrapEmailApiClient mailtrapEmailApiClient) {
+        this.mailtrapEmailApiClient = mailtrapEmailApiClient;
+    }
+
+    @Override
+    public void send(final EmailMessage email) {
+        try {
+            final Optional<String> providerMessageId = mailtrapEmailApiClient.send(email);
+            if (providerMessageId.isPresent()) {
+                LOG.info(
+                    "Mailtrap email sent for type={} recipient={} providerMessageId={}",
+                    email.type(),
+                    email.recipient().value(),
+                    providerMessageId.orElseThrow()
+                );
+                return;
+            }
+
+            LOG.info(
+                "Mailtrap email sent for type={} recipient={}",
+                email.type(),
+                email.recipient().value()
+            );
+        } catch (final EmailDeliveryException exception) {
+            LOG.error(
+                "Mailtrap email delivery failed for type={} recipient={}",
+                email.type(),
+                email.recipient().value(),
+                exception
+            );
+            throw exception;
+        }
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/email/MailtrapHttpClient.java
+++ b/auth/src/main/java/com/kartoush/auth/email/MailtrapHttpClient.java
@@ -1,0 +1,9 @@
+package com.kartoush.auth.email;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public interface MailtrapHttpClient {
+
+    HttpResponse<String> send(HttpRequest request);
+}

--- a/auth/src/test/java/com/kartoush/auth/email/BrevoEmailDeliveryServiceTest.java
+++ b/auth/src/test/java/com/kartoush/auth/email/BrevoEmailDeliveryServiceTest.java
@@ -1,0 +1,58 @@
+package com.kartoush.auth.email;
+
+import com.kartoush.platform.types.Email;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BrevoEmailDeliveryServiceTest {
+
+    @Test
+    void shouldDelegateToBrevoApiClient() {
+        final BrevoEmailApiClient brevoEmailApiClient = mock(BrevoEmailApiClient.class);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_PASSWORD_RESET,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Reset your Kartoush password",
+            "Reset it here",
+            "https://kartoush.dev/reset-password?token=abc"
+        );
+        when(brevoEmailApiClient.send(email)).thenReturn(Optional.of("brevo-message-id"));
+
+        final BrevoEmailDeliveryService service = new BrevoEmailDeliveryService(brevoEmailApiClient);
+
+        assertThatCode(() -> service.send(email)).doesNotThrowAnyException();
+        verify(brevoEmailApiClient).send(email);
+    }
+
+    @Test
+    void shouldRethrowBrevoDeliveryFailures() {
+        final BrevoEmailApiClient brevoEmailApiClient = mock(BrevoEmailApiClient.class);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_PASSWORD_RESET,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Reset your Kartoush password",
+            "Reset it here",
+            "https://kartoush.dev/reset-password?token=abc"
+        );
+        final EmailDeliveryException exception = new EmailDeliveryException("Brevo email delivery failed");
+        doThrow(exception).when(brevoEmailApiClient).send(email);
+
+        final BrevoEmailDeliveryService service = new BrevoEmailDeliveryService(brevoEmailApiClient);
+
+        assertThatThrownBy(() -> service.send(email))
+            .isInstanceOf(EmailDeliveryException.class)
+            .hasMessage("Brevo email delivery failed");
+    }
+}

--- a/auth/src/test/java/com/kartoush/auth/email/DefaultBrevoEmailApiClientTest.java
+++ b/auth/src/test/java/com/kartoush/auth/email/DefaultBrevoEmailApiClientTest.java
@@ -1,0 +1,139 @@
+package com.kartoush.auth.email;
+
+import com.kartoush.platform.types.Email;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultBrevoEmailApiClientTest {
+
+    @Test
+    void shouldBuildBrevoRequestAndExtractMessageId() {
+        final BrevoHttpClient brevoHttpClient = mock(BrevoHttpClient.class);
+        final EmailDeliveryProperties.Brevo properties = new EmailDeliveryProperties.Brevo();
+        properties.setApiBaseUrl("https://api.brevo.com/v3");
+        properties.setApiKey("brevo-api-key");
+
+        final HttpRequestCapturingResponse response = new HttpRequestCapturingResponse(
+            201,
+            "{\"messageId\":\"brevo-message-id\"}"
+        );
+        when(brevoHttpClient.send(any(HttpRequest.class))).thenAnswer(invocation -> {
+            response.setRequest(invocation.getArgument(0));
+            return response;
+        });
+
+        final DefaultBrevoEmailApiClient client = new DefaultBrevoEmailApiClient(brevoHttpClient, properties);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_ACTIVATION,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Activate your Kartoush account",
+            "Click here",
+            "https://kartoush.dev/activate?token=abc"
+        );
+
+        final Optional<String> messageId = client.send(email);
+
+        assertThat(messageId).contains("brevo-message-id");
+        assertThat(response.request.uri()).isEqualTo(URI.create("https://api.brevo.com/v3/smtp/email"));
+        assertThat(response.request.headers().firstValue("api-key")).contains("brevo-api-key");
+        assertThat(response.request.headers().firstValue("content-type")).contains("application/json");
+        assertThat(response.request.method()).isEqualTo("POST");
+    }
+
+    @Test
+    void shouldThrowWhenBrevoReturnsNonSuccessStatus() {
+        final BrevoHttpClient brevoHttpClient = mock(BrevoHttpClient.class);
+        final EmailDeliveryProperties.Brevo properties = new EmailDeliveryProperties.Brevo();
+        properties.setApiBaseUrl("https://api.brevo.com/v3");
+        properties.setApiKey("brevo-api-key");
+
+        when(brevoHttpClient.send(any(HttpRequest.class)))
+            .thenReturn(new HttpRequestCapturingResponse(500, "{\"message\":\"provider failure\"}"));
+
+        final DefaultBrevoEmailApiClient client = new DefaultBrevoEmailApiClient(brevoHttpClient, properties);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_PASSWORD_RESET,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Reset your Kartoush password",
+            "Reset it here",
+            "https://kartoush.dev/reset-password?token=abc"
+        );
+
+        assertThatThrownBy(() -> client.send(email))
+            .isInstanceOf(EmailDeliveryException.class)
+            .hasMessage("Brevo email delivery failed with status 500");
+    }
+
+    static class HttpRequestCapturingResponse implements HttpResponse<String> {
+
+        private final int statusCode;
+        private final String body;
+        private HttpRequest request;
+
+        HttpRequestCapturingResponse(final int statusCode, final String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        void setRequest(final HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public int statusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public Optional<HttpResponse<String>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public String body() {
+            return body;
+        }
+
+        @Override
+        public Optional<javax.net.ssl.SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return request.uri();
+        }
+
+        @Override
+        public java.net.http.HttpClient.Version version() {
+            return java.net.http.HttpClient.Version.HTTP_1_1;
+        }
+
+    }
+}

--- a/auth/src/test/java/com/kartoush/auth/email/DefaultMailtrapEmailApiClientTest.java
+++ b/auth/src/test/java/com/kartoush/auth/email/DefaultMailtrapEmailApiClientTest.java
@@ -1,0 +1,140 @@
+package com.kartoush.auth.email;
+
+import com.kartoush.platform.types.Email;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultMailtrapEmailApiClientTest {
+
+    @Test
+    void shouldBuildMailtrapRequestAndExtractMessageId() {
+        final MailtrapHttpClient mailtrapHttpClient = mock(MailtrapHttpClient.class);
+        final EmailDeliveryProperties.Mailtrap properties = new EmailDeliveryProperties.Mailtrap();
+        properties.setApiBaseUrl("https://sandbox.api.mailtrap.io/api/send");
+        properties.setApiToken("mailtrap-api-token");
+        properties.setInboxId(12345);
+
+        final HttpRequestCapturingResponse response = new HttpRequestCapturingResponse(
+            200,
+            "{\"message_ids\":[\"mailtrap-message-id\"]}"
+        );
+        when(mailtrapHttpClient.send(any(HttpRequest.class))).thenAnswer(invocation -> {
+            response.setRequest(invocation.getArgument(0));
+            return response;
+        });
+
+        final DefaultMailtrapEmailApiClient client = new DefaultMailtrapEmailApiClient(mailtrapHttpClient, properties);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_ACTIVATION,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Activate your Kartoush account",
+            "Click here",
+            "https://kartoush.dev/activate?token=abc"
+        );
+
+        final Optional<String> messageId = client.send(email);
+
+        assertThat(messageId).contains("mailtrap-message-id");
+        assertThat(response.request.uri()).isEqualTo(URI.create("https://sandbox.api.mailtrap.io/api/send/12345"));
+        assertThat(response.request.headers().firstValue("Api-Token")).contains("mailtrap-api-token");
+        assertThat(response.request.headers().firstValue("content-type")).contains("application/json");
+        assertThat(response.request.method()).isEqualTo("POST");
+    }
+
+    @Test
+    void shouldThrowWhenMailtrapReturnsNonSuccessStatus() {
+        final MailtrapHttpClient mailtrapHttpClient = mock(MailtrapHttpClient.class);
+        final EmailDeliveryProperties.Mailtrap properties = new EmailDeliveryProperties.Mailtrap();
+        properties.setApiBaseUrl("https://sandbox.api.mailtrap.io/api/send");
+        properties.setApiToken("mailtrap-api-token");
+        properties.setInboxId(12345);
+
+        when(mailtrapHttpClient.send(any(HttpRequest.class)))
+            .thenReturn(new HttpRequestCapturingResponse(401, "{\"message\":\"unauthorized\"}"));
+
+        final DefaultMailtrapEmailApiClient client = new DefaultMailtrapEmailApiClient(mailtrapHttpClient, properties);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_PASSWORD_RESET,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Reset your Kartoush password",
+            "Reset it here",
+            "https://kartoush.dev/reset-password?token=abc"
+        );
+
+        assertThatThrownBy(() -> client.send(email))
+            .isInstanceOf(EmailDeliveryException.class)
+            .hasMessage("Mailtrap email delivery failed with status 401");
+    }
+
+    static class HttpRequestCapturingResponse implements HttpResponse<String> {
+
+        private final int statusCode;
+        private final String body;
+        private HttpRequest request;
+
+        HttpRequestCapturingResponse(final int statusCode, final String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        void setRequest(final HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public int statusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public Optional<HttpResponse<String>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public String body() {
+            return body;
+        }
+
+        @Override
+        public Optional<javax.net.ssl.SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return request.uri();
+        }
+
+        @Override
+        public java.net.http.HttpClient.Version version() {
+            return java.net.http.HttpClient.Version.HTTP_1_1;
+        }
+    }
+}

--- a/auth/src/test/java/com/kartoush/auth/email/MailtrapEmailDeliveryServiceTest.java
+++ b/auth/src/test/java/com/kartoush/auth/email/MailtrapEmailDeliveryServiceTest.java
@@ -1,0 +1,58 @@
+package com.kartoush.auth.email;
+
+import com.kartoush.platform.types.Email;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MailtrapEmailDeliveryServiceTest {
+
+    @Test
+    void shouldDelegateToMailtrapApiClient() {
+        final MailtrapEmailApiClient mailtrapEmailApiClient = mock(MailtrapEmailApiClient.class);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_ACTIVATION,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Activate your Kartoush account",
+            "Hello from Kartoush",
+            "https://kartoush.dev/activate?token=abc"
+        );
+        when(mailtrapEmailApiClient.send(email)).thenReturn(Optional.of("mailtrap-message-id"));
+
+        final MailtrapEmailDeliveryService service = new MailtrapEmailDeliveryService(mailtrapEmailApiClient);
+
+        assertThatCode(() -> service.send(email)).doesNotThrowAnyException();
+        verify(mailtrapEmailApiClient).send(email);
+    }
+
+    @Test
+    void shouldRethrowMailtrapDeliveryFailures() {
+        final MailtrapEmailApiClient mailtrapEmailApiClient = mock(MailtrapEmailApiClient.class);
+        final EmailMessage email = new EmailMessage(
+            EmailMessageType.CUSTOMER_PASSWORD_RESET,
+            new Email("jack@kartoush.com"),
+            new Email("no-reply@notify.kartoush.com"),
+            "Kartoush",
+            "Reset your Kartoush password",
+            "Reset it here",
+            "https://kartoush.dev/reset-password?token=abc"
+        );
+        final EmailDeliveryException exception = new EmailDeliveryException("Mailtrap email delivery failed");
+        doThrow(exception).when(mailtrapEmailApiClient).send(email);
+
+        final MailtrapEmailDeliveryService service = new MailtrapEmailDeliveryService(mailtrapEmailApiClient);
+
+        assertThatThrownBy(() -> service.send(email))
+            .isInstanceOf(EmailDeliveryException.class)
+            .hasMessage("Mailtrap email delivery failed");
+    }
+}

--- a/docs/auth/authentication-contracts-and-security-behavior.md
+++ b/docs/auth/authentication-contracts-and-security-behavior.md
@@ -14,7 +14,7 @@ Kartoush currently exposes the following customer-facing auth flow:
 
 1. `POST /api/customers`
    Creates a `PENDING` customer and issues an activation token through the
-   configured activation email service
+   configured email delivery service
 2. `POST /api/customers/{customerId}/activation`
    Activates the customer and returns a one-time password setup token
 3. `POST /api/customers/{customerId}/initial-password`

--- a/docs/auth/transactional-email-provider-configuration.md
+++ b/docs/auth/transactional-email-provider-configuration.md
@@ -1,0 +1,171 @@
+# Transactional Email Provider Configuration
+
+## Purpose
+
+This document explains how Kartoush chooses and configures transactional email
+delivery by environment.
+
+For the architectural decision behind this setup, see:
+
+- `docs/architecture/decisions/0031-transactional-email-provider-and-sending-domain-strategy.md`
+
+## Current Delivery Modes
+
+Kartoush supports the following delivery modes through the shared internal
+email boundary:
+
+- `noop`
+  - Does not send email
+  - Logs that delivery was requested
+  - Safe default when delivery is disabled
+- `mailtrap`
+  - Sends email through the Mailtrap email sandbox API
+  - Intended for local and development inspection
+- `brevo`
+  - Sends email through the Brevo transactional email API
+  - Intended for production transactional delivery
+
+## Spring Profile Direction
+
+The current profile direction is:
+
+- `dev`
+  - Defaults to Mailtrap as the selected provider
+  - Delivery is disabled unless explicitly enabled through environment
+    configuration
+- `test`
+  - Defaults to no-op delivery
+- `prod`
+  - Defaults to Brevo as the selected provider
+  - Delivery is enabled by default and expects real provider configuration
+
+## Shared Email Configuration
+
+These values are used regardless of the provider:
+
+- `KARTOUSH_EMAIL_SENDER_NAME`
+- `KARTOUSH_EMAIL_SENDER_ADDRESS`
+- `KARTOUSH_EMAIL_ACTIVATION_BASE_URL`
+- `KARTOUSH_EMAIL_PASSWORD_RESET_BASE_URL`
+- `KARTOUSH_EMAIL_DELIVERY_PROVIDER`
+- `KARTOUSH_EMAIL_DELIVERY_ENABLED`
+
+Examples:
+
+```bash
+export KARTOUSH_EMAIL_SENDER_NAME="Kartoush"
+export KARTOUSH_EMAIL_SENDER_ADDRESS="no-reply@notify.kartoush.com"
+export KARTOUSH_EMAIL_ACTIVATION_BASE_URL="http://localhost:3000/activate"
+export KARTOUSH_EMAIL_PASSWORD_RESET_BASE_URL="http://localhost:3000/reset-password"
+```
+
+## Local Development With Mailtrap
+
+To inspect local email through Mailtrap, run these `export` commands in the
+same terminal session before starting the application:
+
+```bash
+export SPRING_PROFILES_ACTIVE=dev
+export KARTOUSH_EMAIL_DELIVERY_PROVIDER=mailtrap
+export KARTOUSH_EMAIL_DELIVERY_ENABLED=true
+export KARTOUSH_EMAIL_MAILTRAP_API_BASE_URL="https://sandbox.api.mailtrap.io/api/send"
+export KARTOUSH_EMAIL_MAILTRAP_API_TOKEN="your-mailtrap-api-token"
+export KARTOUSH_EMAIL_MAILTRAP_INBOX_ID=12345
+```
+
+If delivery should remain off in local development, leave
+`KARTOUSH_EMAIL_DELIVERY_ENABLED=false` or omit it entirely.
+
+### Local Quick Start
+
+Use this flow when you want to verify local customer emails in Mailtrap:
+
+1. Start PostgreSQL locally and make sure Kartoush can connect to it
+2. Export the `dev` Mailtrap environment variables shown above
+3. Export the shared customer email settings if you want non-default values
+4. Start the application
+
+```bash
+./gradlew :app:bootRun
+```
+
+5. Trigger an email-producing flow, for example:
+   - Create a customer through `POST /api/customers` to send an activation email
+   - Request a password reset through `POST /api/auth/password-reset`
+6. Review the delivered message in the configured Mailtrap inbox
+
+Use the `dev` profile for real local Mailtrap delivery checks. The `test`
+profile stays on no-op delivery and is intended for automated tests rather
+than provider-backed local inspection.
+
+## Test Behavior
+
+The `test` profile defaults to:
+
+- `KARTOUSH_EMAIL_DELIVERY_PROVIDER=noop`
+- `KARTOUSH_EMAIL_DELIVERY_ENABLED=false`
+
+Most automated tests should continue using no-op or mocked delivery rather
+than attempting real provider interaction.
+
+## Production Configuration With Brevo
+
+Production delivery expects the `prod` profile and Brevo configuration:
+
+```bash
+export SPRING_PROFILES_ACTIVE=prod
+export KARTOUSH_EMAIL_DELIVERY_PROVIDER=brevo
+export KARTOUSH_EMAIL_DELIVERY_ENABLED=true
+export KARTOUSH_EMAIL_BREVO_API_BASE_URL="https://api.brevo.com/v3"
+export KARTOUSH_EMAIL_BREVO_API_KEY="your-brevo-api-key"
+export KARTOUSH_EMAIL_SENDER_NAME="Kartoush"
+export KARTOUSH_EMAIL_SENDER_ADDRESS="no-reply@notify.kartoush.com"
+export KARTOUSH_EMAIL_ACTIVATION_BASE_URL="https://kartoush.com/activate"
+export KARTOUSH_EMAIL_PASSWORD_RESET_BASE_URL="https://kartoush.com/reset-password"
+```
+
+The Brevo API key must not be committed. Runtime production secrets should come
+from AWS Secrets Manager or AWS Systems Manager Parameter Store.
+
+## CI And Workflow Secrets
+
+GitHub secrets are intended for CI and workflow automation only.
+
+They are appropriate when:
+
+- A workflow needs provider credentials
+- A CI environment must exercise provider-backed setup
+
+They are not the source of truth for runtime production secrets.
+
+## Provider Setup Expectations
+
+Kartoush currently assumes a dedicated sending subdomain:
+
+- `notify.kartoush.com`
+
+Before real delivery is used, the sending domain should be configured with:
+
+- Provider verification records
+- SPF
+- DKIM
+- DMARC
+
+MX records are not required for this one-way transactional sending setup.
+
+## Failure Handling
+
+Provider failures are treated as infrastructure failures.
+
+Current behavior:
+
+- Delivery failures are logged with provider, email type, and recipient context
+- Raw activation, password setup, and password reset tokens must not be logged
+- If provider delivery fails, the email delivery call throws an
+  `EmailDeliveryException`
+- Customer-facing flows may therefore fail after the business-side token work
+  has already completed, which matches the current registration and reset flow
+  design
+
+When available, provider message IDs should be logged instead of secret values
+or raw tokens.

--- a/docs/customer/customer-lifecycle-and-api-behavior.md
+++ b/docs/customer/customer-lifecycle-and-api-behavior.md
@@ -313,7 +313,7 @@ Resend behavior:
 - issuing a new activation token consumes any existing active token for that
   customer before creating the replacement
 - the new token becomes the only valid activation token for that customer
-- token delivery is delegated to the configured activation email service
+- token delivery is delegated to the configured email delivery service
 
 Error scenarios:
 


### PR DESCRIPTION
## Summary
Add provider-backed email delivery adapters and profile-based configuration so Kartoush can use Mailtrap for local and development inspection and Brevo for real transactional email delivery.

## Scope
- Add Mailtrap and Brevo delivery adapters behind the shared `EmailDeliveryService` boundary
- Add provider-aware delivery configuration and profile defaults for `dev`, `test`, and `prod`
- Add provider-specific failure handling and configuration validation
- Document local Mailtrap setup, production Brevo configuration, DNS expectations, and secret handling
- Keep activation and password reset flows using the shared internal email boundary

## Notes
- Mailtrap local or development delivery now uses the Mailtrap sandbox API with an API token and inbox id rather than SMTP credentials
- Provider credentials remain externalized and are not committed to source control
- Live verification was performed against Mailtrap after the adapter changes were wired into the full local customer activation flow

## Testing
- `./gradlew --no-daemon :auth:test --tests com.kartoush.auth.email.DefaultCustomerEmailFactoryTest --tests com.kartoush.auth.email.MailtrapEmailDeliveryServiceTest --tests com.kartoush.auth.email.DefaultMailtrapEmailApiClientTest --tests com.kartoush.auth.email.BrevoEmailDeliveryServiceTest --tests com.kartoush.auth.email.DefaultBrevoEmailApiClientTest`
- `./gradlew --no-daemon :app:test --tests com.kartoush.config.CustomerEmailConfigurationTest :app:integrationTest --tests com.kartoush.api.auth.CustomerPasswordResetFlowIntegrationTest`
- Live local Mailtrap verification through `POST /api/customers` under the `dev` profile

Closes #276
