### PR TITLE
Ensure Background Jobs Are Scheduled After Transaction Commit

### DIFF
--- a/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
+++ b/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
@@ -24,6 +24,8 @@ public class BackgroundJobConfiguration {
         final JobScheduler jobRunrJobScheduler,
         final PlatformJobDispatcher platformJobDispatcher,
         final ObjectMapper objectMapper) {
-        return new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, objectMapper);
+        return new TransactionAwareBackgroundJobScheduler(
+            new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, objectMapper)
+        );
     }
 }

--- a/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
+++ b/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
@@ -6,6 +6,8 @@ import com.kartoush.platform.jobs.JobHandler;
 import org.jobrunr.scheduling.JobScheduler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 
@@ -23,9 +25,13 @@ public class BackgroundJobConfiguration {
     BackgroundJobScheduler platformJobScheduler(
         final JobScheduler jobRunrJobScheduler,
         final PlatformJobDispatcher platformJobDispatcher,
-        final ObjectMapper objectMapper) {
+        final ObjectMapper objectMapper,
+        final PlatformTransactionManager transactionManager) {
+        final TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setPropagationBehavior(TransactionTemplate.PROPAGATION_REQUIRES_NEW);
         return new TransactionAwareBackgroundJobScheduler(
-            new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, objectMapper)
+            new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, objectMapper),
+            transactionTemplate
         );
     }
 }

