### PR TITLE
Add Codex Workflow and Memory Guidance

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,35 @@
+# Codex Guidance for Kartoush
+
+This directory is lightweight working context for future Codex sessions in the
+Kartoush repository.
+
+Use it as:
+
+- `memory/` for durable repo facts that should stay stable across tasks
+- `workflows/` for short checklists on how to explore, plan, implement,
+  review, and ship work in this repo
+- `handoffs/latest.md` as a fill-in template when a session stops mid-task
+
+Notable memory files:
+
+- `memory/editorial-style.md` for writing and formatting rules that are easy to miss in code-focused sessions
+
+Keep this directory:
+
+- Keep it concise
+- Keep it repo-specific
+- Keep it grounded in code, ADRs, and scripts that actually exist
+- Keep it free of framework or agent-system complexity
+
+When updating it:
+
+- Prefer facts already visible in `README`, ADRs, Gradle files, module
+  structure, tests, and GitHub scripts
+- Do not turn it into long-form project documentation
+- Update `memory/` when architecture or workflow rules become durable
+- Use `handoffs/latest.md` for per-task status, not `memory/`
+
+Validation:
+
+- Run `bash .github/scripts/validate-editorial-style.sh` after editing `.codex/` files
+- The script checks sentence-case bullets and catches suspicious early prose wrapping in `.codex/` and issue-import markdown

--- a/.codex/handoffs/latest.md
+++ b/.codex/handoffs/latest.md
@@ -1,0 +1,32 @@
+# Handoff Template
+
+## Current Task
+
+- Issue or objective
+- Current branch
+- Current status
+
+## What Changed
+
+- Key behavior or documentation changes
+- Any decisions made during the session
+
+## Tests Run
+
+- Exact commands run
+- Result summary
+
+## Files Touched
+
+- Important files changed
+- Migrations, docs, and tests included
+
+## Risks / Follow-Ups
+
+- Anything not verified
+- Any open questions
+- Any follow-up issue or ADR needed
+
+## Next Recommended Action
+
+- Next concrete step for the next session

--- a/.codex/memory/architecture.md
+++ b/.codex/memory/architecture.md
@@ -1,0 +1,72 @@
+# Architecture Memory
+
+## System shape
+
+- Kartoush is a modular monolith backend
+- Java 25, Spring Boot 4, Gradle, PostgreSQL, Flyway
+- Main modules in `settings.gradle`:
+  - `app`
+  - `auth`
+  - `customer`
+  - `notification`
+  - `platform:platform-types`
+  - `platform:platform-validation`
+  - `test-support`
+
+## Module roles
+
+- `app`
+  - HTTP entry point
+  - controllers, request and response models, OpenAPI docs, error mapping, app services
+- `customer`
+  - customer lifecycle, activation, registration, Terms of Service, public customer facades
+- `auth`
+  - customer password ownership, sign-in, auth sessions, password setup, password reset
+- `notification`
+  - shared email delivery boundary and provider adapters
+  - currently email only
+- `platform-types`
+  - shared value types and ULID support
+- `platform-validation`
+  - shared request validation helpers and validation error model
+- `test-support`
+  - shared integration-test annotations and Postgres/Testcontainers support
+
+## Boundary expectations
+
+- `app` depends on module facades, not persistence internals
+- Facade contracts are explicit and should not expose entities
+- Customer lifecycle stays in `customer`
+- Credential and sign-in behavior stays in `auth`
+- Email sending stays in `notification`
+- Shared primitive-like types such as `CustomerId`, `Email`, `PhoneNumber`, and `CustomerStatus` live in `platform-types`
+
+## Current layering patterns
+
+- Package naming commonly follows:
+  - `domain`
+  - `facade`
+  - `internal`
+  - `persistence`
+  - `service`
+  - `exception`
+- Implementations commonly use `Default...` naming
+- Persistence repositories and entities stay inside the owning module
+
+## API and facade boundary nuance
+
+- The repo is moving toward app-owned HTTP request models and separate facade contracts
+- That split is already visible in auth and terms endpoints
+- Customer create and update still bind directly to facade input models in `CustomerController`
+- Do not assume the split is complete everywhere
+
+## Auth and session direction
+
+- Kartoush uses opaque bearer tokens backed by server-side auth sessions
+- Auth currently issues tokens but protected-route enforcement is still separate follow-up work
+
+## Notification direction
+
+- Provider-specific email code lives under `notification.email.provider.*`
+- Shared delivery types live under `notification.email.delivery`
+- Shared email composition for customer flows lives under `notification.email.customer`

