### PR TITLE
Add Jobrunr Infrastructure and Postgres-Backed Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ local Mailtrap-backed quick start, see:
 
 - `docs/auth/transactional-email-provider-configuration.md`
 
+For JobRunr background job runtime configuration and the local dashboard setup,
+see:
+
+- `docs/infrastructure/jobrunr-background-job-configuration.md`
+
 ---
 
 ## API Documentation

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,10 +22,12 @@ dependencies {
     implementation project(':auth')
     implementation project(':customer')
     implementation project(':notification')
+    implementation project(':platform:platform-jobs')
     implementation project(':platform:platform-types')
     implementation project(':platform:platform-validation')
     testImplementation project(":test-support")
 
+    implementation(libs.jobrunrSpringBoot4Starter)
     implementation(libs.springBootStarterWeb)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
+++ b/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
@@ -1,0 +1,29 @@
+package com.kartoush.config.jobs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
+import com.kartoush.platform.jobs.JobHandler;
+import org.jobrunr.scheduling.JobScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class BackgroundJobConfiguration {
+
+    @Bean
+    PlatformJobDispatcher platformJobDispatcher(
+        final ObjectMapper objectMapper,
+        final List<JobHandler<?>> jobHandlers) {
+        return new PlatformJobDispatcher(objectMapper, jobHandlers);
+    }
+
+    @Bean
+    BackgroundJobScheduler platformJobScheduler(
+        final JobScheduler jobRunrJobScheduler,
+        final PlatformJobDispatcher platformJobDispatcher,
+        final ObjectMapper objectMapper) {
+        return new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, objectMapper);
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/JobRunrPlatformJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/JobRunrPlatformJobScheduler.java
@@ -1,0 +1,70 @@
+package com.kartoush.config.jobs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
+import com.kartoush.platform.jobs.JobRequest;
+import com.kartoush.platform.jobs.JobSchedulingException;
+import org.jobrunr.scheduling.JobScheduler;
+
+import java.time.Instant;
+
+public class JobRunrPlatformJobScheduler implements BackgroundJobScheduler {
+
+    private final JobScheduler jobRunrJobScheduler;
+
+    private final PlatformJobDispatcher platformJobDispatcher;
+
+    private final ObjectMapper objectMapper;
+
+    public JobRunrPlatformJobScheduler(
+        final JobScheduler jobRunrJobScheduler,
+        final PlatformJobDispatcher platformJobDispatcher,
+        final ObjectMapper objectMapper) {
+        this.jobRunrJobScheduler = jobRunrJobScheduler;
+        this.platformJobDispatcher = platformJobDispatcher;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void enqueue(final JobRequest request) {
+        final SerializedJobRequest serializedJobRequest = serialize(request);
+
+        try {
+            jobRunrJobScheduler.enqueue(() -> platformJobDispatcher.dispatch(
+                serializedJobRequest.requestType(),
+                serializedJobRequest.payload()
+            ));
+        } catch (final RuntimeException ex) {
+            throw new JobSchedulingException("Failed to enqueue job request of type " + request.getClass().getName(), ex);
+        }
+    }
+
+    @Override
+    public void schedule(final JobRequest request, final Instant scheduledAt) {
+        final SerializedJobRequest serializedJobRequest = serialize(request);
+
+        try {
+            jobRunrJobScheduler.schedule(scheduledAt, () -> platformJobDispatcher.dispatch(
+                serializedJobRequest.requestType(),
+                serializedJobRequest.payload()
+            ));
+        } catch (final RuntimeException ex) {
+            throw new JobSchedulingException("Failed to schedule job request of type " + request.getClass().getName(), ex);
+        }
+    }
+
+    private SerializedJobRequest serialize(final JobRequest request) {
+        try {
+            return new SerializedJobRequest(
+                request.getClass().getName(),
+                objectMapper.writeValueAsString(request)
+            );
+        } catch (final JsonProcessingException ex) {
+            throw new JobSchedulingException("Failed to serialize job request of type " + request.getClass().getName(), ex);
+        }
+    }
+
+    private record SerializedJobRequest(String requestType, String payload) {
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/PlatformJobDispatcher.java
+++ b/app/src/main/java/com/kartoush/config/jobs/PlatformJobDispatcher.java
@@ -1,0 +1,76 @@
+package com.kartoush.config.jobs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.jobs.JobRequest;
+import org.springframework.core.ResolvableType;
+
+import java.util.List;
+
+public class PlatformJobDispatcher {
+
+    private final ObjectMapper objectMapper;
+
+    private final List<JobHandler<?>> jobHandlers;
+
+    public PlatformJobDispatcher(
+        final ObjectMapper objectMapper,
+        final List<JobHandler<?>> jobHandlers) {
+        this.objectMapper = objectMapper;
+        this.jobHandlers = List.copyOf(jobHandlers);
+    }
+
+    public void dispatch(final String requestType, final String payload) {
+        final JobRequest request = deserialize(requestType, payload);
+        final JobHandler<JobRequest> jobHandler = resolveHandler(request.getClass());
+        jobHandler.handle(request);
+    }
+
+    private JobRequest deserialize(final String requestType, final String payload) {
+        final Class<?> resolvedRequestType;
+        try {
+            resolvedRequestType = Class.forName(requestType);
+        } catch (final ClassNotFoundException ex) {
+            throw new IllegalStateException("Unknown job request type " + requestType, ex);
+        }
+
+        if (!JobRequest.class.isAssignableFrom(resolvedRequestType)) {
+            throw new IllegalStateException("Resolved type does not implement JobRequest: " + requestType);
+        }
+
+        try {
+            return (JobRequest) objectMapper.readValue(payload, resolvedRequestType);
+        } catch (final JsonProcessingException ex) {
+            throw new IllegalStateException("Failed to deserialize job request of type " + requestType, ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private JobHandler<JobRequest> resolveHandler(final Class<?> requestType) {
+        final List<JobHandler<?>> matchingHandlers = jobHandlers.stream()
+            .filter(jobHandler -> requestType.equals(resolveHandledRequestType(jobHandler)))
+            .toList();
+
+        if (matchingHandlers.isEmpty()) {
+            throw new IllegalStateException("No JobHandler registered for request type " + requestType.getName());
+        }
+
+        if (matchingHandlers.size() > 1) {
+            throw new IllegalStateException("Multiple JobHandler beans registered for request type " + requestType.getName());
+        }
+
+        return (JobHandler<JobRequest>) matchingHandlers.getFirst();
+    }
+
+    private Class<?> resolveHandledRequestType(final JobHandler<?> jobHandler) {
+        final ResolvableType resolvableType = ResolvableType.forInstance(jobHandler).as(JobHandler.class);
+        final Class<?> resolvedRequestType = resolvableType.getGeneric(0).resolve();
+
+        if (resolvedRequestType == null) {
+            throw new IllegalStateException("Could not resolve JobHandler request type for " + jobHandler.getClass().getName());
+        }
+
+        return resolvedRequestType;
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/PlatformJobDispatcher.java
+++ b/app/src/main/java/com/kartoush/config/jobs/PlatformJobDispatcher.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kartoush.platform.jobs.JobHandler;
 import com.kartoush.platform.jobs.JobRequest;
+import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.core.ResolvableType;
 
 import java.util.List;
@@ -64,11 +65,12 @@ public class PlatformJobDispatcher {
     }
 
     private Class<?> resolveHandledRequestType(final JobHandler<?> jobHandler) {
-        final ResolvableType resolvableType = ResolvableType.forInstance(jobHandler).as(JobHandler.class);
+        final Class<?> targetClass = AopProxyUtils.ultimateTargetClass(jobHandler);
+        final ResolvableType resolvableType = ResolvableType.forClass(targetClass).as(JobHandler.class);
         final Class<?> resolvedRequestType = resolvableType.getGeneric(0).resolve();
 
         if (resolvedRequestType == null) {
-            throw new IllegalStateException("Could not resolve JobHandler request type for " + jobHandler.getClass().getName());
+            throw new IllegalStateException("Could not resolve JobHandler request type for " + targetClass.getName());
         }
 
         return resolvedRequestType;

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -3,6 +3,13 @@ spring:
     activate:
       on-profile: dev
 
+jobrunr:
+  background-job-server:
+    enabled: ${KARTOUSH_JOBRUNR_BACKGROUND_JOB_SERVER_ENABLED:true}
+  dashboard:
+    enabled: ${KARTOUSH_JOBRUNR_DASHBOARD_ENABLED:true}
+    port: ${KARTOUSH_JOBRUNR_DASHBOARD_PORT:8000}
+
 kartoush:
   email:
     delivery:

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -3,6 +3,12 @@ spring:
     activate:
       on-profile: prod
 
+jobrunr:
+  background-job-server:
+    enabled: ${KARTOUSH_JOBRUNR_BACKGROUND_JOB_SERVER_ENABLED:true}
+  dashboard:
+    enabled: ${KARTOUSH_JOBRUNR_DASHBOARD_ENABLED:false}
+
 kartoush:
   email:
     delivery:

--- a/app/src/main/resources/application-test.yml
+++ b/app/src/main/resources/application-test.yml
@@ -3,6 +3,12 @@ spring:
     activate:
       on-profile: test
 
+jobrunr:
+  background-job-server:
+    enabled: false
+  dashboard:
+    enabled: false
+
 kartoush:
   email:
     delivery:

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
 logging:
   level:
     org.flywaydb: info
+    org.jobrunr: info
     com.kartoush: TRACE
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
@@ -51,3 +52,7 @@ kartoush:
       require-lowercase: true
       require-digit: true
       require-special-character: true
+
+jobrunr:
+  database:
+    table-prefix: jobrunr.

--- a/app/src/main/resources/db/migration/V16__create_jobrunr_schema.sql
+++ b/app/src/main/resources/db/migration/V16__create_jobrunr_schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS jobrunr;

--- a/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
@@ -1,0 +1,41 @@
+package com.kartoush.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.config.jobs.BackgroundJobConfiguration;
+import com.kartoush.config.jobs.PlatformJobDispatcher;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.jobs.JobRequest;
+import org.junit.jupiter.api.Test;
+import org.jobrunr.scheduling.JobScheduler;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BackgroundJobConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withBean(ObjectMapper.class, ObjectMapper::new)
+        .withBean(JobScheduler.class, () -> org.mockito.Mockito.mock(JobScheduler.class))
+        .withBean(JobHandler.class, ExampleJobHandler::new)
+        .withUserConfiguration(BackgroundJobConfiguration.class);
+
+    @Test
+    void shouldProvidePlatformJobSchedulerBackedByJobRunr() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(BackgroundJobScheduler.class);
+            assertThat(context).hasSingleBean(PlatformJobDispatcher.class);
+        });
+    }
+
+    record ExampleJobRequest(String customerId) implements JobRequest {
+    }
+
+    static final class ExampleJobHandler implements JobHandler<ExampleJobRequest> {
+
+        @Override
+        public void handle(final ExampleJobRequest request) {
+        }
+    }
+}

--- a/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
@@ -11,12 +11,13 @@ import org.jobrunr.scheduling.JobScheduler;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class BackgroundJobConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withBean(ObjectMapper.class, ObjectMapper::new)
-        .withBean(JobScheduler.class, () -> org.mockito.Mockito.mock(JobScheduler.class))
+        .withBean(JobScheduler.class, () -> mock(JobScheduler.class))
         .withBean(JobHandler.class, ExampleJobHandler::new)
         .withUserConfiguration(BackgroundJobConfiguration.class);
 

--- a/app/src/test/java/com/kartoush/config/JobRunrInfrastructureIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/config/JobRunrInfrastructureIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.kartoush.config;
+
+import com.kartoush.KartoushApplication;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.jobs.JobRequest;
+import com.kartoush.testsupport.PostgresSpringIntegrationTest;
+import com.kartoush.testsupport.SpringIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringIntegrationTest
+@Import({KartoushApplication.class, JobRunrInfrastructureIntegrationTest.JobRunrTestConfiguration.class})
+class JobRunrInfrastructureIntegrationTest extends PostgresSpringIntegrationTest {
+
+    @Autowired
+    private BackgroundJobScheduler platformJobScheduler;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldProvidePlatformJobSchedulerBean() {
+        assertThat(platformJobScheduler).isNotNull();
+    }
+
+    @Test
+    void shouldPersistEnqueuedJobsToPostgres() {
+        platformJobScheduler.enqueue(new ExampleJobRequest("01JOBJOBRUNR00000000000001"));
+
+        final Integer jobCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(id) FROM jobrunr.jobrunr_jobs",
+            Integer.class
+        );
+
+        assertThat(jobCount).isNotNull();
+        assertThat(jobCount).isGreaterThanOrEqualTo(1);
+    }
+
+    record ExampleJobRequest(String customerId) implements JobRequest {
+    }
+
+    @TestConfiguration
+    static class JobRunrTestConfiguration {
+
+        @Bean
+        JobHandler<ExampleJobRequest> exampleJobHandler() {
+            return new ExampleJobHandler();
+        }
+
+        static final class ExampleJobHandler implements JobHandler<ExampleJobRequest> {
+
+            @Override
+            public void handle(final ExampleJobRequest request) {
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/kartoush/config/PlatformJobDispatcherTest.java
+++ b/app/src/test/java/com/kartoush/config/PlatformJobDispatcherTest.java
@@ -1,0 +1,40 @@
+package com.kartoush.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.config.jobs.PlatformJobDispatcher;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.jobs.JobRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlatformJobDispatcherTest {
+
+    @Test
+    void shouldDeserializeRequestAndDispatchToMatchingHandler() throws Exception {
+        final RecordingJobHandler jobHandler = new RecordingJobHandler();
+        final PlatformJobDispatcher dispatcher =
+            new PlatformJobDispatcher(new ObjectMapper(), java.util.List.of(jobHandler));
+        final ExampleJobRequest request = new ExampleJobRequest("01JOBJOBRUNR00000000000001");
+
+        dispatcher.dispatch(
+            ExampleJobRequest.class.getName(),
+            new ObjectMapper().writeValueAsString(request)
+        );
+
+        assertThat(jobHandler.handledRequest).isEqualTo(request);
+    }
+
+    record ExampleJobRequest(String customerId) implements JobRequest {
+    }
+
+    static final class RecordingJobHandler implements JobHandler<ExampleJobRequest> {
+
+        private ExampleJobRequest handledRequest;
+
+        @Override
+        public void handle(final ExampleJobRequest request) {
+            this.handledRequest = request;
+        }
+    }
+}

--- a/app/src/test/java/com/kartoush/config/PlatformJobDispatcherTest.java
+++ b/app/src/test/java/com/kartoush/config/PlatformJobDispatcherTest.java
@@ -5,6 +5,7 @@ import com.kartoush.config.jobs.PlatformJobDispatcher;
 import com.kartoush.platform.jobs.JobHandler;
 import com.kartoush.platform.jobs.JobRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,6 +24,29 @@ class PlatformJobDispatcherTest {
         );
 
         assertThat(jobHandler.handledRequest).isEqualTo(request);
+    }
+
+    @Test
+    void shouldResolveHandledRequestTypeFromProxiedHandler() throws Exception {
+        final RecordingJobHandler targetHandler = new RecordingJobHandler();
+        final ProxyFactory proxyFactory = new ProxyFactory(targetHandler);
+        proxyFactory.setProxyTargetClass(false);
+        proxyFactory.addInterface(JobHandler.class);
+
+        @SuppressWarnings("unchecked")
+        final JobHandler<ExampleJobRequest> proxiedHandler =
+            (JobHandler<ExampleJobRequest>) proxyFactory.getProxy();
+
+        final PlatformJobDispatcher dispatcher =
+            new PlatformJobDispatcher(new ObjectMapper(), java.util.List.of(proxiedHandler));
+        final ExampleJobRequest request = new ExampleJobRequest("01JOBJOBRUNR00000000000001");
+
+        dispatcher.dispatch(
+            ExampleJobRequest.class.getName(),
+            new ObjectMapper().writeValueAsString(request)
+        );
+
+        assertThat(targetHandler.handledRequest).isEqualTo(request);
     }
 
     record ExampleJobRequest(String customerId) implements JobRequest {

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -1,0 +1,157 @@
+# JobRunr Background Job Configuration
+
+## Purpose
+
+This document explains how Kartoush wires JobRunr for durable background job
+execution and how that setup behaves by environment.
+
+This document covers runtime configuration only.
+
+It does not replace the architectural decision work tracked separately for the
+broader background job direction.
+
+## Current Role
+
+JobRunr is the infrastructure mechanism for durable background job execution in
+Kartoush.
+
+At this stage, Kartoush provides:
+
+- A framework-free platform scheduling boundary through `platform-jobs`
+- A JobRunr-backed adapter in `app`
+- Postgres-backed persistent job storage
+- Local and development dashboard support
+
+At this stage, Kartoush does not yet provide:
+
+- Activation email job scheduling
+- After-commit scheduling behavior
+- A broader recurring cleanup job implementation
+
+Those are follow-up tasks in the same epic.
+
+## Module Boundary
+
+The JobRunr runtime wiring lives in `app`.
+
+The shared scheduling contract lives in:
+
+- `platform:platform-jobs`
+
+Application code should depend on:
+
+- `BackgroundJobScheduler`
+- `JobRequest`
+- `JobHandler`
+
+Application and domain code should not depend directly on JobRunr types.
+
+## Persistence Model
+
+JobRunr stores job metadata in PostgreSQL.
+
+The current configuration uses:
+
+- `jobrunr.database.table-prefix=jobrunr.`
+
+That places JobRunr tables in a dedicated `jobrunr` schema while still using
+the same PostgreSQL database as the rest of the application.
+
+## Spring Profile Direction
+
+The current profile behavior is:
+
+- `dev`
+  - Background job server enabled by default
+  - Dashboard enabled by default
+- `test`
+  - Background job server disabled
+  - Dashboard disabled
+- `prod`
+  - Background job server enabled by default
+  - Dashboard disabled by default
+
+## Configuration Surface
+
+### Shared Configuration
+
+Shared settings currently live in `application.yml`:
+
+- `jobrunr.database.table-prefix`
+
+Kartoush also creates the `jobrunr` schema explicitly through Flyway before
+JobRunr starts creating its own tables there.
+
+### Development Configuration
+
+Development settings currently live in `application-dev.yml`:
+
+- `jobrunr.background-job-server.enabled`
+- `jobrunr.dashboard.enabled`
+- `jobrunr.dashboard.port`
+
+Environment overrides:
+
+```bash
+export KARTOUSH_JOBRUNR_BACKGROUND_JOB_SERVER_ENABLED=true
+export KARTOUSH_JOBRUNR_DASHBOARD_ENABLED=true
+export KARTOUSH_JOBRUNR_DASHBOARD_PORT=8000
+```
+
+### Production Configuration
+
+Production defaults currently live in `application-prod.yml`:
+
+- `jobrunr.background-job-server.enabled`
+- `jobrunr.dashboard.enabled`
+
+Environment overrides:
+
+```bash
+export KARTOUSH_JOBRUNR_BACKGROUND_JOB_SERVER_ENABLED=true
+export KARTOUSH_JOBRUNR_DASHBOARD_ENABLED=false
+```
+
+## Local Quick Start
+
+Use this flow when you want to verify that JobRunr starts locally and persists
+jobs to PostgreSQL:
+
+1. Start PostgreSQL locally and make sure Kartoush can connect to it
+2. Run the application with the `dev` profile
+
+```bash
+export SPRING_PROFILES_ACTIVE=dev
+./gradlew :app:bootRun
+```
+
+3. Open the JobRunr dashboard locally if enabled
+
+```text
+http://localhost:8000
+```
+
+4. Trigger a code path that enqueues a background job once later tasks wire one
+   in
+
+At the current stage, the dashboard and database wiring can be verified even
+though customer-facing job scheduling is still a follow-up task.
+
+## Test Behavior
+
+The `test` profile disables the background job server and dashboard.
+
+This keeps most automated tests deterministic until later tasks begin
+exercising actual job scheduling behavior.
+
+Focused integration tests may still verify that JobRunr starts and can persist
+jobs when needed.
+
+## Operational Notes
+
+- JobRunr storage is durable because job records are written to PostgreSQL
+- The local dashboard is intended for development use only at this stage
+- Production-sensitive dashboard exposure should stay disabled unless there is
+  a deliberate operational reason to enable it
+- JobRunr is being introduced as durable task infrastructure, not as a domain
+  event system

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 springBootVersion = "4.0.6"
+jobrunrVersion = "8.3.0"
 springdoc = "3.0.2"
 testcontainers = "2.0.3"
 springDependencyManagementVersion = "1.1.7"
@@ -21,6 +22,7 @@ springBootStarterTest = { module = "org.springframework.boot:spring-boot-starter
 springBootStarterDataJpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBootVersion" }
 springBootStarterWeb = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springBootVersion" }
 springBootStarterWebmvcTest = { module = "org.springframework.boot:spring-boot-starter-webmvc-test", version.ref = "springBootVersion" }
+jobrunrSpringBoot4Starter = { module = "org.jobrunr:jobrunr-spring-boot-4-starter", version.ref = "jobrunrVersion" }
 springBootStarterFlyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 springBootTest = { module = "org.springframework.boot:spring-boot-test", version.ref = "springBootVersion" }
 springBootTestAutoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure", version.ref = "springBootVersion" }

--- a/platform/platform-jobs/src/main/java/com/kartoush/platform/jobs/BackgroundJobScheduler.java
+++ b/platform/platform-jobs/src/main/java/com/kartoush/platform/jobs/BackgroundJobScheduler.java
@@ -6,7 +6,7 @@ import java.time.Instant;
  * Schedules durable background work without exposing infrastructure details to
  * application code.
  */
-public interface JobScheduler {
+public interface BackgroundJobScheduler {
 
     void enqueue(JobRequest request);
 

--- a/platform/platform-jobs/src/test/java/com/kartoush/platform/jobs/BackgroundJobSchedulerContractTest.java
+++ b/platform/platform-jobs/src/test/java/com/kartoush/platform/jobs/BackgroundJobSchedulerContractTest.java
@@ -6,11 +6,11 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class JobSchedulerContractTest {
+class BackgroundJobSchedulerContractTest {
 
     @Test
     void shouldAllowEnqueueingTypedJobRequests() {
-        final RecordingJobScheduler scheduler = new RecordingJobScheduler();
+        final RecordingBackgroundJobScheduler scheduler = new RecordingBackgroundJobScheduler();
         final ExampleJobRequest request = new ExampleJobRequest("01HXJOB0000000000000000001");
 
         scheduler.enqueue(request);
@@ -22,7 +22,7 @@ class JobSchedulerContractTest {
 
     @Test
     void shouldAllowSchedulingTypedJobRequestsForLaterExecution() {
-        final RecordingJobScheduler scheduler = new RecordingJobScheduler();
+        final RecordingBackgroundJobScheduler scheduler = new RecordingBackgroundJobScheduler();
         final ExampleJobRequest request = new ExampleJobRequest("01HXJOB0000000000000000001");
         final Instant scheduledAt = Instant.parse("2026-05-12T12:00:00Z");
 
@@ -36,7 +36,7 @@ class JobSchedulerContractTest {
     private record ExampleJobRequest(String customerId) implements JobRequest {
     }
 
-    private static final class RecordingJobScheduler implements JobScheduler {
+    private static final class RecordingBackgroundJobScheduler implements BackgroundJobScheduler {
 
         private JobRequest enqueuedRequest;
         private JobRequest scheduledRequest;


### PR DESCRIPTION
## Summary
- Add JobRunr as Kartoush's durable background job infrastructure
- Wire a JobRunr-backed adapter behind the `platform-jobs` scheduling boundary
- Move JobRunr storage into a dedicated `jobrunr` schema and document the runtime configuration

## Scope
- Add the JobRunr Spring Boot 4 starter through the shared version catalog
- Add app-side JobRunr configuration and the `BackgroundJobScheduler` adapter wiring
- Configure profile-specific JobRunr behavior for `dev`, `test`, and `prod`
- Add a Flyway migration to create the `jobrunr` schema
- Add focused configuration, dispatcher, and Postgres-backed integration tests

## Notes
- This PR adds infrastructure only
- It does not schedule activation emails yet
- It does not implement after-commit scheduling behavior yet

## Testing
- `./gradlew :platform:platform-jobs:test`
- `./gradlew :app:test --tests com.kartoush.config.BackgroundJobConfigurationTest --tests com.kartoush.config.PlatformJobDispatcherTest -x :app:jacocoTestReport`
- `./gradlew :app:integrationTest --tests com.kartoush.config.JobRunrInfrastructureIntegrationTest`
- `bash .github/scripts/validate-editorial-style.sh`

Closes #294
