### PR TITLE
Harden Issue Importer Markdown Parsing

### DIFF
--- a/.github/issue-import/README.md
+++ b/.github/issue-import/README.md
@@ -311,6 +311,10 @@ Source file names are useful when related work is being imported from local
 markdown files. GitHub issue numbers are useful when a dependency already
 exists in GitHub and is not represented by a local import file.
 
+Dependencies entries must stay as bullet list items. Non-list prose or empty
+dependency bullets inside a `Dependencies` section are treated as importer
+errors and move the file to `failed/` with a specific message.
+
 ## Label Handling
 
 `Labels:` can be defined as a comma-separated metadata value, for example:
@@ -576,6 +580,7 @@ Typical failure cases:
 
 - missing `Title:` metadata
 - invalid metadata before the blank-line separator
+- malformed `Dependencies` sections
 - GitHub issue creation failure
 - unresolved `Parent:`
 - sub-issue linking failure

--- a/.github/scripts/import-issues.sh
+++ b/.github/scripts/import-issues.sh
@@ -172,6 +172,7 @@ linked_count=0
 failed_count=0
 warning_count=0
 LOOKUP_ISSUE_ID_ATTEMPTS=0
+PARSE_METADATA_ERROR=""
 
 parse_metadata() {
   local file="$1"
@@ -182,6 +183,7 @@ parse_metadata() {
   local body_file
   local in_metadata="true"
 
+  PARSE_METADATA_ERROR=""
   body_file="$(mktemp)"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -198,7 +200,8 @@ parse_metadata() {
       elif [[ "$line" == Status:* ]]; then
         status="$(trim "${line#Status:}")"
       else
-        print_verbose "Invalid metadata line in $(basename "$file"): $line"
+        PARSE_METADATA_ERROR="Invalid metadata line in $(basename "$file"): $line"
+        print_verbose "$PARSE_METADATA_ERROR"
         rm -f "$body_file"
         return 1
       fi
@@ -208,7 +211,8 @@ parse_metadata() {
   done < "$file"
 
   if [[ -z "$title" ]]; then
-    print_verbose "Missing required Title metadata in $(basename "$file")"
+    PARSE_METADATA_ERROR="Missing required Title metadata in $(basename "$file")"
+    print_verbose "$PARSE_METADATA_ERROR"
     rm -f "$body_file"
     return 1
   fi
@@ -652,6 +656,7 @@ emit_warning() {
   print_warning "$message"
 }
 
+if [[ "${IMPORT_ISSUES_SOURCE_ONLY:-false}" != "true" ]]; then
 preflight_import
 
 if ! load_repo_labels; then
@@ -687,6 +692,7 @@ print_verbose "DRY_RUN=$DRY_RUN"
 print_verbose "ASSIGN_TO_SELF=$ASSIGN_TO_SELF"
 if [[ -n "$AUTHENTICATED_USER" ]]; then
   print_verbose "AUTHENTICATED_USER=$AUTHENTICATED_USER"
+fi
 fi
 print_verbose "IMPORT_CONFIG_FILE=$IMPORT_CONFIG_FILE"
 print_verbose "IMPORT_LOCAL_CONFIG_FILE=$IMPORT_LOCAL_CONFIG_FILE"
@@ -763,9 +769,37 @@ lookup_issue_rest_id_with_retry() {
 lookup_issue_number_by_title_in_dir() {
   local dir="$1"
   local title="$2"
-  local matches file
+  local matches=()
+  local file
+  local line
+  local parsed_title
+  local restore_nullglob="false"
 
-  mapfile -t matches < <(grep -l "^Title: $title\$" "$dir"/*.md 2>/dev/null || true)
+  if ! shopt -q nullglob; then
+    shopt -s nullglob
+    restore_nullglob="true"
+  fi
+
+  for file in "$dir"/*.md; do
+    parsed_title=""
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -z "$line" ]] && break
+
+      if [[ "$line" == Title:* ]]; then
+        parsed_title="$(trim "${line#Title:}")"
+        break
+      fi
+    done < "$file"
+
+    if [[ "$parsed_title" == "$title" ]]; then
+      matches+=("$file")
+    fi
+  done
+
+  if [[ "$restore_nullglob" == "true" ]]; then
+    shopt -u nullglob
+  fi
 
   if [[ ${#matches[@]} -eq 0 ]]; then
     return 1
@@ -882,12 +916,18 @@ rewrite_dependencies_in_body_file() {
   local dependency_warnings=()
   local dependency_logs=()
   local in_dependencies="false"
+  local dependency_line_number=0
+  local line_number=0
 
   rewritten_file="$(mktemp)"
+  DEPENDENCY_PARSE_ERROR=""
 
   while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+
     if [[ "$line" =~ ^#{1,6}[[:space:]]+Dependencies[[:space:]]*$ ]]; then
       in_dependencies="true"
+      dependency_line_number=0
       printf '%s\n' "$line" >> "$rewritten_file"
       continue
     fi
@@ -898,14 +938,28 @@ rewrite_dependencies_in_body_file() {
       continue
     fi
 
-    if [[ "$in_dependencies" == "true" && "$line" =~ ^([[:space:]]*[-*][[:space:]]+)(.+)$ ]]; then
+    if [[ "$in_dependencies" == "true" ]]; then
+      dependency_line_number=$((dependency_line_number + 1))
+
+      if [[ -z "$line" ]]; then
+        printf '%s\n' "$line" >> "$rewritten_file"
+        continue
+      fi
+
+      if [[ "$line" =~ ^([[:space:]]*[-*][[:space:]]+)(.*)$ ]]; then
       local dependency_prefix dependency_reference
       dependency_prefix="${BASH_REMATCH[1]}"
       dependency_reference="${BASH_REMATCH[2]}"
 
       normalize_dependency_reference "$dependency_reference"
 
-      if [[ -z "$NORMALIZED_DEPENDENCY_REFERENCE" || "$NORMALIZED_DEPENDENCY_REFERENCE" == "None" ]]; then
+      if [[ -z "$NORMALIZED_DEPENDENCY_REFERENCE" ]]; then
+        DEPENDENCY_PARSE_ERROR="Empty Dependencies entry at body line $line_number"
+        rm -f "$rewritten_file"
+        return 1
+      fi
+
+      if [[ "$NORMALIZED_DEPENDENCY_REFERENCE" == "None" ]]; then
         printf '%s\n' "$line" >> "$rewritten_file"
         continue
       fi
@@ -918,6 +972,11 @@ rewrite_dependencies_in_body_file() {
         printf '%s\n' "$line" >> "$rewritten_file"
       fi
       continue
+      fi
+
+      DEPENDENCY_PARSE_ERROR="Invalid Dependencies entry at body line $line_number: $line"
+      rm -f "$rewritten_file"
+      return 1
     fi
 
     printf '%s\n' "$line" >> "$rewritten_file"
@@ -1182,6 +1241,7 @@ link_sub_issue() {
   print_success "    Linked"
 }
 
+if [[ "${IMPORT_ISSUES_SOURCE_ONLY:-false}" != "true" ]]; then
 files=( "$PENDING_DIR"/*.md )
 [[ -e "${files[0]}" ]] || {
   print_warning "No pending markdown files found in $PENDING_DIR"
@@ -1196,7 +1256,7 @@ for file in "${files[@]}"; do
   printf '%s\n' "$base"
 
   if ! parse_metadata "$file"; then
-    move_to_failed "$file" "Metadata error"
+    move_to_failed "$file" "${PARSE_METADATA_ERROR:-Metadata error}"
     printf '\n'
     continue
   fi
@@ -1315,7 +1375,13 @@ for file in "${files[@]}"; do
   effective_status="${FILE_EFFECTIVE_STATUS[$file]}"
 
   parse_metadata "$file"
-  rewrite_dependencies_in_body_file "$PARSED_BODY_FILE"
+  if ! rewrite_dependencies_in_body_file "$PARSED_BODY_FILE"; then
+    rm -f "$PARSED_BODY_FILE"
+    move_to_failed "$file" "${DEPENDENCY_PARSE_ERROR:-Dependency parsing failed}" "true" "$num" "$url"
+    print_warning "  Issue #$num was created but dependency parsing failed"
+    printf '\n'
+    continue
+  fi
 
   if [[ ${#RESOLVED_DEPENDENCY_LOGS[@]} -gt 0 ]]; then
     printf '  Dependencies\n'
@@ -1386,4 +1452,5 @@ if (( failed_count > 0 )); then
   print_error "${COLOR_BOLD}Failed:${COLOR_RESET}  $failed_count"
 else
   printf '%s%sFailed:%s  %s%s\n' "$COLOR_RED" "$COLOR_BOLD" "$COLOR_RESET" "$failed_count" "$COLOR_RESET"
+fi
 fi

--- a/.github/scripts/issue-import-common.sh
+++ b/.github/scripts/issue-import-common.sh
@@ -181,13 +181,14 @@ strip_trailing_metadata_comment() {
   local temp_file
 
   temp_file="$(mktemp)"
-  perl -0pe 's/(?:\n\s*)*<!--\n(?:.*?\n)*?-->[\r\n\s]*$//s' "$file" > "$temp_file"
+  perl -0pe 's{(?:\n\s*)*<!--\n(?:(?:(?:Imported|Timestamp|IssueCreated|Issue|URL|Error|RetryCount): .*?)\n)+-->[\r\n\s]*$}{}s' "$file" > "$temp_file"
   mv "$temp_file" "$file"
 }
 
 parse_trailing_metadata() {
   local file="$1"
   local line
+  local metadata_block=""
 
   META_IMPORTED=""
   META_TIMESTAMP=""
@@ -196,6 +197,16 @@ parse_trailing_metadata() {
   META_URL=""
   META_ERROR=""
   META_RETRY_COUNT=""
+
+  metadata_block="$(
+    perl -0ne '
+      if (/(?:\n\s*)*<!--\n((?:(?:(?:Imported|Timestamp|IssueCreated|Issue|URL|Error|RetryCount): .*?)\n)+)-->\s*$/s) {
+        print $1;
+      }
+    ' "$file"
+  )"
+
+  [[ -n "$metadata_block" ]] || return 0
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" =~ ^Imported:\ (.+)$ ]]; then
@@ -213,5 +224,5 @@ parse_trailing_metadata() {
     elif [[ "$line" =~ ^RetryCount:\ ([0-9]+)$ ]]; then
       META_RETRY_COUNT="${BASH_REMATCH[1]}"
     fi
-  done < "$file"
+  done <<< "$metadata_block"
 }

--- a/.github/scripts/test-import-issues.sh
+++ b/.github/scripts/test-import-issues.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+export IMPORT_ISSUES_SOURCE_ONLY="true"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/.github/scripts/import-issues.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "$expected" != "$actual" ]]; then
+    printf 'Expected: %s\n' "$expected" >&2
+    printf 'Actual:   %s\n' "$actual" >&2
+    fail "$message"
+  fi
+}
+
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+  local message="$3"
+
+  grep -Fq "$expected" "$file" || fail "$message"
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local expected="$2"
+  local message="$3"
+
+  if grep -Fq "$expected" "$file"; then
+    fail "$message"
+  fi
+}
+
+test_parse_metadata_reports_specific_invalid_line() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+Title: [Task]: Example
+Oops: wrong
+
+Body
+EOF
+
+  if parse_metadata "$temp_file"; then
+    fail "parse_metadata should fail for invalid metadata"
+  fi
+
+  assert_eq "Invalid metadata line in $(basename "$temp_file"): Oops: wrong" "$PARSE_METADATA_ERROR" "parse_metadata should preserve the invalid line details"
+  rm -f "$temp_file"
+}
+
+test_parse_metadata_reports_missing_title() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+Parent: Epic: Example
+
+Body
+EOF
+
+  if parse_metadata "$temp_file"; then
+    fail "parse_metadata should fail when Title is missing"
+  fi
+
+  assert_eq "Missing required Title metadata in $(basename "$temp_file")" "$PARSE_METADATA_ERROR" "parse_metadata should preserve the missing title details"
+  rm -f "$temp_file"
+}
+
+test_lookup_issue_number_by_title_in_dir_matches_literal_title() {
+  local temp_dir
+  local temp_file
+  local title
+
+  temp_dir="$(mktemp -d)"
+  temp_file="$temp_dir/2026-05-12T00-00-00-issue-999-01-task-example.md"
+  title='[Task]: Support OAuth [GraphQL] + GitHub?'
+
+  cat > "$temp_file" <<EOF
+Title: $title
+
+Body
+
+<!--
+Imported: 2026-05-12T00:00:00-0500
+Issue: #999
+URL: https://github.com/jbolous/kartoush/issues/999
+-->
+EOF
+
+  if ! lookup_issue_number_by_title_in_dir "$temp_dir" "$title"; then
+    fail "lookup_issue_number_by_title_in_dir should match literal-safe titles"
+  fi
+
+  assert_eq "999" "$LOOKED_UP_PARENT_ISSUE_NUMBER" "lookup_issue_number_by_title_in_dir should resolve the issue number from importer metadata"
+  rm -rf "$temp_dir"
+}
+
+test_strip_trailing_metadata_comment_preserves_normal_html_comment() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+Visible content
+
+<!-- normal trailing comment -->
+EOF
+
+  strip_trailing_metadata_comment "$temp_file"
+
+  assert_file_contains "$temp_file" "<!-- normal trailing comment -->" "strip_trailing_metadata_comment should keep normal trailing comments"
+  rm -f "$temp_file"
+}
+
+test_strip_trailing_metadata_comment_removes_importer_footer_only() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+Visible content
+
+<!--
+Imported: 2026-05-12T00:00:00-0500
+Issue: #999
+URL: https://github.com/jbolous/kartoush/issues/999
+-->
+EOF
+
+  strip_trailing_metadata_comment "$temp_file"
+
+  assert_file_not_contains "$temp_file" "Imported: 2026-05-12T00:00:00-0500" "strip_trailing_metadata_comment should remove importer metadata footers"
+  assert_file_contains "$temp_file" "Visible content" "strip_trailing_metadata_comment should preserve the main body"
+  rm -f "$temp_file"
+}
+
+test_parse_trailing_metadata_ignores_non_importer_comment_lines() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+Body
+
+<!--
+Note: This is not importer metadata
+Issue: #321
+-->
+EOF
+
+  parse_trailing_metadata "$temp_file"
+
+  assert_eq "" "${META_ISSUE_NUMBER:-}" "parse_trailing_metadata should ignore non-importer trailing comments"
+  rm -f "$temp_file"
+}
+
+test_parse_trailing_metadata_reads_importer_footer() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+Body
+
+<!--
+Imported: Failed
+Timestamp: 2026-05-12T00:00:00-0500
+IssueCreated: true
+Issue: #321
+URL: https://github.com/jbolous/kartoush/issues/321
+RetryCount: 2
+Error: Example failure
+-->
+EOF
+
+  parse_trailing_metadata "$temp_file"
+
+  assert_eq "321" "$META_ISSUE_NUMBER" "parse_trailing_metadata should read importer issue numbers"
+  assert_eq "2" "$META_RETRY_COUNT" "parse_trailing_metadata should read importer retry counts"
+  assert_eq "Example failure" "$META_ERROR" "parse_trailing_metadata should read importer error summaries"
+  rm -f "$temp_file"
+}
+
+test_rewrite_dependencies_rejects_non_list_content() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+## Dependencies
+This should have been a bullet
+EOF
+
+  if rewrite_dependencies_in_body_file "$temp_file"; then
+    fail "rewrite_dependencies_in_body_file should fail for prose inside Dependencies"
+  fi
+
+  assert_eq "Invalid Dependencies entry at body line 2: This should have been a bullet" "$DEPENDENCY_PARSE_ERROR" "rewrite_dependencies_in_body_file should explain malformed dependency prose"
+  rm -f "$temp_file"
+}
+
+test_rewrite_dependencies_rejects_empty_bullets() {
+  local temp_file
+
+  temp_file="$(mktemp)"
+  cat > "$temp_file" <<'EOF'
+## Dependencies
+-    
+EOF
+
+  if rewrite_dependencies_in_body_file "$temp_file"; then
+    fail "rewrite_dependencies_in_body_file should fail for empty dependency bullets"
+  fi
+
+  assert_eq "Empty Dependencies entry at body line 2" "$DEPENDENCY_PARSE_ERROR" "rewrite_dependencies_in_body_file should explain empty dependency bullets"
+  rm -f "$temp_file"
+}
+
+test_parse_metadata_reports_specific_invalid_line
+test_parse_metadata_reports_missing_title
+test_lookup_issue_number_by_title_in_dir_matches_literal_title
+test_strip_trailing_metadata_comment_preserves_normal_html_comment
+test_strip_trailing_metadata_comment_removes_importer_footer_only
+test_parse_trailing_metadata_ignores_non_importer_comment_lines
+test_parse_trailing_metadata_reads_importer_footer
+test_rewrite_dependencies_rejects_non_list_content
+test_rewrite_dependencies_rejects_empty_bullets
+
+printf 'Importer regression checks passed.\n'


### PR DESCRIPTION
## Summary
- Make importer title matching literal-safe instead of regex-sensitive
- Preserve specific metadata parse errors and fail malformed Dependencies sections clearly
- Restrict importer footer parsing and stripping to importer-shaped metadata comments

## Scope
- Harden metadata parsing and failed-file error messages
- Replace regex-based title matching with direct Title metadata comparison
- Tighten trailing importer footer parsing and stripping
- Add a lightweight importer regression script for parser edge cases
- Update importer docs for malformed Dependencies handling

## Testing
- bash -n .github/scripts/import-issues.sh
- bash -n .github/scripts/issue-import-common.sh
- bash -n .github/scripts/test-import-issues.sh
- bash .github/scripts/test-import-issues.sh

Closes #244