--- a/.codex/memory/architecture.md
+++ b/.codex/memory/architecture.md
@@ -17,20 +17,20 @@
 
 - `app`
   - HTTP entry point
-  - controllers, request and response models, OpenAPI docs, error mapping, app services
+  - Controllers, request and response models, OpenAPI docs, error mapping, and app services
 - `customer`
-  - customer lifecycle, activation, registration, Terms of Service, public customer facades
+  - Customer lifecycle, activation, registration, Terms of Service, and public customer facades
 - `auth`
-  - customer password ownership, sign-in, auth sessions, password setup, password reset
+  - Customer password ownership, sign-in, auth sessions, password setup, and password reset
 - `notification`
-  - shared email delivery boundary and provider adapters
-  - currently email only
+  - Shared email delivery boundary and provider adapters
+  - Currently email only
 - `platform-types`
-  - shared value types and ULID support
+  - Shared value types and ULID support
 - `platform-validation`
-  - shared request validation helpers and validation error model
+  - Shared request validation helpers and validation error model
 - `test-support`
-  - shared integration-test annotations and Postgres/Testcontainers support
+  - Shared integration-test annotations and Postgres/Testcontainers support
 
 ## Boundary expectations
 

--- a/.codex/memory/conventions.md
+++ b/.codex/memory/conventions.md
@@ -1,0 +1,43 @@
+# Conventions Memory
+
+## Java and Spring style
+
+- Use constructor injection
+- Prefer `final` parameters and immutable values where practical
+- Simple HTTP request and response shapes are commonly Java `record`s
+- Explicit Spring stereotypes are used for controllers, services, and configuration classes
+- Logger pattern is `private static final Logger LOG = LoggerFactory.getLogger(...)`
+
+## Naming
+
+- Tests use `should<ExpectedBehavior>When<Condition>`
+- Implementation classes commonly use `Default...`
+- Branch names follow `<type>/<scope>-<short-description>`
+- Use lowercase kebab-case in branch names
+
+## Boundary and model usage
+
+- Do not leak JPA entities outside the owning module
+- Do not pass domain objects across HTTP boundaries
+- Prefer value types from `platform-types` instead of raw strings where the domain already has a type
+- Controller code should stay focused on HTTP concerns and delegation
+- Facade validators own business and module-specific validation
+- App-layer validation is for request shape and binding concerns
+
+## Logging
+
+- Avoid logging raw activation, password setup, or password reset tokens
+- Prefer stable identifiers and provider message ids over secrets
+- Log useful request context such as customer id or email only when it is not a secret-bearing value
+
+## Mapping and DTOs
+
+- Customer persistence still uses MapStruct mappers in `customer.persistence.mapper`
+- Do not assume MapStruct is the default answer elsewhere
+- Prefer explicit mapping when it keeps boundaries clearer
+
+## Notification code
+
+- Keep provider-specific code in provider packages
+- Keep low-level HTTP concerns behind shared notification HTTP and API client types
+- Do not couple customer or auth flows directly to provider SDKs or APIs

--- a/.codex/memory/domain-rules.md
+++ b/.codex/memory/domain-rules.md
@@ -22,9 +22,9 @@
 - `POST /api/customers` is the registration entry point
 - Successful registration creates a `PENDING` customer
 - Registration requires:
-  - first name
-  - last name
-  - valid email
+  - First name
+  - Last name
+  - Valid email
   - Terms acceptance set to true
   - Terms version matching the current active Terms record
 - Registration persists Terms acceptance audit data
@@ -48,11 +48,11 @@
 - Setup token must exist, be unexpired, and not already be consumed
 - Password confirmation must match
 - Current default password policy requires:
