### PR TITLE
Align Repository Guidance With Current Implementation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,55 +1,63 @@
 # Contributing to Kartoush
 
-Thank you for your interest in contributing to Kartoush.
+Thank you for contributing to Kartoush.
 
-Kartoush is currently in a **pre-implementation phase**, with an emphasis on thoughtful design, clear documentation, and intentional decision-making before writing production code.
+Kartoush is an active modular monolith backend project. The repository already contains production code, integration tests, ADRs, and supporting workflow tooling, so contributions should align with the current implementation rather than treat the repo as design-only.
 
-## Current Focus
+## Current Expectations
 
-At this stage, contributions are primarily centered around:
+- Keep changes small and focused
+- Respect module boundaries
+- Prefer updating existing guidance and issues over creating duplicate direction
+- Document meaningful architectural tradeoffs in ADRs or issue notes when the reasoning is not obvious from the code
 
-- Clarifying project goals and non-goals
-- Proposing and discussing architectural or technical decisions
-- Improving documentation and structure
-- Identifying risks, constraints, and tradeoffs early
+## Where to Start
 
-Production code contributions will come later, once core decisions have been made.
+- Read the root `README.md` for setup, testing, and current project context
+- Review ADRs under `docs/architecture/decisions/`
+- Check `.codex/README.md` for lightweight repo memory and workflow guidance
+- Review the existing issue before starting work so new changes stay aligned with the intended scope
 
-## How to Contribute Right Now
+## Contributions That Fit Well
 
-### Design and Decision Discussions
-
-- Review existing decision records under `docs/decisions`
-- Propose new decisions or alternatives via GitHub issues
-- Open pull requests to:
-  - Add new decision records
-  - Update existing ones as discussions evolve
-  - Improve clarity or documentation
-
-Decision records may start as **open questions** and evolve over time.
-
-### Issues
-
-- Use issues to raise questions, ideas, or concerns
-- Keep issues focused on a single topic or decision
-- Link issues to relevant decision records when applicable
+- Feature work tied to an existing task or epic
+- Refactors that improve boundaries, clarity, or testability
+- Documentation updates that remove stale guidance or explain intentional exceptions
+- Test improvements that strengthen existing behavior or close coverage gaps
 
 ## Pull Requests
 
-- Keep pull requests small and focused
-- Prefer documentation and decision updates over code changes at this stage
-- Clearly explain the intent and context of the change
+- Keep pull requests narrow enough to review quickly
+- Explain what changed, why it changed, and how it was verified
+- Use PR titles that work as clean squash-merge commit messages
+- Run the relevant Gradle tests for the area you changed
+- Do not include local-only workarounds in shared docs or PR testing notes unless other developers need them too
 
-## Coding (Later)
+## Current Transition Notes
 
-Coding standards, tooling, and workflows will be documented once the project moves into implementation.  
-Until then, avoid introducing production code unless explicitly discussed and agreed upon.
+Kartoush has a few areas that are intentionally mixed while the codebase is being cleaned up.
+
+- The repo is moving toward app-owned HTTP request models and separate facade contracts, but that split is not complete everywhere yet
+- Notification delivery now lives in the `notification` module, but durable background job processing is still follow-up work
+- Some documentation and workflow rules are newer than older merged code, so align new work with the current direction instead of copying older inconsistencies forward
+
+When you touch one of these areas, either follow the established local pattern or make the cleanup explicit in the task or PR.
+
+## Testing and Validation
+
+- Use `./gradlew verifyAll` for full verification when the change is broad
+- Use targeted module and integration tests when the change is narrow and the full suite is unnecessary
+- If you edit `.codex/` or issue-import files, run `bash .github/scripts/validate-editorial-style.sh`
+
+## Issues and Planning
+
+- Keep issues focused on one outcome
+- Prefer updating overlapping issues instead of creating duplicates
+- Make dependencies explicit when one task must land before another
+- Use the issue import workflow under `.github/issue-import/` when you are creating new planned work
 
 ## Code of Conduct
 
-Be respectful, constructive, and collaborative.  
-Assume good intent and focus discussions on ideas, not individuals.
+Be respectful, constructive, and collaborative.
 
----
-
-*Kartoush values clear thinking before clever solutions.*
+Assume good intent, focus on the work, and prefer clarity over cleverness.


### PR DESCRIPTION
## Summary
- Align `.github/CONTRIBUTING.md` with the current implemented state of the repository
- Remove stale pre-implementation guidance that no longer matches how Kartoush is being built
- Call out the main intentional mixed-state areas so contributors are not pushed in the wrong direction

## Scope
- Rewrite the contributor guide around the current modular monolith implementation
- Fix outdated ADR path references
- Add concise guidance for current contribution expectations, testing, and issue workflow
- Document the current request-model and notification-job transition notes instead of implying they are already complete

## Notes
- This PR is intentionally narrow and only updates contributor guidance
- The broader follow-up task for remaining documentation alignment is tracked under `#301`

## Testing
- Not run, because this is a documentation-only change

Closes #301