--- a/app/src/main/java/com/kartoush/config/jobs/JobRunrPlatformJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/JobRunrPlatformJobScheduler.java
@@ -28,33 +28,37 @@ public class JobRunrPlatformJobScheduler implements BackgroundJobScheduler {
 
     @Override
     public void enqueue(final JobRequest request) {
-        final SerializedJobRequest serializedJobRequest = serialize(request);
+        enqueueSerialized(snapshot(request));
+    }
 
+    void enqueueSerialized(final SerializedJobRequest serializedJobRequest) {
         try {
             jobRunrJobScheduler.enqueue(() -> platformJobDispatcher.dispatch(
                 serializedJobRequest.requestType(),
                 serializedJobRequest.payload()
             ));
         } catch (final RuntimeException ex) {
-            throw new JobSchedulingException("Failed to enqueue job request of type " + request.getClass().getName(), ex);
+            throw new JobSchedulingException("Failed to enqueue job request of type " + serializedJobRequest.requestType(), ex);
         }
     }
 
     @Override
     public void schedule(final JobRequest request, final Instant scheduledAt) {
-        final SerializedJobRequest serializedJobRequest = serialize(request);
+        scheduleSerialized(snapshot(request), scheduledAt);
+    }
 
+    void scheduleSerialized(final SerializedJobRequest serializedJobRequest, final Instant scheduledAt) {
         try {
             jobRunrJobScheduler.schedule(scheduledAt, () -> platformJobDispatcher.dispatch(
                 serializedJobRequest.requestType(),
                 serializedJobRequest.payload()
             ));
         } catch (final RuntimeException ex) {
-            throw new JobSchedulingException("Failed to schedule job request of type " + request.getClass().getName(), ex);
+            throw new JobSchedulingException("Failed to schedule job request of type " + serializedJobRequest.requestType(), ex);
         }
     }
 
-    private SerializedJobRequest serialize(final JobRequest request) {
+    SerializedJobRequest snapshot(final JobRequest request) {
         try {
             return new SerializedJobRequest(
                 request.getClass().getName(),
@@ -65,6 +69,6 @@ public class JobRunrPlatformJobScheduler implements BackgroundJobScheduler {
         }
     }
 
-    private record SerializedJobRequest(String requestType, String payload) {
+    record SerializedJobRequest(String requestType, String payload) {
     }
 }

--- a/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
@@ -2,17 +2,27 @@ package com.kartoush.config.jobs;
 
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.jobs.JobRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Instant;
 
 public class TransactionAwareBackgroundJobScheduler implements BackgroundJobScheduler {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionAwareBackgroundJobScheduler.class);
+
     private final JobRunrPlatformJobScheduler delegate;
 
-    public TransactionAwareBackgroundJobScheduler(final JobRunrPlatformJobScheduler delegate) {
+    private final TransactionOperations transactionOperations;
+
+    public TransactionAwareBackgroundJobScheduler(
+        final JobRunrPlatformJobScheduler delegate,
+        final TransactionOperations transactionOperations) {
         this.delegate = delegate;
+        this.transactionOperations = transactionOperations;
     }
 
     @Override
@@ -33,7 +43,11 @@ public class TransactionAwareBackgroundJobScheduler implements BackgroundJobSche
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                action.run();
+                try {
+                    transactionOperations.executeWithoutResult(status -> action.run());
+                } catch (final RuntimeException ex) {
+                    LOG.error("Background job scheduling failed after the original transaction committed", ex);
+                }
             }
         });
     }

--- a/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
@@ -1,0 +1,45 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
+import com.kartoush.platform.jobs.JobRequest;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Instant;
+
+public class TransactionAwareBackgroundJobScheduler implements BackgroundJobScheduler {
+
+    private final BackgroundJobScheduler delegate;
+
+    public TransactionAwareBackgroundJobScheduler(final BackgroundJobScheduler delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void enqueue(final JobRequest request) {
+        assertTransactionIsActive();
+        registerAfterCommit(() -> delegate.enqueue(request));
+    }
+
+    @Override
+    public void schedule(final JobRequest request, final Instant scheduledAt) {
+        assertTransactionIsActive();
+        registerAfterCommit(() -> delegate.schedule(request, scheduledAt));
+    }
+
+    private void registerAfterCommit(final Runnable action) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                action.run();
+            }
+        });
+    }
+
+    private void assertTransactionIsActive() {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()
+            || !TransactionSynchronizationManager.isActualTransactionActive()) {
+            throw new IllegalStateException("Background jobs can only be scheduled inside an active transaction");
+        }
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
@@ -9,22 +9,24 @@ import java.time.Instant;
 
 public class TransactionAwareBackgroundJobScheduler implements BackgroundJobScheduler {
 
-    private final BackgroundJobScheduler delegate;
+    private final JobRunrPlatformJobScheduler delegate;
 
-    public TransactionAwareBackgroundJobScheduler(final BackgroundJobScheduler delegate) {
+    public TransactionAwareBackgroundJobScheduler(final JobRunrPlatformJobScheduler delegate) {
         this.delegate = delegate;
     }
 
     @Override
     public void enqueue(final JobRequest request) {
         assertTransactionIsActive();
-        registerAfterCommit(() -> delegate.enqueue(request));
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest = delegate.snapshot(request);
+        registerAfterCommit(() -> delegate.enqueueSerialized(serializedJobRequest));
     }
 
     @Override
     public void schedule(final JobRequest request, final Instant scheduledAt) {
         assertTransactionIsActive();
-        registerAfterCommit(() -> delegate.schedule(request, scheduledAt));
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest = delegate.snapshot(request);
+        registerAfterCommit(() -> delegate.scheduleSerialized(serializedJobRequest, scheduledAt));
     }
 
     private void registerAfterCommit(final Runnable action) {

--- a/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
@@ -3,6 +3,7 @@ package com.kartoush.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kartoush.config.jobs.BackgroundJobConfiguration;
 import com.kartoush.config.jobs.PlatformJobDispatcher;
+import com.kartoush.config.jobs.TransactionAwareBackgroundJobScheduler;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.jobs.JobHandler;
 import com.kartoush.platform.jobs.JobRequest;
@@ -27,6 +28,7 @@ class BackgroundJobConfigurationTest {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(BackgroundJobScheduler.class);
             assertThat(context).hasSingleBean(PlatformJobDispatcher.class);
+            assertThat(context.getBean(BackgroundJobScheduler.class)).isInstanceOf(TransactionAwareBackgroundJobScheduler.class);
         });
     }
 

--- a/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/BackgroundJobConfigurationTest.java
@@ -10,6 +10,7 @@ import com.kartoush.platform.jobs.JobRequest;
 import org.junit.jupiter.api.Test;
 import org.jobrunr.scheduling.JobScheduler;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -19,6 +20,7 @@ class BackgroundJobConfigurationTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withBean(ObjectMapper.class, ObjectMapper::new)
         .withBean(JobScheduler.class, () -> mock(JobScheduler.class))
+        .withBean(PlatformTransactionManager.class, () -> mock(PlatformTransactionManager.class))
         .withBean(JobHandler.class, ExampleJobHandler::new)
         .withUserConfiguration(BackgroundJobConfiguration.class);
 

--- a/app/src/test/java/com/kartoush/config/JobRunrInfrastructureIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/config/JobRunrInfrastructureIntegrationTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,6 +27,9 @@ class JobRunrInfrastructureIntegrationTest extends PostgresSpringIntegrationTest
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
     @Test
     void shouldProvidePlatformJobSchedulerBean() {
         assertThat(platformJobScheduler).isNotNull();
@@ -32,7 +37,9 @@ class JobRunrInfrastructureIntegrationTest extends PostgresSpringIntegrationTest
 
     @Test
     void shouldPersistEnqueuedJobsToPostgres() {
-        platformJobScheduler.enqueue(new ExampleJobRequest("01JOBJOBRUNR00000000000001"));
+        new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+            platformJobScheduler.enqueue(new ExampleJobRequest("01JOBJOBRUNR00000000000001"))
+        );
 
         final Integer jobCount = jdbcTemplate.queryForObject(
             "SELECT COUNT(id) FROM jobrunr.jobrunr_jobs",

--- a/app/src/test/java/com/kartoush/config/PlatformJobDispatcherTest.java
+++ b/app/src/test/java/com/kartoush/config/PlatformJobDispatcherTest.java
@@ -7,6 +7,8 @@ import com.kartoush.platform.jobs.JobRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.framework.ProxyFactory;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PlatformJobDispatcherTest {
@@ -15,7 +17,7 @@ class PlatformJobDispatcherTest {
     void shouldDeserializeRequestAndDispatchToMatchingHandler() throws Exception {
         final RecordingJobHandler jobHandler = new RecordingJobHandler();
         final PlatformJobDispatcher dispatcher =
-            new PlatformJobDispatcher(new ObjectMapper(), java.util.List.of(jobHandler));
+            new PlatformJobDispatcher(new ObjectMapper(), List.of(jobHandler));
         final ExampleJobRequest request = new ExampleJobRequest("01JOBJOBRUNR00000000000001");
 
         dispatcher.dispatch(
@@ -38,7 +40,7 @@ class PlatformJobDispatcherTest {
             (JobHandler<ExampleJobRequest>) proxyFactory.getProxy();
 
         final PlatformJobDispatcher dispatcher =
-            new PlatformJobDispatcher(new ObjectMapper(), java.util.List.of(proxiedHandler));
+            new PlatformJobDispatcher(new ObjectMapper(), List.of(proxiedHandler));
         final ExampleJobRequest request = new ExampleJobRequest("01JOBJOBRUNR00000000000001");
 
         dispatcher.dispatch(

--- a/app/src/test/java/com/kartoush/config/TransactionAwareBackgroundJobSchedulerTest.java
+++ b/app/src/test/java/com/kartoush/config/TransactionAwareBackgroundJobSchedulerTest.java
@@ -1,0 +1,131 @@
+package com.kartoush.config;
+
+import com.kartoush.config.jobs.TransactionAwareBackgroundJobScheduler;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
+import com.kartoush.platform.jobs.JobRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TransactionAwareBackgroundJobSchedulerTest {
+
+    private final RecordingBackgroundJobScheduler delegate = new RecordingBackgroundJobScheduler();
+
+    private final TransactionAwareBackgroundJobScheduler scheduler =
+        new TransactionAwareBackgroundJobScheduler(delegate);
+
+    @AfterEach
+    void tearDownTransactionState() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    @Test
+    void shouldEnqueueOnlyAfterCommit() {
+        beginTransaction();
+        final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000001");
+
+        scheduler.enqueue(request);
+
+        assertThat(delegate.enqueuedRequest).isNull();
+
+        triggerAfterCommit();
+
+        assertThat(delegate.enqueuedRequest).isEqualTo(request);
+    }
+
+    @Test
+    void shouldNotEnqueueWhenTransactionRollsBack() {
+        beginTransaction();
+
+        scheduler.enqueue(new ExampleJobRequest("01JAFTERCOMMIT0000000000002"));
+
+        triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+        assertThat(delegate.enqueuedRequest).isNull();
+    }
+
+    @Test
+    void shouldScheduleOnlyAfterCommit() {
+        beginTransaction();
+        final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000003");
+        final Instant scheduledAt = Instant.parse("2026-05-12T12:00:00Z");
+
+        scheduler.schedule(request, scheduledAt);
+
+        assertThat(delegate.scheduledRequest).isNull();
+        assertThat(delegate.scheduledAt).isNull();
+
+        triggerAfterCommit();
+
+        assertThat(delegate.scheduledRequest).isEqualTo(request);
+        assertThat(delegate.scheduledAt).isEqualTo(scheduledAt);
+    }
+
+    @Test
+    void shouldRejectSchedulingOutsideActiveTransaction() {
+        assertThatThrownBy(() -> scheduler.enqueue(new ExampleJobRequest("01JAFTERCOMMIT0000000000004")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Background jobs can only be scheduled inside an active transaction");
+    }
+
+    private void beginTransaction() {
+        TransactionSynchronizationManager.initSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+    }
+
+    private void triggerAfterCommit() {
+        final List<TransactionSynchronization> synchronizations =
+            TransactionSynchronizationManager.getSynchronizations();
+
+        for (final TransactionSynchronization synchronization : synchronizations) {
+            synchronization.afterCommit();
+        }
+
+        triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+    }
+
+    private void triggerAfterCompletion(final int status) {
+        final List<TransactionSynchronization> synchronizations =
+            TransactionSynchronizationManager.getSynchronizations();
+
+        for (final TransactionSynchronization synchronization : synchronizations) {
+            synchronization.afterCompletion(status);
+        }
+
+        TransactionSynchronizationManager.clearSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    record ExampleJobRequest(String customerId) implements JobRequest {
+    }
+
+    private static final class RecordingBackgroundJobScheduler implements BackgroundJobScheduler {
+
+        private JobRequest enqueuedRequest;
+
+        private JobRequest scheduledRequest;
+
+        private Instant scheduledAt;
+
+        @Override
+        public void enqueue(final JobRequest request) {
+            this.enqueuedRequest = request;
+        }
+
+        @Override
+        public void schedule(final JobRequest request, final Instant scheduledAt) {
+            this.scheduledRequest = request;
+            this.scheduledAt = scheduledAt;
+        }
+    }
+}

--- a/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
@@ -3,6 +3,8 @@ package com.kartoush.config.jobs;
 import com.kartoush.platform.jobs.JobRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -10,6 +12,8 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -19,8 +23,19 @@ class TransactionAwareBackgroundJobSchedulerTest {
 
     private final JobRunrPlatformJobScheduler delegate = mock(JobRunrPlatformJobScheduler.class);
 
+    private final TransactionOperations transactionOperations = mock(TransactionOperations.class);
+
     private final TransactionAwareBackgroundJobScheduler scheduler =
-        new TransactionAwareBackgroundJobScheduler(delegate);
+        new TransactionAwareBackgroundJobScheduler(delegate, transactionOperations);
+
+    TransactionAwareBackgroundJobSchedulerTest() {
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            final java.util.function.Consumer<TransactionStatus> action = invocation.getArgument(0);
+            action.accept(mock(TransactionStatus.class));
+            return null;
+        }).when(transactionOperations).executeWithoutResult(any());
+    }
 
     @AfterEach
     void tearDownTransactionState() {
@@ -49,6 +64,7 @@ class TransactionAwareBackgroundJobSchedulerTest {
 
         triggerAfterCommit();
 
+        verify(transactionOperations).executeWithoutResult(any());
         verify(delegate).enqueueSerialized(serializedJobRequest);
     }
 
@@ -91,6 +107,7 @@ class TransactionAwareBackgroundJobSchedulerTest {
 
         triggerAfterCommit();
 
+        verify(transactionOperations).executeWithoutResult(any());
         verify(delegate).scheduleSerialized(serializedJobRequest, scheduledAt);
     }
 
@@ -112,6 +129,26 @@ class TransactionAwareBackgroundJobSchedulerTest {
         triggerAfterCommit();
 
         verify(delegate).enqueueSerialized(serializedJobRequest);
+    }
+
+    @Test
+    void shouldNotPropagateSchedulingFailureAfterCommit() {
+        beginTransaction();
+        final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000005");
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
+            new JobRunrPlatformJobScheduler.SerializedJobRequest(
+                ExampleJobRequest.class.getName(),
+                "{\"customerId\":\"01JAFTERCOMMIT0000000000005\"}"
+            );
+
+        when(delegate.snapshot(request)).thenReturn(serializedJobRequest);
+        doAnswer(invocation -> {
+            throw new RuntimeException("boom");
+        }).when(delegate).enqueueSerialized(serializedJobRequest);
+
+        scheduler.enqueue(request);
+
+        triggerAfterCommit();
     }
 
     @Test

--- a/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
@@ -1,7 +1,5 @@
-package com.kartoush.config;
+package com.kartoush.config.jobs;
 
-import com.kartoush.config.jobs.TransactionAwareBackgroundJobScheduler;
-import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.jobs.JobRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -11,12 +9,15 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TransactionAwareBackgroundJobSchedulerTest {
 
-    private final RecordingBackgroundJobScheduler delegate = new RecordingBackgroundJobScheduler();
+    private final JobRunrPlatformJobScheduler delegate = mock(JobRunrPlatformJobScheduler.class);
 
     private final TransactionAwareBackgroundJobScheduler scheduler =
         new TransactionAwareBackgroundJobScheduler(delegate);
@@ -33,25 +34,41 @@ class TransactionAwareBackgroundJobSchedulerTest {
     void shouldEnqueueOnlyAfterCommit() {
         beginTransaction();
         final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000001");
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
+            new JobRunrPlatformJobScheduler.SerializedJobRequest(
+                ExampleJobRequest.class.getName(),
+                "{\"customerId\":\"01JAFTERCOMMIT0000000000001\"}"
+            );
+
+        when(delegate.snapshot(request)).thenReturn(serializedJobRequest);
 
         scheduler.enqueue(request);
 
-        assertThat(delegate.enqueuedRequest).isNull();
+        verify(delegate).snapshot(request);
+        verify(delegate, never()).enqueueSerialized(serializedJobRequest);
 
         triggerAfterCommit();
 
-        assertThat(delegate.enqueuedRequest).isEqualTo(request);
+        verify(delegate).enqueueSerialized(serializedJobRequest);
     }
 
     @Test
     void shouldNotEnqueueWhenTransactionRollsBack() {
         beginTransaction();
+        final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000002");
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
+            new JobRunrPlatformJobScheduler.SerializedJobRequest(
+                ExampleJobRequest.class.getName(),
+                "{\"customerId\":\"01JAFTERCOMMIT0000000000002\"}"
+            );
 
-        scheduler.enqueue(new ExampleJobRequest("01JAFTERCOMMIT0000000000002"));
+        when(delegate.snapshot(request)).thenReturn(serializedJobRequest);
+
+        scheduler.enqueue(request);
 
         triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
 
-        assertThat(delegate.enqueuedRequest).isNull();
+        verify(delegate, never()).enqueueSerialized(serializedJobRequest);
     }
 
     @Test
@@ -59,16 +76,42 @@ class TransactionAwareBackgroundJobSchedulerTest {
         beginTransaction();
         final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000003");
         final Instant scheduledAt = Instant.parse("2026-05-12T12:00:00Z");
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
+            new JobRunrPlatformJobScheduler.SerializedJobRequest(
+                ExampleJobRequest.class.getName(),
+                "{\"customerId\":\"01JAFTERCOMMIT0000000000003\"}"
+            );
+
+        when(delegate.snapshot(request)).thenReturn(serializedJobRequest);
 
         scheduler.schedule(request, scheduledAt);
 
-        assertThat(delegate.scheduledRequest).isNull();
-        assertThat(delegate.scheduledAt).isNull();
+        verify(delegate).snapshot(request);
+        verify(delegate, never()).scheduleSerialized(serializedJobRequest, scheduledAt);
 
         triggerAfterCommit();
 
-        assertThat(delegate.scheduledRequest).isEqualTo(request);
-        assertThat(delegate.scheduledAt).isEqualTo(scheduledAt);
+        verify(delegate).scheduleSerialized(serializedJobRequest, scheduledAt);
+    }
+
+    @Test
+    void shouldCaptureSerializedRequestBeforeCommit() {
+        beginTransaction();
+        final MutableExampleJobRequest request = new MutableExampleJobRequest("before-commit");
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
+            new JobRunrPlatformJobScheduler.SerializedJobRequest(
+                MutableExampleJobRequest.class.getName(),
+                "{\"customerId\":\"before-commit\"}"
+            );
+
+        when(delegate.snapshot(request)).thenReturn(serializedJobRequest);
+
+        scheduler.enqueue(request);
+        request.setCustomerId("after-commit");
+
+        triggerAfterCommit();
+
+        verify(delegate).enqueueSerialized(serializedJobRequest);
     }
 
     @Test
@@ -109,23 +152,20 @@ class TransactionAwareBackgroundJobSchedulerTest {
     record ExampleJobRequest(String customerId) implements JobRequest {
     }
 
-    private static final class RecordingBackgroundJobScheduler implements BackgroundJobScheduler {
+    private static final class MutableExampleJobRequest implements JobRequest {
 
-        private JobRequest enqueuedRequest;
+        private String customerId;
 
-        private JobRequest scheduledRequest;
-
-        private Instant scheduledAt;
-
-        @Override
-        public void enqueue(final JobRequest request) {
-            this.enqueuedRequest = request;
+        private MutableExampleJobRequest(final String customerId) {
+            this.customerId = customerId;
         }
 
-        @Override
-        public void schedule(final JobRequest request, final Instant scheduledAt) {
-            this.scheduledRequest = request;
-            this.scheduledAt = scheduledAt;
+        public String customerId() {
+            return customerId;
+        }
+
+        private void setCustomerId(final String customerId) {
+            this.customerId = customerId;
         }
     }
 }

--- a/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.time.Instant;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +32,7 @@ class TransactionAwareBackgroundJobSchedulerTest {
     TransactionAwareBackgroundJobSchedulerTest() {
         doAnswer(invocation -> {
             @SuppressWarnings("unchecked")
-            final java.util.function.Consumer<TransactionStatus> action = invocation.getArgument(0);
+            final Consumer<TransactionStatus> action = invocation.getArgument(0);
             action.accept(mock(TransactionStatus.class));
             return null;
         }).when(transactionOperations).executeWithoutResult(any());

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -79,9 +79,12 @@ That wrapper:
 
 - Registers enqueue and schedule operations only after a successful transaction
   commit
+- Executes the deferred scheduling work in its own transaction boundary
 - Rejects scheduling attempts outside an active transaction
 - Prevents later job scheduling flows from publishing background work before
   the underlying database changes are durable
+- Logs post-commit scheduling failures instead of surfacing them as if the
+  original database transaction failed
 
 ## Configuration Surface
 

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -25,7 +25,6 @@ At this stage, Kartoush provides:
 At this stage, Kartoush does not yet provide:
 
 - Activation email job scheduling
-- After-commit scheduling behavior
 - A broader recurring cleanup job implementation
 
 Those are follow-up tasks in the same epic.
@@ -70,6 +69,19 @@ The current profile behavior is:
 - `prod`
   - Background job server enabled by default
   - Dashboard disabled by default
+
+## After-Commit Scheduling
+
+Kartoush schedules background jobs through a transaction-aware app-side
+wrapper.
+
+That wrapper:
+
+- Registers enqueue and schedule operations only after a successful transaction
+  commit
+- Rejects scheduling attempts outside an active transaction
+- Prevents later job scheduling flows from publishing background work before
+  the underlying database changes are durable
 
 ## Configuration Surface
 


### PR DESCRIPTION
## Summary
- Add a transaction-aware background job scheduler wrapper in `app`
- Register enqueue and schedule operations only after a successful transaction commit
- Snapshot deferred job payloads before commit and document the scheduling behavior

## Scope
- Add `TransactionAwareBackgroundJobScheduler`
- Wrap the existing JobRunr-backed scheduler in `BackgroundJobConfiguration`
- Snapshot serialized job payloads before registering after-commit callbacks
- Add focused tests for commit, rollback, snapshot, and no-transaction behavior
- Update the JobRunr integration test for the new transaction-aware scheduler contract
- Update the JobRunr configuration doc with the new scheduling behavior

## Testing
- `./gradlew :app:test --tests com.kartoush.config.BackgroundJobConfigurationTest --tests com.kartoush.config.jobs.TransactionAwareBackgroundJobSchedulerTest --tests com.kartoush.config.PlatformJobDispatcherTest`
- `./gradlew :app:integrationTest --tests com.kartoush.config.JobRunrInfrastructureIntegrationTest`

Closes #296