-  - at least 12 characters
-  - one uppercase letter
-  - one lowercase letter
-  - one digit
-  - one special character
+  - At least 12 characters
+  - One uppercase letter
+  - One lowercase letter
+  - One digit
+  - One special character
 - Successful setup consumes the setup token
 
 ## Sign-in
@@ -84,8 +84,8 @@
 ## Notification and email
 
 - Current customer-facing email flows:
-  - activation
-  - password reset
+  - Activation
+  - Password reset
 - Provider direction:
   - `mailtrap` for local or dev inspection
   - `brevo` for production transactional sending

--- a/.codex/memory/domain-rules.md
+++ b/.codex/memory/domain-rules.md
@@ -1,0 +1,92 @@
+# Domain Rules Memory
+
+## Customer lifecycle
+
+- Customer statuses:
+  - `PENDING`
+  - `ACTIVE`
+  - `INACTIVE`
+  - `DELETED`
+- Valid transitions:
+  - `PENDING -> ACTIVE`
+  - `PENDING -> INACTIVE`
+  - `PENDING -> DELETED`
+  - `ACTIVE -> INACTIVE`
+  - `ACTIVE -> DELETED`
+  - `INACTIVE -> ACTIVE`
+  - `INACTIVE -> DELETED`
+- `DELETED` is terminal
+
+## Registration
+
+- `POST /api/customers` is the registration entry point
+- Successful registration creates a `PENDING` customer
+- Registration requires:
+  - first name
+  - last name
+  - valid email
+  - Terms acceptance set to true
+  - Terms version matching the current active Terms record
+- Registration persists Terms acceptance audit data
+- Registration issues an activation token and requests activation email delivery
+
+## Activation
+
+- Activation uses `POST /api/customers/{customerId}/activation`
+- Customer must exist and be `PENDING`
+- Activation token must belong to the customer
+- Token must exist, be unexpired, and not already be consumed
+- Successful activation moves the customer to `ACTIVE`
+- Successful activation consumes the activation token
+- Successful activation returns a one-time password setup token
+
+## Initial password setup
+
+- Initial password setup uses `POST /api/customers/{customerId}/initial-password`
+- Customer must exist and be `ACTIVE`
+- Setup token must belong to the customer
+- Setup token must exist, be unexpired, and not already be consumed
+- Password confirmation must match
+- Current default password policy requires:
+  - at least 12 characters
+  - one uppercase letter
+  - one lowercase letter
+  - one digit
+  - one special character
+- Successful setup consumes the setup token
+
+## Sign-in
+
+- Sign-in uses `POST /api/auth/sign-in`
+- Customer must exist
+- Customer must be `ACTIVE`
+- Customer must already have a password
+- Password must match the stored hash
+- Successful sign-in returns an opaque bearer token
+- Failed sign-in attempts do not create auth-session records
+
+## Password reset
+
+- Reset request uses `POST /api/auth/password-reset`
+- Request always returns `204 No Content` for a well-formed email
+- Reset tokens are issued only for `ACTIVE` customers with an existing password
+- Reset confirmation uses `POST /api/auth/password-reset/confirm`
+- Successful reset consumes the reset token
+- A customer cannot reset to the password currently on the account
+- Successful password reset revokes existing auth sessions
+
+## Resend activation
+
+- Resend uses `POST /api/customers/{customerId}/activation/resend`
+- Resend is allowed only for `PENDING` customers
+- Issuing a new activation token consumes the previous active token first
+
+## Notification and email
+
+- Current customer-facing email flows:
+  - activation
+  - password reset
+- Provider direction:
+  - `mailtrap` for local or dev inspection
+  - `brevo` for production transactional sending
+- Sending subdomain direction is `notify.kartoush.com`

--- a/.codex/memory/editorial-style.md
+++ b/.codex/memory/editorial-style.md
@@ -32,5 +32,6 @@ miss during implementation work.
 ## PR and summary text
 
 - Keep summaries direct and plain
+- Use sentence case for PR bullets and summary lists
 - List the real commands that someone else should run
 - Do not include local-only environment workarounds in shared PR testing notes unless they are required for other developers

--- a/.codex/memory/editorial-style.md
+++ b/.codex/memory/editorial-style.md
@@ -1,0 +1,36 @@
+# Editorial Style Memory
+
+Use this file for repo-specific writing and formatting rules that are easy to
+miss during implementation work.
+
+## Bullets
+
+- Use sentence case for bullets
+- Capitalize the first word of the bullet
+- Do not write bullets as all-lowercase fragments unless the bullet is only a literal value such as a command, path, or code identifier
+
+## Titles
+
+- Use title case for titles and headings when the repo expects a title
+- Do not capitalize every word blindly
+- Keep short words such as `to`, `the`, `a`, `an`, `and`, `or`, `of`, and `in` lowercase unless they are the first word
+
+## Markdown style
+
+- Do not wrap prose early just to keep lines short
+- Let paragraphs read naturally
+- Keep lists flat
+- Prefer short, direct sentences over abstract phrasing
+
+## Issue importer files
+
+- Follow the importer metadata order exactly
+- Keep task and epic wording concrete
+- Avoid buzzwords and unnecessary framework language
+- Use natural wrapping, not narrow manual line breaks
+
+## PR and summary text
+
+- Keep summaries direct and plain
+- List the real commands that someone else should run
+- Do not include local-only environment workarounds in shared PR testing notes unless they are required for other developers

--- a/.codex/memory/github-workflow.md
+++ b/.codex/memory/github-workflow.md
@@ -1,0 +1,67 @@
+# GitHub Workflow Memory
+
+## Branching and merge
+
+- Branch naming ADR:
+  - `<type>/<scope>-<short-description>`
+- Allowed types:
+  - `feat`
+  - `fix`
+  - `chore`
+  - `docs`
+  - `refactor`
+  - `test`
+- Use lowercase kebab-case
+- Do not include issue numbers in branch names
+- Merge strategy is squash-and-merge
+- PR titles should read cleanly as the final squashed commit message
+
+## Pull requests
+
+- Keep PRs small and focused
+- CI runs on pull requests and on pushes to `main`
+- Current required CI shape:
+  - unit tests
+  - auth API integration tests
+  - customer API integration tests
+  - terms API integration tests
+  - customer module integration tests
+  - auth module integration tests
+
+## Issue import workflow
+
+- Importer files live in `.github/issue-import/pending/`
+- Imported files move to `.github/issue-import/imported/`
+- Failed imports move to `.github/issue-import/failed/`
+- Use the templates in `.github/issue-import/templates/`
+- Metadata header order matters
+- Task files usually use:
+  - `Title:`
+  - `Parent:` when applicable
+  - `Labels:`
+  - `Status:`
+- Dependencies go in a `## Dependencies` section, not metadata
+- Importer default status is `Backlog`
+- Run a dry-run before a real import:
+  - `.github/scripts/import-issues.sh --dry-run --verbose`
+
+## Existing issue labels
+
+- `epic`
+- `task`
+- `architecture`
+- `documentation`
+- `application`
+- `platform`
+- `infrastructure`
+- `integration`
+- `testing`
+- `ci`
+- Plus domain-specific labels such as `aws` and `customer`
+
+## Current issue and epic conventions
+
+- Use one epic for a broader outcome and linked task issues for concrete work
+- Prefer updating overlapping issues rather than creating duplicates
+- Keep task scope narrow and implementation-ready
+- Make dependencies explicit in the issue body when sequencing matters

--- a/.codex/memory/github-workflow.md
+++ b/.codex/memory/github-workflow.md
@@ -21,12 +21,12 @@
 - Keep PRs small and focused
 - CI runs on pull requests and on pushes to `main`
 - Current required CI shape:
-  - unit tests
-  - auth API integration tests
-  - customer API integration tests
-  - terms API integration tests
-  - customer module integration tests
-  - auth module integration tests
+  - Unit tests
+  - Auth API integration tests
+  - Customer API integration tests
+  - Terms API integration tests
+  - Customer module integration tests
+  - Auth module integration tests
 
 ## Issue import workflow
 

--- a/.codex/memory/testing.md
+++ b/.codex/memory/testing.md
@@ -1,0 +1,66 @@
+# Testing Memory
+
+## Repo testing strategy
+
+- `./gradlew verifyAll` is the repo-wide verification command recommended in `README`
+- Root `verifyAll` depends on `test` in all subprojects and any `integrationTest` tasks that exist
+
+## Test layers
+
+- Unit tests
+  - default choice for isolated logic
+  - no Spring context unless there is a strong reason
+- Persistence tests
+  - use real PostgreSQL behavior
+  - commonly `@DataJpaTest`, Testcontainers, and `@ServiceConnection`
+- Web tests
+  - focused MVC slices for controllers and HTTP behavior
+- Integration tests
+  - Spring context plus collaborating components and real infrastructure when needed
+
+## Current Gradle task shape
+
+- `app`, `auth`, and `customer` define custom `integrationTest` tasks
+- Integration tests are tagged with `integration`
+- `notification` currently has unit tests only
+
+## Shared test support
+
+- `test-support` provides shared annotations and base support, including:
+  - `@IntegrationTest`
+  - `@SpringIntegrationTest`
+  - `@HttpSpringIntegrationTest`
+  - `@PostgresDataJpaTest`
+  - `@PostgresSpringIntegrationTest`
+  - `@PostgresRestAssuredIntegrationTest`
+
+## Useful commands
+
+- All tests:
+  - `./gradlew verifyAll`
+- Unit tests only:
+  - `./gradlew test`
+- App API integration:
+  - `./gradlew --no-daemon :app:integrationTest --tests 'com.kartoush.api.auth.*'`
+  - `./gradlew --no-daemon :app:integrationTest --tests 'com.kartoush.api.customer.*'`
+  - `./gradlew --no-daemon :app:integrationTest --tests 'com.kartoush.api.terms.*'`
+- Customer module integration:
+  - `./gradlew --no-daemon :customer:integrationTest`
+- Auth module integration:
+  - `./gradlew --no-daemon :auth:integrationTest`
+
+## CI coverage
+
+- CI runs:
+  - `unit-tests`
+  - API integration matrix for `auth`, `customer`, and `terms`
+  - `customer-module-integration-tests`
+  - `auth-module-integration-tests`
+- `verify` checks those upstream jobs
+
+## Test-writing conventions
+
+- Prefer method names in `shouldXWhenY` form
+- Use `given / when / then` comments only when they improve readability
+- Do not use `@DisplayName` as the normal style
+- Do not replace real persistence behavior with mocks in repository tests

--- a/.codex/memory/testing.md
+++ b/.codex/memory/testing.md
@@ -8,13 +8,13 @@
 ## Test layers
 
 - Unit tests
-  - default choice for isolated logic
-  - no Spring context unless there is a strong reason
+  - Default choice for isolated logic
+  - No Spring context unless there is a strong reason
 - Persistence tests
-  - use real PostgreSQL behavior
-  - commonly `@DataJpaTest`, Testcontainers, and `@ServiceConnection`
+  - Use real PostgreSQL behavior
+  - Commonly `@DataJpaTest`, Testcontainers, and `@ServiceConnection`
 - Web tests
-  - focused MVC slices for controllers and HTTP behavior
+  - Focused MVC slices for controllers and HTTP behavior
 - Integration tests
   - Spring context plus collaborating components and real infrastructure when needed
 

--- a/.codex/workflows/explore.md
+++ b/.codex/workflows/explore.md
@@ -6,10 +6,10 @@ Before changing code:
 2. Inspect the owning module and its public facade first
 3. Check whether the behavior already has tests
 4. Find the boundary lines:
-   - controller vs app service
-   - facade vs internal service
-   - domain vs persistence
-   - module vs module
+   - Controller vs app service
+   - Facade vs internal service
+   - Domain vs persistence
+   - Module vs module
 5. Check current CI or task conventions if the change affects tests or workflows
 6. Look for overlapping open issues before creating new issue-import files
 

--- a/.codex/workflows/explore.md
+++ b/.codex/workflows/explore.md
@@ -1,0 +1,21 @@
+# Explore Workflow
+
+Before changing code:
+
+1. Read the relevant issue, ADR, and any directly related docs
+2. Inspect the owning module and its public facade first
+3. Check whether the behavior already has tests
+4. Find the boundary lines:
+   - controller vs app service
+   - facade vs internal service
+   - domain vs persistence
+   - module vs module
+5. Check current CI or task conventions if the change affects tests or workflows
+6. Look for overlapping open issues before creating new issue-import files
+
+Questions to answer before planning:
+
+- Which module should own this behavior
+- Whether the rule is already documented in an ADR or behavior doc
+- Whether the change needs a new contract model, exception, migration, or config property
+- What the narrowest useful test slice is

--- a/.codex/workflows/implement.md
+++ b/.codex/workflows/implement.md
@@ -1,0 +1,24 @@
+# Implement Workflow
+
+When changing code:
+
+1. Keep the change inside the owning module unless there is a real boundary reason not to
+2. Prefer explicit code over clever indirection
+3. Do not leak provider, framework, or persistence details across module boundaries
+4. Keep logs useful but never log raw auth or email tokens
+5. Add or update the narrowest tests that prove the behavior
+6. Update docs or ADRs when the change alters a documented rule or architecture decision
+
+Implementation reminders for Kartoush:
+
+- Customer lifecycle stays in `customer`
+- Credential and session behavior stays in `auth`
+- Email delivery stays in `notification`
+- Shared value objects belong in `platform-types`
+- Request-shape validation belongs near HTTP models, business validation belongs in facades or validators
+
+Do not:
+
+- Move code across modules just because it is convenient
+- Make provider-specific code reachable from controllers, facades, or domain types
+- Treat opaque access tokens as self-describing JWTs

--- a/.codex/workflows/plan.md
+++ b/.codex/workflows/plan.md
@@ -1,0 +1,23 @@
+# Plan Workflow
+
+When preparing a plan:
+
+1. State the target module ownership clearly
+2. Separate behavior changes from cleanup changes
+3. Call out migrations, config, docs, and tests explicitly
+4. Keep the plan incremental and reversible where possible
+5. If the work crosses module boundaries, explain why the dependency direction is still valid
+
+Good plan shape:
+
+- Module and boundary changes
+- Runtime behavior changes
+- Test changes
+- Documentation or ADR updates
+- Risks or open questions
+
+Avoid:
+
+- Mixing opportunistic refactors into behavior work without calling it out
+- Introducing new shared modules without explaining why an existing one is not appropriate
+- Planning broad framework work when a narrow repo-specific change is enough

--- a/.codex/workflows/review.md
+++ b/.codex/workflows/review.md
@@ -1,0 +1,20 @@
+# Review Workflow
+
+Before finishing:
+
+1. Re-read the issue or task and check that the scope stayed tight
+2. Check module ownership again
+3. Look for duplicated code or duplicated abstractions
+4. Check names for clarity
+5. Verify exceptions, logs, and config names are understandable
+6. Confirm tests cover the changed behavior, not just happy paths
+7. Confirm docs still match runtime behavior
+8. Confirm bullets and checklist items use sentence case where the repo expects prose bullets
+
+Review questions:
+
+- Whether this introduced framework leakage across a module boundary
+- Whether this added a provider-specific concept where a repo-owned interface should exist
+- Whether this changed a documented rule without updating docs
+- Whether this added a new test slice that CI does not run
+- Whether this changed request or response contracts that need MVC or OpenAPI coverage

--- a/.codex/workflows/ship.md
+++ b/.codex/workflows/ship.md
@@ -1,0 +1,24 @@
+# Ship Workflow
+
+When closing out work:
+
+1. Summarize what changed in plain language
+2. List the tests actually run
+3. Call out docs or ADR updates
+4. Note any remaining gaps or deliberate follow-up work
+5. If a PR is being opened, make sure the title can serve as the squash commit title
+
+For docs-only work:
+
+- Run a lightweight sanity check rather than the full suite unless the change affects build or test wiring
+
+For code work:
+
+- Run focused tests during development
+- Use broader verification when the risk or scope justifies it
+
+Always mention:
+
+- What was not verified
+- Any repo facts that were uncertain
+- Any follow-up issue that should exist but does not

--- a/.github/issue-import/README.md
+++ b/.github/issue-import/README.md
@@ -160,7 +160,8 @@ Recommended workflow:
 1. Copy the appropriate template into `pending/`
 2. Rename it with a numeric prefix such as `00-` or `01-`
 3. Replace the placeholder title and section content
-4. Run a dry run before importing for real
+4. Run `bash .github/scripts/validate-editorial-style.sh`
+5. Run a dry run before importing for real
 
 Example:
 
@@ -168,6 +169,17 @@ Example:
 cp .github/issue-import/templates/task-template.md \
   .github/issue-import/pending/00-task-example.md
 ```
+
+The editorial style script checks:
+
+- sentence-case bullets
+- suspicious early prose wrapping
+
+It is intended for:
+
+- `.github/issue-import/pending/`
+- `.github/issue-import/templates/`
+- `.codex/`
 
 You can also print a template directly from the importer:
 

--- a/.github/issue-import/templates/epic-template.md
+++ b/.github/issue-import/templates/epic-template.md
@@ -12,14 +12,16 @@ Describe the broader problem or outcome this epic is intended to cover.
 
 ## Scope
 
-- list the major workstreams or deliverables included in this epic
-- keep scope high level and outcome-oriented
+- Use sentence case for bullets
+- List the major workstreams or deliverables included in this epic
+- Keep scope high level and outcome-oriented
 
 ## Acceptance Criteria
 
-- the epic defines a clear and coherent slice of work
-- the scope is broad enough to justify grouping multiple tasks beneath it
-- the expected outcome is understandable without additional context
+- Use sentence case for bullets
+- The epic defines a clear and coherent slice of work
+- The scope is broad enough to justify grouping multiple tasks beneath it
+- The expected outcome is understandable without additional context
 
 ## Dependencies
 

--- a/.github/issue-import/templates/task-template.md
+++ b/.github/issue-import/templates/task-template.md
@@ -19,13 +19,15 @@ Describe the specific change or capability this task should deliver.
 
 ## Scope
 
-- list the concrete implementation work included in this task
-- keep each bullet specific enough to guide execution
+- Use sentence case for bullets
+- List the concrete implementation work included in this task
+- Keep each bullet specific enough to guide execution
 
 ## Acceptance Criteria
 
-- describe the expected behavior or outcome that defines completion
-- include any important validation expectations
+- Use sentence case for bullets
+- Describe the expected behavior or outcome that defines completion
+- Include any important validation expectations
 
 ## Dependencies
 

--- a/.github/scripts/validate-editorial-style.sh
+++ b/.github/scripts/validate-editorial-style.sh
@@ -35,7 +35,7 @@ for target in "${TARGETS[@]}"; do
     fi
     printf '%s\n' "$match"
     failed=1
-  done < <(grep -R -n -E '^- [a-z]' "$target" 2>/dev/null || true)
+  done < <(grep -R -n -E '^[[:space:]]*-[[:space:]]+[a-z]' "$target" 2>/dev/null || true)
 done
 
 if [[ $failed -ne 0 ]]; then
@@ -69,7 +69,8 @@ def is_prose(line: str) -> bool:
     )
     if stripped.startswith(blocked_prefixes):
         return False
-    if stripped[0].isdigit() and len(stripped) > 1 and stripped[1] == ".":
+    digit_prefix = stripped.split(".", 1)[0]
+    if digit_prefix.isdigit() and stripped[len(digit_prefix):].startswith("."):
         return False
     return True
 

--- a/.github/scripts/validate-editorial-style.sh
+++ b/.github/scripts/validate-editorial-style.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+declare -a TARGETS=()
+
+if [[ $# -gt 0 ]]; then
+  TARGETS=( "$@" )
+else
+  TARGETS=(
+    "$ROOT_DIR/.codex"
+    "$ROOT_DIR/.github/issue-import/pending"
+    "$ROOT_DIR/.github/issue-import/templates"
+  )
+fi
+
+failed=0
+
+print_header() {
+  printf '%s\n' "$1"
+  printf '%s\n' "$(printf '%*s' "${#1}" '' | tr ' ' '-')"
+}
+
+print_header "Checking editorial style"
+
+for target in "${TARGETS[@]}"; do
+  [[ -e "$target" ]] || continue
+
+  while IFS= read -r match; do
+    [[ -n "$match" ]] || continue
+    if [[ $failed -eq 0 ]]; then
+      printf '%s\n' ""
+      printf '%s\n' "Found lowercase bullet starts that violate sentence case:"
+    fi
+    printf '%s\n' "$match"
+    failed=1
+  done < <(grep -R -n -E '^- [a-z]' "$target" 2>/dev/null || true)
+done
+
+if [[ $failed -ne 0 ]]; then
+  printf '\n'
+  printf '%s\n' "Fix the bullets above so they start in sentence case."
+  exit 1
+fi
+
+early_wrap_matches="$(
+  python3 - "${TARGETS[@]}" <<'PY'
+from pathlib import Path
+import sys
+
+def is_prose(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    blocked_prefixes = (
+        "#",
+        "- ",
+        "* ",
+        ">",
+        "```",
+        "|",
+        "Title:",
+        "Parent:",
+        "Labels:",
+        "Status:",
+        "<!--",
+        "-->",
+    )
+    if stripped.startswith(blocked_prefixes):
+        return False
+    if stripped[0].isdigit() and len(stripped) > 1 and stripped[1] == ".":
+        return False
+    return True
+
+for raw_target in sys.argv[1:]:
+    target = Path(raw_target)
+    if not target.exists():
+        continue
+
+    files = [target] if target.is_file() else sorted(target.rglob("*.md"))
+
+    for path in files:
+        lines = path.read_text().splitlines()
+        in_code_block = False
+        in_html_comment = False
+
+        for index in range(len(lines) - 1):
+            line = lines[index]
+            next_line = lines[index + 1]
+            stripped = line.strip()
+            next_stripped = next_line.strip()
+
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+
+            if "<!--" in stripped:
+                in_html_comment = True
+            if in_code_block or in_html_comment:
+                if "-->" in stripped:
+                    in_html_comment = False
+                continue
+
+            if is_prose(line) and is_prose(next_line) and len(line.rstrip()) < 72:
+                print(f"{path}:{index + 1}:{line.rstrip()}")
+PY
+)"
+
+if [[ -n "$early_wrap_matches" ]]; then
+  printf '\n'
+  printf '%s\n' "Found suspicious early prose wrapping:"
+  printf '%s\n' "$early_wrap_matches"
+  printf '\n'
+  printf '%s\n' "Reflow the prose above so it reads naturally instead of wrapping early."
+  exit 1
+fi
+
+printf '\n'
+printf '%s\n' "Editorial style check passed."

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ For detailed testing conventions and design decisions, see:
 
 - `docs/architecture/decisions/0023-testing-strategy-and-conventions.md`
 - `docs/testing/api-testing-strategy.md`
+- `.codex/README.md` for lightweight Codex workflow and repo memory guidance
 
 For transactional email provider and environment configuration, including the
 local Mailtrap-backed quick start, see:


### PR DESCRIPTION
## Summary
- Add a lightweight `.codex/` directory with repo-specific memory, reusable workflows, and a clean handoff template
- Add an editorial-style memory file so writing and formatting rules are durable instead of conversational
- Add a lightweight editorial validation script and document it in the Codex and issue-import docs

## Scope
- Add `.codex/memory/`, `.codex/workflows/`, and `.codex/handoffs/`
- Capture current Kartoush guidance from the README, ADRs, Gradle files, module layout, tests, CI, and issue-import workflow
- Add `.github/scripts/validate-editorial-style.sh` for sentence-case bullets and suspicious early prose wrapping
- Update the issue-import templates and README so the style check is part of the drafting workflow
- Add a brief root README pointer to the Codex guidance

## Notes
- This stays intentionally lightweight and repo-specific rather than introducing a larger agent framework
- The new editorial validation is local workflow guidance for now, not CI enforcement

## Testing
- `bash .github/scripts/validate-editorial-style.sh`
- `./gradlew --no-daemon help`

Closes #300