### PR TITLE
Add durable activation email job

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,8 @@ ij_java_class_brace_style = end_of_line
 ij_java_method_brace_style = end_of_line
 ij_java_block_brace_style = end_of_line
 ij_java_lambda_brace_style = end_of_line
+ij_java_catch_on_new_line = true
+ij_java_finally_on_new_line = true
 
 ij_java_keep_simple_methods_in_one_line = false
 ij_java_keep_simple_classes_in_one_line = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,8 +19,6 @@ ij_java_class_brace_style = end_of_line
 ij_java_method_brace_style = end_of_line
 ij_java_block_brace_style = end_of_line
 ij_java_lambda_brace_style = end_of_line
-ij_java_catch_on_new_line = true
-ij_java_finally_on_new_line = true
 
 ij_java_keep_simple_methods_in_one_line = false
 ij_java_keep_simple_classes_in_one_line = false

--- a/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
@@ -12,7 +12,6 @@ import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.customer.CustomerEmailFactory;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.platform.jobs.JobHandler;
-import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,10 +71,9 @@ public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobR
 
         try {
             activationTokenService.validate(pendingCustomer.getId(), rawToken);
-        }
-        catch (final ActivationTokenNotFoundException
-            | ActivationTokenConsumedException
-            | ActivationTokenExpiredException exception) {
+        } catch (final ActivationTokenNotFoundException
+                       | ActivationTokenConsumedException
+                       | ActivationTokenExpiredException exception) {
             LOG.info(
                 "Skipping activation email job because token for customer {} is no longer valid",
                 request.customerId()

--- a/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
@@ -1,7 +1,6 @@
 package com.kartoush.config.jobs;
 
-import com.kartoush.customer.domain.Customer;
-import com.kartoush.customer.exception.CustomerNotFoundException;
+import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.customer.CustomerEmailFactory;
@@ -30,14 +29,13 @@ public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobR
 
     @Override
     public void handle(final ActivationEmailJobRequest request) {
-        final Customer customer = customerService.getCustomerById(request.customerId())
-            .orElseThrow(() -> new CustomerNotFoundException(request.customerId()));
+        final ActivationEmailDelivery activationEmail = customerService.issueActivationEmail(request.customerId());
 
         emailDeliveryService.send(
             customerEmailFactory.newActivationEmail(
-                customer.getEmail(),
-                CustomerId.of(request.customerId()),
-                request.rawToken()
+                activationEmail.email(),
+                activationEmail.customerId(),
+                activationEmail.rawToken()
             )
         );
     }

--- a/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
@@ -1,6 +1,10 @@
 package com.kartoush.config.jobs;
 
 import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.exception.ActivationTokenConsumedException;
+import com.kartoush.customer.exception.ActivationTokenExpiredException;
+import com.kartoush.customer.exception.ActivationTokenNotFoundException;
+import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.CustomerService;
@@ -8,6 +12,7 @@ import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.customer.CustomerEmailFactory;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +27,8 @@ public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobR
 
     private final CustomerService customerService;
 
+    private final ActivationTokenService activationTokenService;
+
     private final ActivationEmailJobCipher activationEmailJobCipher;
 
     private final CustomerEmailFactory customerEmailFactory;
@@ -30,10 +37,12 @@ public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobR
 
     public ActivationEmailJobHandler(
         final CustomerService customerService,
+        final ActivationTokenService activationTokenService,
         final ActivationEmailJobCipher activationEmailJobCipher,
         final CustomerEmailFactory customerEmailFactory,
         final EmailDeliveryService emailDeliveryService) {
         this.customerService = customerService;
+        this.activationTokenService = activationTokenService;
         this.activationEmailJobCipher = activationEmailJobCipher;
         this.customerEmailFactory = customerEmailFactory;
         this.emailDeliveryService = emailDeliveryService;
@@ -59,10 +68,25 @@ public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobR
             return;
         }
 
+        final String rawToken = activationEmailJobCipher.decrypt(request.encryptedToken());
+
+        try {
+            activationTokenService.validate(pendingCustomer.getId(), rawToken);
+        }
+        catch (final ActivationTokenNotFoundException
+            | ActivationTokenConsumedException
+            | ActivationTokenExpiredException exception) {
+            LOG.info(
+                "Skipping activation email job because token for customer {} is no longer valid",
+                request.customerId()
+            );
+            return;
+        }
+
         final ActivationEmailDelivery activationEmail = new ActivationEmailDelivery(
             pendingCustomer.getId(),
             pendingCustomer.getEmail(),
-            activationEmailJobCipher.decrypt(request.encryptedRawToken())
+            rawToken
         );
 
         emailDeliveryService.send(

--- a/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
@@ -1,17 +1,28 @@
 package com.kartoush.config.jobs;
 
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.customer.CustomerEmailFactory;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.types.CustomerStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobRequest> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ActivationEmailJobHandler.class);
+
     private final CustomerService customerService;
+
+    private final ActivationEmailJobCipher activationEmailJobCipher;
 
     private final CustomerEmailFactory customerEmailFactory;
 
@@ -19,16 +30,40 @@ public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobR
 
     public ActivationEmailJobHandler(
         final CustomerService customerService,
+        final ActivationEmailJobCipher activationEmailJobCipher,
         final CustomerEmailFactory customerEmailFactory,
         final EmailDeliveryService emailDeliveryService) {
         this.customerService = customerService;
+        this.activationEmailJobCipher = activationEmailJobCipher;
         this.customerEmailFactory = customerEmailFactory;
         this.emailDeliveryService = emailDeliveryService;
     }
 
     @Override
     public void handle(final ActivationEmailJobRequest request) {
-        final ActivationEmailDelivery activationEmail = customerService.issueActivationEmail(request.customerId());
+        final Optional<Customer> customer = customerService.getCustomerById(request.customerId());
+
+        if (customer.isEmpty()) {
+            LOG.info("Skipping activation email job because customer {} no longer exists", request.customerId());
+            return;
+        }
+
+        final Customer pendingCustomer = customer.orElseThrow();
+
+        if (pendingCustomer.getStatus() != CustomerStatus.PENDING) {
+            LOG.info(
+                "Skipping activation email job because customer {} is now in {} status",
+                request.customerId(),
+                pendingCustomer.getStatus()
+            );
+            return;
+        }
+
+        final ActivationEmailDelivery activationEmail = new ActivationEmailDelivery(
+            pendingCustomer.getId(),
+            pendingCustomer.getEmail(),
+            activationEmailJobCipher.decrypt(request.encryptedRawToken())
+        );
 
         emailDeliveryService.send(
             customerEmailFactory.newActivationEmail(

--- a/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
@@ -1,0 +1,44 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.exception.CustomerNotFoundException;
+import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.notification.email.customer.CustomerEmailFactory;
+import com.kartoush.notification.email.delivery.EmailDeliveryService;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.types.CustomerId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ActivationEmailJobHandler implements JobHandler<ActivationEmailJobRequest> {
+
+    private final CustomerService customerService;
+
+    private final CustomerEmailFactory customerEmailFactory;
+
+    private final EmailDeliveryService emailDeliveryService;
+
+    public ActivationEmailJobHandler(
+        final CustomerService customerService,
+        final CustomerEmailFactory customerEmailFactory,
+        final EmailDeliveryService emailDeliveryService) {
+        this.customerService = customerService;
+        this.customerEmailFactory = customerEmailFactory;
+        this.emailDeliveryService = emailDeliveryService;
+    }
+
+    @Override
+    public void handle(final ActivationEmailJobRequest request) {
+        final Customer customer = customerService.getCustomerById(request.customerId())
+            .orElseThrow(() -> new CustomerNotFoundException(request.customerId()));
+
+        emailDeliveryService.send(
+            customerEmailFactory.newActivationEmail(
+                customer.getEmail(),
+                CustomerId.of(request.customerId()),
+                request.rawToken()
+            )
+        );
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/ActivationEmailJobHandler.java
@@ -6,7 +6,6 @@ import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.customer.CustomerEmailFactory;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.platform.jobs.JobHandler;
-import com.kartoush.platform.types.CustomerId;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobScheduler.java
@@ -2,8 +2,6 @@ package com.kartoush.config.jobs;
 
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.jobs.JobRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -11,8 +9,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant;
 
 public class TransactionAwareBackgroundJobScheduler implements BackgroundJobScheduler {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TransactionAwareBackgroundJobScheduler.class);
 
     private final JobRunrPlatformJobScheduler delegate;
 
@@ -43,11 +39,7 @@ public class TransactionAwareBackgroundJobScheduler implements BackgroundJobSche
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                try {
-                    transactionOperations.executeWithoutResult(status -> action.run());
-                } catch (final RuntimeException ex) {
-                    LOG.error("Background job scheduling failed after the original transaction committed", ex);
-                }
+                transactionOperations.executeWithoutResult(status -> action.run());
             }
         });
     }

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -10,6 +10,9 @@ jobrunr:
     enabled: ${KARTOUSH_JOBRUNR_DASHBOARD_ENABLED:false}
 
 kartoush:
+  jobs:
+    activation-email:
+      encryption-key: ${KARTOUSH_JOBS_ACTIVATION_EMAIL_ENCRYPTION_KEY:}
   email:
     delivery:
       provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:brevo}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -35,6 +35,9 @@ logging:
     root: info
 
 kartoush:
+  jobs:
+    activation-email:
+      encryption-key: ${KARTOUSH_JOBS_ACTIVATION_EMAIL_ENCRYPTION_KEY:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=}
   email:
     customer:
       sender-name: ${KARTOUSH_EMAIL_SENDER_NAME:Kartoush}

--- a/app/src/test/java/com/kartoush/api/auth/CustomerPasswordResetFlowIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/auth/CustomerPasswordResetFlowIntegrationTest.java
@@ -2,6 +2,7 @@ package com.kartoush.api.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.config.jobs.ActivationEmailJobHandler;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.notification.email.EmailMessageType;
@@ -12,6 +13,8 @@ import com.kartoush.api.error.ErrorCode;
 import com.kartoush.customer.facade.model.CreateCustomerInput;
 import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
 import com.kartoush.auth.service.PasswordResetTokenHasher;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
 import com.kartoush.platform.ulid.UlidGenerator;
@@ -77,6 +80,12 @@ class CustomerPasswordResetFlowIntegrationTest extends PostgresSpringIntegration
     @Autowired
     private UlidGenerator ulidGenerator;
 
+    @Autowired
+    private ActivationEmailJobHandler activationEmailJobHandler;
+
+    @MockitoBean
+    private BackgroundJobScheduler backgroundJobScheduler;
+
     @MockitoBean
     private EmailDeliveryService emailDeliveryService;
 
@@ -91,7 +100,15 @@ class CustomerPasswordResetFlowIntegrationTest extends PostgresSpringIntegration
 
         capturedActivationEmails.clear();
         capturedPasswordResetEmails.clear();
+        reset(backgroundJobScheduler);
         reset(emailDeliveryService);
+
+        doAnswer(invocation -> {
+            final ActivationEmailJobRequest request =
+                invocation.getArgument(0, ActivationEmailJobRequest.class);
+            activationEmailJobHandler.handle(request);
+            return null;
+        }).when(backgroundJobScheduler).enqueue(any(ActivationEmailJobRequest.class));
 
         doAnswer(invocation -> {
             final EmailMessage email = invocation.getArgument(0, EmailMessage.class);

--- a/app/src/test/java/com/kartoush/api/auth/CustomerSignInFlowIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/auth/CustomerSignInFlowIntegrationTest.java
@@ -2,6 +2,7 @@ package com.kartoush.api.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.config.jobs.ActivationEmailJobHandler;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.notification.email.EmailMessageType;
@@ -9,6 +10,8 @@ import com.kartoush.auth.persistence.repository.CustomerAuthSessionRepository;
 import com.kartoush.api.error.ErrorCode;
 import com.kartoush.customer.facade.model.CreateCustomerInput;
 import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
 import com.kartoush.platform.ulid.UlidGenerator;
@@ -63,6 +66,12 @@ class CustomerSignInFlowIntegrationTest extends PostgresSpringIntegrationTest {
     @Autowired
     private UlidGenerator ulidGenerator;
 
+    @Autowired
+    private ActivationEmailJobHandler activationEmailJobHandler;
+
+    @MockitoBean
+    private BackgroundJobScheduler backgroundJobScheduler;
+
     @MockitoBean
     private EmailDeliveryService emailDeliveryService;
 
@@ -74,7 +83,14 @@ class CustomerSignInFlowIntegrationTest extends PostgresSpringIntegrationTest {
         customerAuthSessionRepository.deleteAll();
 
         capturedActivationEmails.clear();
+        reset(backgroundJobScheduler);
         reset(emailDeliveryService);
+        doAnswer(invocation -> {
+            final ActivationEmailJobRequest request =
+                invocation.getArgument(0, ActivationEmailJobRequest.class);
+            activationEmailJobHandler.handle(request);
+            return null;
+        }).when(backgroundJobScheduler).enqueue(any(ActivationEmailJobRequest.class));
         doAnswer(invocation -> {
             final EmailMessage email = invocation.getArgument(0, EmailMessage.class);
             if (email.type() == EmailMessageType.CUSTOMER_ACTIVATION) {

--- a/app/src/test/java/com/kartoush/api/customer/AbstractCustomerApiIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/AbstractCustomerApiIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.kartoush.api.customer;
 
+import com.kartoush.config.jobs.ActivationEmailJobHandler;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.notification.email.EmailMessageType;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.Email;
 import com.kartoush.platform.ulid.UlidGenerator;
 import com.kartoush.testsupport.HttpSpringIntegrationTest;
@@ -25,7 +28,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
 
 @HttpSpringIntegrationTest
-abstract class AbstractCustomerRestAssuredIntegrationTest extends PostgresRestAssuredIntegrationTest {
+abstract class AbstractCustomerApiIntegrationTest extends PostgresRestAssuredIntegrationTest {
 
     protected static final String BASE_URL = "/api/customers";
     protected static final String ACTIVATION_PATH = "/{customerId}/activation";
@@ -38,6 +41,12 @@ abstract class AbstractCustomerRestAssuredIntegrationTest extends PostgresRestAs
     @Autowired
     protected UlidGenerator ulidGenerator;
 
+    @Autowired
+    private ActivationEmailJobHandler activationEmailJobHandler;
+
+    @MockitoBean
+    private BackgroundJobScheduler backgroundJobScheduler;
+
     @MockitoBean
     private EmailDeliveryService emailDeliveryService;
 
@@ -46,7 +55,14 @@ abstract class AbstractCustomerRestAssuredIntegrationTest extends PostgresRestAs
     @BeforeEach
     void setUpActivationEmailCapture() {
         capturedActivationEmails.clear();
+        reset(backgroundJobScheduler);
         reset(emailDeliveryService);
+        doAnswer(invocation -> {
+            final ActivationEmailJobRequest request =
+                invocation.getArgument(0, ActivationEmailJobRequest.class);
+            activationEmailJobHandler.handle(request);
+            return null;
+        }).when(backgroundJobScheduler).enqueue(any(ActivationEmailJobRequest.class));
         doAnswer(invocation -> {
             final EmailMessage email = invocation.getArgument(0, EmailMessage.class);
             if (email.type() == EmailMessageType.CUSTOMER_ACTIVATION) {

--- a/app/src/test/java/com/kartoush/api/customer/ActivationAndPasswordSetupIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/ActivationAndPasswordSetupIntegrationTest.java
@@ -2,6 +2,7 @@ package com.kartoush.api.customer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.config.jobs.ActivationEmailJobHandler;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.notification.email.EmailMessageType;
@@ -17,6 +18,8 @@ import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
 import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.customer.service.ActivationTokenHasher;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.ActivationTokenId;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
@@ -53,7 +56,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringIntegrationTest
 @AutoConfigureMockMvc
-class CustomerActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegrationTest {
+class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegrationTest {
 
     private static final String BASE_URL = "/api/customers";
     private static final String ACTIVATION_PATH = "/{customerId}/activation";
@@ -89,6 +92,12 @@ class CustomerActivationAndPasswordSetupIntegrationTest extends PostgresSpringIn
     @Autowired
     private UlidGenerator ulidGenerator;
 
+    @Autowired
+    private ActivationEmailJobHandler activationEmailJobHandler;
+
+    @MockitoBean
+    private BackgroundJobScheduler backgroundJobScheduler;
+
     @MockitoBean
     private EmailDeliveryService emailDeliveryService;
 
@@ -102,7 +111,14 @@ class CustomerActivationAndPasswordSetupIntegrationTest extends PostgresSpringIn
         customerRepository.deleteAll();
 
         capturedActivationEmails.clear();
+        reset(backgroundJobScheduler);
         reset(emailDeliveryService);
+        doAnswer(invocation -> {
+            final ActivationEmailJobRequest request =
+                invocation.getArgument(0, ActivationEmailJobRequest.class);
+            activationEmailJobHandler.handle(request);
+            return null;
+        }).when(backgroundJobScheduler).enqueue(any(ActivationEmailJobRequest.class));
         doAnswer(invocation -> {
             final EmailMessage email = invocation.getArgument(0, EmailMessage.class);
             if (email.type() == EmailMessageType.CUSTOMER_ACTIVATION) {

--- a/app/src/test/java/com/kartoush/api/customer/ActivationEmailJobSchedulingIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/ActivationEmailJobSchedulingIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.kartoush.api.customer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.customer.facade.model.CreateCustomerInput;
+import com.kartoush.platform.types.CustomerStatus;
+import com.kartoush.platform.ulid.UlidGenerator;
+import com.kartoush.testsupport.PostgresSpringIntegrationTest;
+import com.kartoush.testsupport.SpringIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringIntegrationTest
+@AutoConfigureMockMvc
+class ActivationEmailJobSchedulingIntegrationTest extends PostgresSpringIntegrationTest {
+
+    private static final String CUSTOMERS_PATH = "/api/customers";
+    private static final String FIRST_NAME = "Jack";
+    private static final String LAST_NAME = "Kartoush";
+    private static final String PHONE_NUMBER = "+13125550100";
+    private static final String EMAIL_LOCAL_PART_PREFIX = "jack+";
+    private static final String EMAIL_DOMAIN = "@kartoush.com";
+    private static final String CURRENT_TERMS_VERSION = "2026.04.01";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UlidGenerator ulidGenerator;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldPersistActivationEmailJobAfterCustomerRegistration() throws Exception {
+        final Integer jobCountBefore = jdbcTemplate.queryForObject(
+            "SELECT COUNT(id) FROM jobrunr.jobrunr_jobs",
+            Integer.class
+        );
+
+        final CreateCustomerInput request = new CreateCustomerInput(
+            FIRST_NAME,
+            LAST_NAME,
+            EMAIL_LOCAL_PART_PREFIX + ulidGenerator.next().toLowerCase() + EMAIL_DOMAIN,
+            PHONE_NUMBER,
+            true,
+            CURRENT_TERMS_VERSION
+        );
+
+        mockMvc.perform(post(CUSTOMERS_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.status").value(CustomerStatus.PENDING.name()));
+
+        final Integer jobCountAfter = jdbcTemplate.queryForObject(
+            "SELECT COUNT(id) FROM jobrunr.jobrunr_jobs",
+            Integer.class
+        );
+
+        assertThat(jobCountBefore).isNotNull();
+        assertThat(jobCountAfter).isNotNull();
+        assertThat(jobCountAfter).isEqualTo(jobCountBefore + 1);
+    }
+}

--- a/app/src/test/java/com/kartoush/api/customer/CustomerCreationRestAssuredIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerCreationRestAssuredIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
-class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerRestAssuredIntegrationTest {
+class CustomerCreationRestAssuredIntegrationTest extends AbstractCustomerApiIntegrationTest {
 
     private static final String INVALID_EMAIL = "not-an-email";
     private static final String CURRENT_TERMS_VERSION = "2026.04.01";

--- a/app/src/test/java/com/kartoush/api/customer/CustomerDuplicateEmailRestAssuredIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/CustomerDuplicateEmailRestAssuredIntegrationTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-class CustomerDuplicateEmailRestAssuredIntegrationTest extends AbstractCustomerRestAssuredIntegrationTest {
+class CustomerDuplicateEmailRestAssuredIntegrationTest extends AbstractCustomerApiIntegrationTest {
 
     private static final String CURRENT_TERMS_VERSION = "2026.04.01";
 

--- a/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
@@ -1,0 +1,70 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.domain.CustomerProfile;
+import com.kartoush.customer.exception.CustomerNotFoundException;
+import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.notification.email.EmailMessage;
+import com.kartoush.notification.email.customer.CustomerEmailFactory;
+import com.kartoush.notification.email.delivery.EmailDeliveryService;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.types.Email;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ActivationEmailJobHandlerTest {
+
+    private static final String CUSTOMER_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    private static final String RAW_TOKEN = "activation-token";
+    private static final Email EMAIL = new Email("jack@kartoush.com");
+
+    private final CustomerService customerService = mock(CustomerService.class);
+
+    private final CustomerEmailFactory customerEmailFactory = mock(CustomerEmailFactory.class);
+
+    private final EmailDeliveryService emailDeliveryService = mock(EmailDeliveryService.class);
+
+    private final ActivationEmailJobHandler handler =
+        new ActivationEmailJobHandler(customerService, customerEmailFactory, emailDeliveryService);
+
+    @Test
+    void shouldReloadCustomerAndSendActivationEmail() {
+        final ActivationEmailJobRequest request =
+            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN);
+        final Customer customer = Customer.createNew(
+            CustomerId.of(CUSTOMER_ID),
+            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
+            EMAIL
+        );
+        final EmailMessage emailMessage = mock(EmailMessage.class);
+
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
+        when(customerEmailFactory.newActivationEmail(EMAIL, CustomerId.of(CUSTOMER_ID), RAW_TOKEN))
+            .thenReturn(emailMessage);
+
+        handler.handle(request);
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(customerEmailFactory).newActivationEmail(EMAIL, CustomerId.of(CUSTOMER_ID), RAW_TOKEN);
+        verify(emailDeliveryService).send(emailMessage);
+    }
+
+    @Test
+    void shouldFailWhenCustomerCannotBeReloaded() {
+        final ActivationEmailJobRequest request =
+            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN);
+
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(request))
+            .isInstanceOf(CustomerNotFoundException.class)
+            .hasMessage("Customer not found for id: " + CUSTOMER_ID);
+    }
+}

--- a/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
@@ -1,8 +1,9 @@
 package com.kartoush.config.jobs;
 
-import com.kartoush.customer.service.ActivationEmailDelivery;
-import com.kartoush.customer.exception.CustomerNotFoundException;
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.domain.CustomerProfile;
 import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.notification.email.customer.CustomerEmailFactory;
@@ -11,8 +12,11 @@ import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.Email;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,48 +28,80 @@ class ActivationEmailJobHandlerTest {
 
     private final CustomerService customerService = mock(CustomerService.class);
 
+    private final ActivationEmailJobCipher activationEmailJobCipher = mock(ActivationEmailJobCipher.class);
+
     private final CustomerEmailFactory customerEmailFactory = mock(CustomerEmailFactory.class);
 
     private final EmailDeliveryService emailDeliveryService = mock(EmailDeliveryService.class);
 
     private final ActivationEmailJobHandler handler =
-        new ActivationEmailJobHandler(customerService, customerEmailFactory, emailDeliveryService);
+        new ActivationEmailJobHandler(
+            customerService,
+            activationEmailJobCipher,
+            customerEmailFactory,
+            emailDeliveryService
+        );
 
     @Test
     void shouldIssueActivationEmailAndSendIt() {
-        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID);
-        final ActivationEmailDelivery activationEmail =
-            new ActivationEmailDelivery(CustomerId.of(CUSTOMER_ID), EMAIL, RAW_TOKEN);
+        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID, "encrypted-token");
+        final Customer customer = Customer.createNew(
+            CustomerId.of(CUSTOMER_ID),
+            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
+            EMAIL
+        );
         final EmailMessage emailMessage = mock(EmailMessage.class);
 
-        when(customerService.issueActivationEmail(CUSTOMER_ID)).thenReturn(activationEmail);
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
+        when(activationEmailJobCipher.decrypt("encrypted-token")).thenReturn(RAW_TOKEN);
         when(customerEmailFactory.newActivationEmail(
-            activationEmail.email(),
-            activationEmail.customerId(),
-            activationEmail.rawToken()
+            EMAIL,
+            CustomerId.of(CUSTOMER_ID),
+            RAW_TOKEN
         ))
             .thenReturn(emailMessage);
 
         handler.handle(request);
 
-        verify(customerService).issueActivationEmail(CUSTOMER_ID);
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(activationEmailJobCipher).decrypt("encrypted-token");
         verify(customerEmailFactory).newActivationEmail(
-            activationEmail.email(),
-            activationEmail.customerId(),
-            activationEmail.rawToken()
+            EMAIL,
+            CustomerId.of(CUSTOMER_ID),
+            RAW_TOKEN
         );
         verify(emailDeliveryService).send(emailMessage);
     }
 
     @Test
-    void shouldFailWhenActivationEmailCannotBeIssued() {
-        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID);
+    void shouldSkipWhenCustomerCannotBeReloaded() {
+        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID, "encrypted-token");
 
-        when(customerService.issueActivationEmail(CUSTOMER_ID))
-            .thenThrow(new CustomerNotFoundException(CUSTOMER_ID));
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> handler.handle(request))
-            .isInstanceOf(CustomerNotFoundException.class)
-            .hasMessage("Customer not found for id: " + CUSTOMER_ID);
+        handler.handle(request);
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(activationEmailJobCipher, never()).decrypt("encrypted-token");
+        verify(emailDeliveryService, never()).send(any());
+    }
+
+    @Test
+    void shouldSkipWhenCustomerIsNoLongerPending() {
+        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID, "encrypted-token");
+        final Customer customer = Customer.createNew(
+            CustomerId.of(CUSTOMER_ID),
+            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
+            EMAIL
+        );
+        customer.activate();
+
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
+
+        handler.handle(request);
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(activationEmailJobCipher, never()).decrypt("encrypted-token");
+        verify(emailDeliveryService, never()).send(any());
     }
 }

--- a/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
@@ -1,7 +1,6 @@
 package com.kartoush.config.jobs;
 
-import com.kartoush.customer.domain.Customer;
-import com.kartoush.customer.domain.CustomerProfile;
+import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.exception.CustomerNotFoundException;
 import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
@@ -11,8 +10,6 @@ import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.Email;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -35,33 +32,37 @@ class ActivationEmailJobHandlerTest {
         new ActivationEmailJobHandler(customerService, customerEmailFactory, emailDeliveryService);
 
     @Test
-    void shouldReloadCustomerAndSendActivationEmail() {
-        final ActivationEmailJobRequest request =
-            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN);
-        final Customer customer = Customer.createNew(
-            CustomerId.of(CUSTOMER_ID),
-            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
-            EMAIL
-        );
+    void shouldIssueActivationEmailAndSendIt() {
+        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID);
+        final ActivationEmailDelivery activationEmail =
+            new ActivationEmailDelivery(CustomerId.of(CUSTOMER_ID), EMAIL, RAW_TOKEN);
         final EmailMessage emailMessage = mock(EmailMessage.class);
 
-        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
-        when(customerEmailFactory.newActivationEmail(EMAIL, CustomerId.of(CUSTOMER_ID), RAW_TOKEN))
+        when(customerService.issueActivationEmail(CUSTOMER_ID)).thenReturn(activationEmail);
+        when(customerEmailFactory.newActivationEmail(
+            activationEmail.email(),
+            activationEmail.customerId(),
+            activationEmail.rawToken()
+        ))
             .thenReturn(emailMessage);
 
         handler.handle(request);
 
-        verify(customerService).getCustomerById(CUSTOMER_ID);
-        verify(customerEmailFactory).newActivationEmail(EMAIL, CustomerId.of(CUSTOMER_ID), RAW_TOKEN);
+        verify(customerService).issueActivationEmail(CUSTOMER_ID);
+        verify(customerEmailFactory).newActivationEmail(
+            activationEmail.email(),
+            activationEmail.customerId(),
+            activationEmail.rawToken()
+        );
         verify(emailDeliveryService).send(emailMessage);
     }
 
     @Test
-    void shouldFailWhenCustomerCannotBeReloaded() {
-        final ActivationEmailJobRequest request =
-            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN);
+    void shouldFailWhenActivationEmailCannotBeIssued() {
+        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID);
 
-        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
+        when(customerService.issueActivationEmail(CUSTOMER_ID))
+            .thenThrow(new CustomerNotFoundException(CUSTOMER_ID));
 
         assertThatThrownBy(() -> handler.handle(request))
             .isInstanceOf(CustomerNotFoundException.class)

--- a/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/ActivationEmailJobHandlerTest.java
@@ -2,6 +2,8 @@ package com.kartoush.config.jobs;
 
 import com.kartoush.customer.domain.Customer;
 import com.kartoush.customer.domain.CustomerProfile;
+import com.kartoush.customer.exception.ActivationTokenConsumedException;
+import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
@@ -28,6 +30,8 @@ class ActivationEmailJobHandlerTest {
 
     private final CustomerService customerService = mock(CustomerService.class);
 
+    private final ActivationTokenService activationTokenService = mock(ActivationTokenService.class);
+
     private final ActivationEmailJobCipher activationEmailJobCipher = mock(ActivationEmailJobCipher.class);
 
     private final CustomerEmailFactory customerEmailFactory = mock(CustomerEmailFactory.class);
@@ -37,6 +41,7 @@ class ActivationEmailJobHandlerTest {
     private final ActivationEmailJobHandler handler =
         new ActivationEmailJobHandler(
             customerService,
+            activationTokenService,
             activationEmailJobCipher,
             customerEmailFactory,
             emailDeliveryService
@@ -65,6 +70,7 @@ class ActivationEmailJobHandlerTest {
 
         verify(customerService).getCustomerById(CUSTOMER_ID);
         verify(activationEmailJobCipher).decrypt("encrypted-token");
+        verify(activationTokenService).validate(CustomerId.of(CUSTOMER_ID), RAW_TOKEN);
         verify(customerEmailFactory).newActivationEmail(
             EMAIL,
             CustomerId.of(CUSTOMER_ID),
@@ -102,6 +108,28 @@ class ActivationEmailJobHandlerTest {
 
         verify(customerService).getCustomerById(CUSTOMER_ID);
         verify(activationEmailJobCipher, never()).decrypt("encrypted-token");
+        verify(emailDeliveryService, never()).send(any());
+    }
+
+    @Test
+    void shouldSkipWhenQueuedTokenIsNoLongerValid() {
+        final ActivationEmailJobRequest request = new ActivationEmailJobRequest(CUSTOMER_ID, "encrypted-token");
+        final Customer customer = Customer.createNew(
+            CustomerId.of(CUSTOMER_ID),
+            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
+            EMAIL
+        );
+
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
+        when(activationEmailJobCipher.decrypt("encrypted-token")).thenReturn(RAW_TOKEN);
+        when(activationTokenService.validate(CustomerId.of(CUSTOMER_ID), RAW_TOKEN))
+            .thenThrow(new ActivationTokenConsumedException(CUSTOMER_ID));
+
+        handler.handle(request);
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(activationEmailJobCipher).decrypt("encrypted-token");
+        verify(activationTokenService).validate(CustomerId.of(CUSTOMER_ID), RAW_TOKEN);
         verify(emailDeliveryService, never()).send(any());
     }
 }

--- a/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/TransactionAwareBackgroundJobSchedulerTest.java
@@ -133,7 +133,7 @@ class TransactionAwareBackgroundJobSchedulerTest {
     }
 
     @Test
-    void shouldNotPropagateSchedulingFailureAfterCommit() {
+    void shouldPropagateSchedulingFailureAfterCommit() {
         beginTransaction();
         final ExampleJobRequest request = new ExampleJobRequest("01JAFTERCOMMIT0000000000005");
         final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
@@ -149,7 +149,9 @@ class TransactionAwareBackgroundJobSchedulerTest {
 
         scheduler.enqueue(request);
 
-        triggerAfterCommit();
+        assertThatThrownBy(this::triggerAfterCommit)
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("boom");
     }
 
     @Test

--- a/customer/build.gradle
+++ b/customer/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation project(':auth')
     implementation project(':notification')
+    implementation project(':platform:platform-jobs')
     implementation project(':platform:platform-types')
     implementation project(':platform:platform-validation')
     testImplementation project(":test-support")

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -15,7 +15,11 @@ import com.kartoush.customer.facade.model.UpdateCustomerInput;
 import com.kartoush.customer.internal.validation.CustomerPasswordSetupValidator;
 import com.kartoush.customer.internal.validation.CustomerRegistrationValidator;
 import com.kartoush.customer.internal.validation.CustomerUpdateValidator;
+import com.kartoush.customer.service.ActivationEmailDelivery;
+import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.IssuedActivationToken;
+import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
@@ -32,6 +36,8 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     private final CustomerService customerService;
 
+    private final ActivationTokenService activationTokenService;
+
     private final CustomerPasswordFacade customerPasswordFacade;
 
     private final BackgroundJobScheduler backgroundJobScheduler;
@@ -44,22 +50,28 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     private final CustomerRegistrationValidator customerRegistrationValidator;
 
+    private final ActivationEmailJobCipher activationEmailJobCipher;
+
     public DefaultCustomerFacade(
         final CustomerService customerService,
+        final ActivationTokenService activationTokenService,
         final CustomerPasswordFacade customerPasswordFacade,
         final BackgroundJobScheduler backgroundJobScheduler,
         final UlidGenerator ulidGenerator,
         final CustomerPasswordSetupValidator customerPasswordSetupValidator,
         final CustomerUpdateValidator customerUpdateValidator,
-        final CustomerRegistrationValidator customerRegistrationValidator
+        final CustomerRegistrationValidator customerRegistrationValidator,
+        final ActivationEmailJobCipher activationEmailJobCipher
     ) {
         this.customerService = customerService;
+        this.activationTokenService = activationTokenService;
         this.customerPasswordFacade = customerPasswordFacade;
         this.backgroundJobScheduler = backgroundJobScheduler;
         this.ulidGenerator = ulidGenerator;
         this.customerPasswordSetupValidator = customerPasswordSetupValidator;
         this.customerUpdateValidator = customerUpdateValidator;
         this.customerRegistrationValidator = customerRegistrationValidator;
+        this.activationEmailJobCipher = activationEmailJobCipher;
     }
 
     @Override
@@ -84,7 +96,11 @@ public class DefaultCustomerFacade implements CustomerFacade {
             new Email(input.email()));
 
         final Customer savedCustomer = customerService.registerCustomer(customer, input.termsVersion());
-        backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(savedCustomer.getId().value()));
+        final IssuedActivationToken issuedActivationToken = activationTokenService.createFor(savedCustomer.getId());
+        backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(
+            savedCustomer.getId().value(),
+            activationEmailJobCipher.encrypt(issuedActivationToken.rawToken())
+        ));
 
         return toCustomerView(savedCustomer);
     }
@@ -138,8 +154,11 @@ public class DefaultCustomerFacade implements CustomerFacade {
     @Override
     @Transactional
     public void resendActivationToken(final String customerId) {
-        customerService.validateActivationEmailCanBeIssued(customerId);
-        backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(customerId));
+        final ActivationEmailDelivery activationEmailDelivery = customerService.issueActivationEmail(customerId);
+        backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(
+            customerId,
+            activationEmailJobCipher.encrypt(activationEmailDelivery.rawToken())
+        ));
     }
 
     @Override

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -19,8 +19,8 @@ import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.IssuedActivationToken;
-import com.kartoush.notification.email.customer.CustomerEmailFactory;
-import com.kartoush.notification.email.delivery.EmailDeliveryService;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
@@ -35,13 +35,11 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     private final CustomerService customerService;
 
-    private final EmailDeliveryService emailDeliveryService;
-
-    private final CustomerEmailFactory customerEmailFactory;
-
     private final ActivationTokenService activationTokenService;
 
     private final CustomerPasswordFacade customerPasswordFacade;
+
+    private final BackgroundJobScheduler backgroundJobScheduler;
 
     private final UlidGenerator ulidGenerator;
 
@@ -53,18 +51,18 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     public DefaultCustomerFacade(
         final CustomerService customerService,
-        final EmailDeliveryService emailDeliveryService,
-        final CustomerEmailFactory customerEmailFactory,
         final ActivationTokenService activationTokenService,
         final CustomerPasswordFacade customerPasswordFacade,
+        final BackgroundJobScheduler backgroundJobScheduler,
         final UlidGenerator ulidGenerator,
         final CustomerPasswordSetupValidator customerPasswordSetupValidator,
-        final CustomerUpdateValidator customerUpdateValidator, CustomerRegistrationValidator customerRegistrationValidator) {
+        final CustomerUpdateValidator customerUpdateValidator,
+        final CustomerRegistrationValidator customerRegistrationValidator
+    ) {
         this.customerService = customerService;
-        this.emailDeliveryService = emailDeliveryService;
-        this.customerEmailFactory = customerEmailFactory;
         this.activationTokenService = activationTokenService;
         this.customerPasswordFacade = customerPasswordFacade;
+        this.backgroundJobScheduler = backgroundJobScheduler;
         this.ulidGenerator = ulidGenerator;
         this.customerPasswordSetupValidator = customerPasswordSetupValidator;
         this.customerUpdateValidator = customerUpdateValidator;
@@ -81,6 +79,7 @@ public class DefaultCustomerFacade implements CustomerFacade {
     }
 
     @Override
+    @Transactional
     public CustomerView createCustomer(final CreateCustomerInput input) {
         customerRegistrationValidator.validate(input);
 
@@ -94,10 +93,9 @@ public class DefaultCustomerFacade implements CustomerFacade {
         final Customer savedCustomer = customerService.registerCustomer(customer, input.termsVersion());
         final IssuedActivationToken issuedActivationToken = activationTokenService.createFor(savedCustomer.getId());
 
-        emailDeliveryService.send(
-            customerEmailFactory.newActivationEmail(
-                savedCustomer.getEmail(),
-                savedCustomer.getId(),
+        backgroundJobScheduler.enqueue(
+            new ActivationEmailJobRequest(
+                savedCustomer.getId().value(),
                 issuedActivationToken.rawToken()
             )
         );
@@ -113,12 +111,12 @@ public class DefaultCustomerFacade implements CustomerFacade {
     }
 
     @Override
-    public CustomerView updateCustomer(String customerId, UpdateCustomerInput input) {
+    public CustomerView updateCustomer(final String customerId, final UpdateCustomerInput input) {
 
         customerUpdateValidator.validate(input);
 
-        CustomerProfile profile = buildCustomerProfile(input);
-        Customer savedCustomer = customerService.updateCustomer(customerId, profile);
+        final CustomerProfile profile = buildCustomerProfile(input);
+        final Customer savedCustomer = customerService.updateCustomer(customerId, profile);
 
         return toCustomerView(savedCustomer);
     }
@@ -152,33 +150,33 @@ public class DefaultCustomerFacade implements CustomerFacade {
     }
 
     @Override
+    @Transactional
     public void resendActivationToken(final String customerId) {
         final ActivationEmailDelivery activationEmailDelivery = customerService.issueActivationTokenForResend(customerId);
-        emailDeliveryService.send(
-            customerEmailFactory.newActivationEmail(
-                activationEmailDelivery.email(),
-                activationEmailDelivery.customerId(),
+        backgroundJobScheduler.enqueue(
+            new ActivationEmailJobRequest(
+                activationEmailDelivery.customerId().value(),
                 activationEmailDelivery.rawToken()
             )
         );
     }
 
     @Override
-    public CustomerView reactivateCustomer(String customerId) {
-        Customer reactiveCustomer = customerService.reactivateCustomer(customerId);
+    public CustomerView reactivateCustomer(final String customerId) {
+        final Customer reactiveCustomer = customerService.reactivateCustomer(customerId);
 
         return toCustomerView(reactiveCustomer);
     }
 
     @Override
-    public CustomerView reactivateCustomer(Email email) {
-        Customer reactivatedCustomer = customerService.reactivateCustomerByEmail(email);
+    public CustomerView reactivateCustomer(final Email email) {
+        final Customer reactivatedCustomer = customerService.reactivateCustomerByEmail(email);
 
         return toCustomerView(reactivatedCustomer);
     }
 
     @Override
-    public void deleteCustomer(String customerId) {
+    public void deleteCustomer(final String customerId) {
         customerService.deleteCustomer(CustomerId.of(customerId));
     }
 

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -15,10 +15,7 @@ import com.kartoush.customer.facade.model.UpdateCustomerInput;
 import com.kartoush.customer.internal.validation.CustomerPasswordSetupValidator;
 import com.kartoush.customer.internal.validation.CustomerRegistrationValidator;
 import com.kartoush.customer.internal.validation.CustomerUpdateValidator;
-import com.kartoush.customer.service.ActivationEmailDelivery;
-import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
-import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
@@ -35,8 +32,6 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     private final CustomerService customerService;
 
-    private final ActivationTokenService activationTokenService;
-
     private final CustomerPasswordFacade customerPasswordFacade;
 
     private final BackgroundJobScheduler backgroundJobScheduler;
@@ -51,7 +46,6 @@ public class DefaultCustomerFacade implements CustomerFacade {
 
     public DefaultCustomerFacade(
         final CustomerService customerService,
-        final ActivationTokenService activationTokenService,
         final CustomerPasswordFacade customerPasswordFacade,
         final BackgroundJobScheduler backgroundJobScheduler,
         final UlidGenerator ulidGenerator,
@@ -60,7 +54,6 @@ public class DefaultCustomerFacade implements CustomerFacade {
         final CustomerRegistrationValidator customerRegistrationValidator
     ) {
         this.customerService = customerService;
-        this.activationTokenService = activationTokenService;
         this.customerPasswordFacade = customerPasswordFacade;
         this.backgroundJobScheduler = backgroundJobScheduler;
         this.ulidGenerator = ulidGenerator;
@@ -91,14 +84,7 @@ public class DefaultCustomerFacade implements CustomerFacade {
             new Email(input.email()));
 
         final Customer savedCustomer = customerService.registerCustomer(customer, input.termsVersion());
-        final IssuedActivationToken issuedActivationToken = activationTokenService.createFor(savedCustomer.getId());
-
-        backgroundJobScheduler.enqueue(
-            new ActivationEmailJobRequest(
-                savedCustomer.getId().value(),
-                issuedActivationToken.rawToken()
-            )
-        );
+        backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(savedCustomer.getId().value()));
 
         return toCustomerView(savedCustomer);
     }
@@ -152,13 +138,7 @@ public class DefaultCustomerFacade implements CustomerFacade {
     @Override
     @Transactional
     public void resendActivationToken(final String customerId) {
-        final ActivationEmailDelivery activationEmailDelivery = customerService.issueActivationTokenForResend(customerId);
-        backgroundJobScheduler.enqueue(
-            new ActivationEmailJobRequest(
-                activationEmailDelivery.customerId().value(),
-                activationEmailDelivery.rawToken()
-            )
-        );
+        backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(customerId));
     }
 
     @Override

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -138,6 +138,7 @@ public class DefaultCustomerFacade implements CustomerFacade {
     @Override
     @Transactional
     public void resendActivationToken(final String customerId) {
+        customerService.validateActivationEmailCanBeIssued(customerId);
         backgroundJobScheduler.enqueue(new ActivationEmailJobRequest(customerId));
     }
 

--- a/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
@@ -21,6 +21,8 @@ public interface CustomerService {
 
     Customer activateCustomer(final String customerId, final String rawToken);
 
+    void validateActivationEmailCanBeIssued(final String customerId);
+
     ActivationEmailDelivery issueActivationEmail(final String customerId);
 
     Customer reactivateCustomer(final String customerId);

--- a/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
@@ -21,8 +21,6 @@ public interface CustomerService {
 
     Customer activateCustomer(final String customerId, final String rawToken);
 
-    void validateActivationEmailCanBeIssued(final String customerId);
-
     ActivationEmailDelivery issueActivationEmail(final String customerId);
 
     Customer reactivateCustomer(final String customerId);

--- a/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/CustomerService.java
@@ -21,7 +21,7 @@ public interface CustomerService {
 
     Customer activateCustomer(final String customerId, final String rawToken);
 
-    ActivationEmailDelivery issueActivationTokenForResend(final String customerId);
+    ActivationEmailDelivery issueActivationEmail(final String customerId);
 
     Customer reactivateCustomer(final String customerId);
 

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
@@ -220,12 +220,6 @@ public class DefaultCustomerService implements CustomerService {
 
     @Override
     @Transactional
-    public void validateActivationEmailCanBeIssued(final String customerId) {
-        requirePendingCustomerForActivationEmail(customerId);
-    }
-
-    @Override
-    @Transactional
     public ActivationEmailDelivery issueActivationEmail(final String customerId) {
         final Customer customer = requirePendingCustomerForActivationEmail(customerId);
         final IssuedActivationToken issuedActivationToken = activationTokenService.resendFor(customer.getId());

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
@@ -220,7 +220,7 @@ public class DefaultCustomerService implements CustomerService {
 
     @Override
     @Transactional
-    public ActivationEmailDelivery issueActivationTokenForResend(final String customerId) {
+    public ActivationEmailDelivery issueActivationEmail(final String customerId) {
         final CustomerEntity customerEntity = customerRepository
             .findById(CustomerIdEmbeddable.from(customerId))
             .orElseThrow(() -> new CustomerNotFoundException(customerId));

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultCustomerService.java
@@ -220,7 +220,19 @@ public class DefaultCustomerService implements CustomerService {
 
     @Override
     @Transactional
+    public void validateActivationEmailCanBeIssued(final String customerId) {
+        requirePendingCustomerForActivationEmail(customerId);
+    }
+
+    @Override
+    @Transactional
     public ActivationEmailDelivery issueActivationEmail(final String customerId) {
+        final Customer customer = requirePendingCustomerForActivationEmail(customerId);
+        final IssuedActivationToken issuedActivationToken = activationTokenService.resendFor(customer.getId());
+        return new ActivationEmailDelivery(customer.getId(), customer.getEmail(), issuedActivationToken.rawToken());
+    }
+
+    private Customer requirePendingCustomerForActivationEmail(final String customerId) {
         final CustomerEntity customerEntity = customerRepository
             .findById(CustomerIdEmbeddable.from(customerId))
             .orElseThrow(() -> new CustomerNotFoundException(customerId));
@@ -231,8 +243,7 @@ public class DefaultCustomerService implements CustomerService {
             throw new InvalidActivationTokenResendException(customer.getStatus());
         }
 
-        final IssuedActivationToken issuedActivationToken = activationTokenService.resendFor(customer.getId());
-        return new ActivationEmailDelivery(customer.getId(), customer.getEmail(), issuedActivationToken.rawToken());
+        return customer;
     }
 
     private void validateCustomerCanBeUpdated(final CustomerEntity customer) {

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobCipher.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobCipher.java
@@ -68,8 +68,7 @@ public class ActivationEmailJobCipher {
             System.arraycopy(encryptedBytes, 0, payload, iv.length, encryptedBytes.length);
 
             return Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
-        }
-        catch (final GeneralSecurityException exception) {
+        } catch (final GeneralSecurityException exception) {
             throw new IllegalStateException("Unable to encrypt activation email job token", exception);
         }
     }
@@ -89,8 +88,7 @@ public class ActivationEmailJobCipher {
             final byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
 
             return new String(decryptedBytes, StandardCharsets.UTF_8);
-        }
-        catch (final GeneralSecurityException | IllegalArgumentException exception) {
+        } catch (final GeneralSecurityException | IllegalArgumentException exception) {
             throw new IllegalStateException("Unable to decrypt activation email job token", exception);
         }
     }

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobCipher.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobCipher.java
@@ -14,21 +14,48 @@ import java.util.Base64;
 @Component
 public class ActivationEmailJobCipher {
 
+    private static final String CURRENT_PAYLOAD_VERSION = "v1";
+
     private static final String ENCRYPTION_ALGORITHM = "AES/GCM/NoPadding";
+
     private static final int IV_LENGTH_BYTES = 12;
+
     private static final int GCM_TAG_LENGTH_BITS = 128;
 
     private final SecretKeySpec secretKeySpec;
+
     private final SecureRandom secureRandom = new SecureRandom();
 
     public ActivationEmailJobCipher(final ActivationEmailJobProperties activationEmailJobProperties) {
         this.secretKeySpec = new SecretKeySpec(
             Base64.getDecoder().decode(activationEmailJobProperties.getEncryptionKey()),
-            "AES"
-        );
+            "AES");
     }
 
     public String encrypt(final String rawToken) {
+        return CURRENT_PAYLOAD_VERSION + ":" + encryptV1(rawToken);
+    }
+
+    public String decrypt(final String encryptedRawToken) {
+        final int versionSeparatorIndex = encryptedRawToken.indexOf(':');
+
+        if (versionSeparatorIndex <= 0 || versionSeparatorIndex == encryptedRawToken.length() - 1) {
+            throw new IllegalStateException("Encrypted activation email job token payload version is invalid");
+        }
+
+        final String payloadVersion = encryptedRawToken.substring(0, versionSeparatorIndex);
+        final String encodedPayload = encryptedRawToken.substring(versionSeparatorIndex + 1);
+
+        if (CURRENT_PAYLOAD_VERSION.equals(payloadVersion)) {
+            return decryptV1(encodedPayload);
+        }
+
+        throw new IllegalStateException(
+            "Unsupported activation email job token payload version: " + payloadVersion
+        );
+    }
+
+    private String encryptV1(final String rawToken) {
         try {
             final byte[] iv = new byte[IV_LENGTH_BYTES];
             secureRandom.nextBytes(iv);
@@ -41,14 +68,15 @@ public class ActivationEmailJobCipher {
             System.arraycopy(encryptedBytes, 0, payload, iv.length, encryptedBytes.length);
 
             return Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
-        } catch (final GeneralSecurityException exception) {
+        }
+        catch (final GeneralSecurityException exception) {
             throw new IllegalStateException("Unable to encrypt activation email job token", exception);
         }
     }
 
-    public String decrypt(final String encryptedRawToken) {
+    private String decryptV1(final String encodedPayload) {
         try {
-            final byte[] payload = Base64.getUrlDecoder().decode(encryptedRawToken);
+            final byte[] payload = Base64.getUrlDecoder().decode(encodedPayload);
             if (payload.length <= IV_LENGTH_BYTES) {
                 throw new IllegalStateException("Encrypted activation email job token payload is invalid");
             }
@@ -61,7 +89,8 @@ public class ActivationEmailJobCipher {
             final byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
 
             return new String(decryptedBytes, StandardCharsets.UTF_8);
-        } catch (final GeneralSecurityException | IllegalArgumentException exception) {
+        }
+        catch (final GeneralSecurityException | IllegalArgumentException exception) {
             throw new IllegalStateException("Unable to decrypt activation email job token", exception);
         }
     }

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobCipher.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobCipher.java
@@ -1,0 +1,68 @@
+package com.kartoush.customer.service.job;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Component
+public class ActivationEmailJobCipher {
+
+    private static final String ENCRYPTION_ALGORITHM = "AES/GCM/NoPadding";
+    private static final int IV_LENGTH_BYTES = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    private final SecretKeySpec secretKeySpec;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public ActivationEmailJobCipher(final ActivationEmailJobProperties activationEmailJobProperties) {
+        this.secretKeySpec = new SecretKeySpec(
+            Base64.getDecoder().decode(activationEmailJobProperties.getEncryptionKey()),
+            "AES"
+        );
+    }
+
+    public String encrypt(final String rawToken) {
+        try {
+            final byte[] iv = new byte[IV_LENGTH_BYTES];
+            secureRandom.nextBytes(iv);
+
+            final Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            final byte[] encryptedBytes = cipher.doFinal(rawToken.getBytes(StandardCharsets.UTF_8));
+
+            final byte[] payload = Arrays.copyOf(iv, iv.length + encryptedBytes.length);
+            System.arraycopy(encryptedBytes, 0, payload, iv.length, encryptedBytes.length);
+
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
+        } catch (final GeneralSecurityException exception) {
+            throw new IllegalStateException("Unable to encrypt activation email job token", exception);
+        }
+    }
+
+    public String decrypt(final String encryptedRawToken) {
+        try {
+            final byte[] payload = Base64.getUrlDecoder().decode(encryptedRawToken);
+            if (payload.length <= IV_LENGTH_BYTES) {
+                throw new IllegalStateException("Encrypted activation email job token payload is invalid");
+            }
+
+            final byte[] iv = Arrays.copyOfRange(payload, 0, IV_LENGTH_BYTES);
+            final byte[] encryptedBytes = Arrays.copyOfRange(payload, IV_LENGTH_BYTES, payload.length);
+
+            final Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            final byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+
+            return new String(decryptedBytes, StandardCharsets.UTF_8);
+        } catch (final GeneralSecurityException | IllegalArgumentException exception) {
+            throw new IllegalStateException("Unable to decrypt activation email job token", exception);
+        }
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobProperties.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobProperties.java
@@ -1,0 +1,45 @@
+package com.kartoush.customer.service.job;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+@Component
+@ConfigurationProperties(prefix = "kartoush.jobs.activation-email")
+public class ActivationEmailJobProperties {
+
+    private String encryptionKey = "";
+
+    public String getEncryptionKey() {
+        return encryptionKey;
+    }
+
+    public void setEncryptionKey(final String encryptionKey) {
+        this.encryptionKey = encryptionKey;
+    }
+
+    @PostConstruct
+    void validate() {
+        if (encryptionKey == null || encryptionKey.isBlank()) {
+            throw new IllegalStateException("kartoush.jobs.activation-email.encryption-key must be configured");
+        }
+
+        final byte[] decodedKey;
+        try {
+            decodedKey = Base64.getDecoder().decode(encryptionKey);
+        } catch (final IllegalArgumentException exception) {
+            throw new IllegalStateException(
+                "kartoush.jobs.activation-email.encryption-key must be valid Base64",
+                exception
+            );
+        }
+
+        if (decodedKey.length != 16 && decodedKey.length != 24 && decodedKey.length != 32) {
+            throw new IllegalStateException(
+                "kartoush.jobs.activation-email.encryption-key must decode to 16, 24, or 32 bytes"
+            );
+        }
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
@@ -1,0 +1,9 @@
+package com.kartoush.customer.service.job;
+
+import com.kartoush.platform.jobs.JobRequest;
+
+public record ActivationEmailJobRequest(
+    String customerId,
+    String rawToken
+) implements JobRequest {
+}

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
@@ -3,6 +3,7 @@ package com.kartoush.customer.service.job;
 import com.kartoush.platform.jobs.JobRequest;
 
 public record ActivationEmailJobRequest(
-    String customerId
+    String customerId,
+    String encryptedRawToken
 ) implements JobRequest {
 }

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
@@ -3,7 +3,6 @@ package com.kartoush.customer.service.job;
 import com.kartoush.platform.jobs.JobRequest;
 
 public record ActivationEmailJobRequest(
-    String customerId,
-    String rawToken
+    String customerId
 ) implements JobRequest {
 }

--- a/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/ActivationEmailJobRequest.java
@@ -4,6 +4,6 @@ import com.kartoush.platform.jobs.JobRequest;
 
 public record ActivationEmailJobRequest(
     String customerId,
-    String encryptedRawToken
+    String encryptedToken
 ) implements JobRequest {
 }

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -141,6 +141,7 @@ class DefaultCustomerFacadeTest {
         facade.resendActivationToken(CUSTOMER_ID);
 
         // then
+        verify(customerService).validateActivationEmailCanBeIssued(CUSTOMER_ID);
         verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID));
     }
 

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -11,7 +11,11 @@ import com.kartoush.customer.facade.model.CustomerView;
 import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
 import com.kartoush.customer.internal.validation.CustomerRegistrationValidator;
 import com.kartoush.customer.internal.validation.CustomerPasswordSetupValidator;
+import com.kartoush.customer.service.ActivationEmailDelivery;
+import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.IssuedActivationToken;
+import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
@@ -58,10 +62,16 @@ class DefaultCustomerFacadeTest {
     private CustomerService customerService;
 
     @Mock
+    private ActivationTokenService activationTokenService;
+
+    @Mock
     private CustomerPasswordFacade customerPasswordFacade;
 
     @Mock
     private BackgroundJobScheduler backgroundJobScheduler;
+
+    @Mock
+    private ActivationEmailJobCipher activationEmailJobCipher;
 
     @InjectMocks
     private DefaultCustomerFacade facade;
@@ -72,9 +82,16 @@ class DefaultCustomerFacadeTest {
         final var request = buildCustomerRequest();
         final var saved = buildCustomer();
         final var view = buildCustomerView();
+        final var issuedActivationToken =
+            new IssuedActivationToken(
+                mock(com.kartoush.customer.domain.ActivationToken.class),
+                RAW_TOKEN
+            );
         // when
         when(ulidGenerator.next()).thenReturn(CUSTOMER_ID);
         when(customerService.registerCustomer(any(), any())).thenReturn(saved);
+        when(activationTokenService.createFor(CustomerId.of(CUSTOMER_ID))).thenReturn(issuedActivationToken);
+        when(activationEmailJobCipher.encrypt(RAW_TOKEN)).thenReturn("encrypted-token");
 
         final var result = facade.createCustomer(request);
 
@@ -82,7 +99,9 @@ class DefaultCustomerFacadeTest {
         assertThat(result).isEqualTo(view);
         verify(validator).validate(request);
         verify(customerService).registerCustomer(any(), eq(TERMS_VERSION));
-        verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID));
+        verify(activationTokenService).createFor(CustomerId.of(CUSTOMER_ID));
+        verify(activationEmailJobCipher).encrypt(RAW_TOKEN);
+        verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID, "encrypted-token"));
     }
 
     @Test
@@ -137,12 +156,17 @@ class DefaultCustomerFacadeTest {
     @Test
     void shouldResendActivationToken() {
         // given
+        final ActivationEmailDelivery activationEmailDelivery =
+            new ActivationEmailDelivery(CustomerId.of(CUSTOMER_ID), new Email(EMAIL), RAW_TOKEN);
+        when(customerService.issueActivationEmail(CUSTOMER_ID)).thenReturn(activationEmailDelivery);
+        when(activationEmailJobCipher.encrypt(RAW_TOKEN)).thenReturn("encrypted-token");
         // when
         facade.resendActivationToken(CUSTOMER_ID);
 
         // then
-        verify(customerService).validateActivationEmailCanBeIssued(CUSTOMER_ID);
-        verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID));
+        verify(customerService).issueActivationEmail(CUSTOMER_ID);
+        verify(activationEmailJobCipher).encrypt(RAW_TOKEN);
+        verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID, "encrypted-token"));
     }
 
     private CreateCustomerInput buildCustomerRequest() {

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -3,9 +3,6 @@ package com.kartoush.customer.internal.facade;
 import com.kartoush.auth.domain.PasswordSetupToken;
 import com.kartoush.auth.domain.IssuedPasswordSetupToken;
 import com.kartoush.customer.internal.validation.CustomerRegistrationValidator;
-import com.kartoush.notification.email.customer.CustomerEmailFactory;
-import com.kartoush.notification.email.delivery.EmailDeliveryService;
-import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.auth.facade.CustomerPasswordFacade;
 import com.kartoush.customer.domain.Customer;
 import com.kartoush.customer.domain.CustomerProfile;
@@ -18,6 +15,8 @@ import com.kartoush.customer.service.ActivationEmailDelivery;
 import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.IssuedActivationToken;
+import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
 import com.kartoush.platform.types.Email;
@@ -32,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -61,16 +61,13 @@ class DefaultCustomerFacadeTest {
     private CustomerService customerService;
 
     @Mock
-    private EmailDeliveryService emailDeliveryService;
-
-    @Mock
-    private CustomerEmailFactory customerEmailFactory;
-
-    @Mock
     private ActivationTokenService activationTokenService;
 
     @Mock
     private CustomerPasswordFacade customerPasswordFacade;
+
+    @Mock
+    private BackgroundJobScheduler backgroundJobScheduler;
 
     @InjectMocks
     private DefaultCustomerFacade facade;
@@ -81,24 +78,27 @@ class DefaultCustomerFacadeTest {
         final var request = buildCustomerRequest();
         final var saved = buildCustomer();
         final var view = buildCustomerView();
-        final var issuedActivationToken = new IssuedActivationToken(mock(com.kartoush.customer.domain.ActivationToken.class), RAW_TOKEN);
-        final EmailMessage activationEmail = mock(EmailMessage.class);
+        final var issuedActivationToken =
+            new IssuedActivationToken(
+                mock(com.kartoush.customer.domain.ActivationToken.class),
+                RAW_TOKEN
+            );
 
         // when
         when(ulidGenerator.next()).thenReturn(CUSTOMER_ID);
         when(customerService.registerCustomer(any(), any())).thenReturn(saved);
         when(activationTokenService.createFor(CustomerId.of(CUSTOMER_ID))).thenReturn(issuedActivationToken);
-        when(customerEmailFactory.newActivationEmail(new Email(EMAIL), CustomerId.of(CUSTOMER_ID), RAW_TOKEN))
-            .thenReturn(activationEmail);
 
         final var result = facade.createCustomer(request);
 
         // then
         assertThat(result).isEqualTo(view);
         verify(validator).validate(request);
-        verify(customerService).registerCustomer(any(), org.mockito.ArgumentMatchers.eq(TERMS_VERSION));
+        verify(customerService).registerCustomer(any(), eq(TERMS_VERSION));
         verify(activationTokenService).createFor(CustomerId.of(CUSTOMER_ID));
-        verify(emailDeliveryService).send(activationEmail);
+        verify(backgroundJobScheduler).enqueue(
+            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN)
+        );
     }
 
     @Test
@@ -155,47 +155,48 @@ class DefaultCustomerFacadeTest {
         // given
         final ActivationEmailDelivery activationEmail =
             new ActivationEmailDelivery(CustomerId.of(CUSTOMER_ID), new Email(EMAIL), RAW_TOKEN);
-        final EmailMessage email = mock(EmailMessage.class);
         when(customerService.issueActivationTokenForResend(CUSTOMER_ID)).thenReturn(activationEmail);
-        when(customerEmailFactory.newActivationEmail(new Email(EMAIL), CustomerId.of(CUSTOMER_ID), RAW_TOKEN))
-            .thenReturn(email);
 
         // when
         facade.resendActivationToken(CUSTOMER_ID);
 
         // then
         verify(customerService).issueActivationTokenForResend(CUSTOMER_ID);
-        verify(emailDeliveryService).send(email);
+        verify(backgroundJobScheduler).enqueue(
+            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN)
+        );
     }
 
-    private CreateCustomerInput buildCustomerRequest(){
-        return  new CreateCustomerInput(
-                FIRST_NAME,
-                LAST_NAME,
-                EMAIL,
-                PHONE_NUMBER,
-                true,
-                TERMS_VERSION);
+    private CreateCustomerInput buildCustomerRequest() {
+        return new CreateCustomerInput(
+            FIRST_NAME,
+            LAST_NAME,
+            EMAIL,
+            PHONE_NUMBER,
+            true,
+            TERMS_VERSION
+        );
     }
 
-    private Customer buildCustomer(){
-
-        CustomerId customerId = CustomerId.of(CUSTOMER_ID);
-        CustomerProfile profile = CustomerProfile.of(FIRST_NAME, LAST_NAME, PHONE_NUMBER);
+    private Customer buildCustomer() {
+        final CustomerId customerId = CustomerId.of(CUSTOMER_ID);
+        final CustomerProfile profile = CustomerProfile.of(FIRST_NAME, LAST_NAME, PHONE_NUMBER);
         return Customer.createNew(
-                customerId,
-                profile,
-                new Email(EMAIL));
+            customerId,
+            profile,
+            new Email(EMAIL)
+        );
     }
 
-    private CustomerView buildCustomerView(){
+    private CustomerView buildCustomerView() {
         return new CustomerView(
-                                CUSTOMER_ID,
-                                FIRST_NAME,
-                                LAST_NAME,
-                                EMAIL,
-                                PHONE_NUMBER,
-                                CustomerStatus.PENDING);
+            CUSTOMER_ID,
+            FIRST_NAME,
+            LAST_NAME,
+            EMAIL,
+            PHONE_NUMBER,
+            CustomerStatus.PENDING
+        );
     }
 
     private Customer buildActivatedCustomer() {
@@ -204,7 +205,8 @@ class DefaultCustomerFacadeTest {
         final Customer customer = Customer.createNew(
             customerId,
             profile,
-            new Email(EMAIL));
+            new Email(EMAIL)
+        );
         customer.activate();
         return customer;
     }

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -1,20 +1,17 @@
 package com.kartoush.customer.internal.facade;
 
-import com.kartoush.auth.domain.PasswordSetupToken;
-import com.kartoush.auth.domain.IssuedPasswordSetupToken;
-import com.kartoush.customer.internal.validation.CustomerRegistrationValidator;
 import com.kartoush.auth.facade.CustomerPasswordFacade;
+import com.kartoush.auth.domain.IssuedPasswordSetupToken;
+import com.kartoush.auth.domain.PasswordSetupToken;
 import com.kartoush.customer.domain.Customer;
 import com.kartoush.customer.domain.CustomerProfile;
 import com.kartoush.customer.facade.model.CreateCustomerInput;
 import com.kartoush.customer.facade.model.CustomerActivationView;
 import com.kartoush.customer.facade.model.CustomerView;
 import com.kartoush.customer.facade.model.InitialCustomerPasswordInput;
+import com.kartoush.customer.internal.validation.CustomerRegistrationValidator;
 import com.kartoush.customer.internal.validation.CustomerPasswordSetupValidator;
-import com.kartoush.customer.service.ActivationEmailDelivery;
-import com.kartoush.customer.service.ActivationTokenService;
 import com.kartoush.customer.service.CustomerService;
-import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
@@ -61,9 +58,6 @@ class DefaultCustomerFacadeTest {
     private CustomerService customerService;
 
     @Mock
-    private ActivationTokenService activationTokenService;
-
-    @Mock
     private CustomerPasswordFacade customerPasswordFacade;
 
     @Mock
@@ -78,16 +72,9 @@ class DefaultCustomerFacadeTest {
         final var request = buildCustomerRequest();
         final var saved = buildCustomer();
         final var view = buildCustomerView();
-        final var issuedActivationToken =
-            new IssuedActivationToken(
-                mock(com.kartoush.customer.domain.ActivationToken.class),
-                RAW_TOKEN
-            );
-
         // when
         when(ulidGenerator.next()).thenReturn(CUSTOMER_ID);
         when(customerService.registerCustomer(any(), any())).thenReturn(saved);
-        when(activationTokenService.createFor(CustomerId.of(CUSTOMER_ID))).thenReturn(issuedActivationToken);
 
         final var result = facade.createCustomer(request);
 
@@ -95,10 +82,7 @@ class DefaultCustomerFacadeTest {
         assertThat(result).isEqualTo(view);
         verify(validator).validate(request);
         verify(customerService).registerCustomer(any(), eq(TERMS_VERSION));
-        verify(activationTokenService).createFor(CustomerId.of(CUSTOMER_ID));
-        verify(backgroundJobScheduler).enqueue(
-            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN)
-        );
+        verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID));
     }
 
     @Test
@@ -153,18 +137,11 @@ class DefaultCustomerFacadeTest {
     @Test
     void shouldResendActivationToken() {
         // given
-        final ActivationEmailDelivery activationEmail =
-            new ActivationEmailDelivery(CustomerId.of(CUSTOMER_ID), new Email(EMAIL), RAW_TOKEN);
-        when(customerService.issueActivationTokenForResend(CUSTOMER_ID)).thenReturn(activationEmail);
-
         // when
         facade.resendActivationToken(CUSTOMER_ID);
 
         // then
-        verify(customerService).issueActivationTokenForResend(CUSTOMER_ID);
-        verify(backgroundJobScheduler).enqueue(
-            new ActivationEmailJobRequest(CUSTOMER_ID, RAW_TOKEN)
-        );
+        verify(backgroundJobScheduler).enqueue(new ActivationEmailJobRequest(CUSTOMER_ID));
     }
 
     private CreateCustomerInput buildCustomerRequest() {

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultCustomerServiceTest.java
@@ -361,7 +361,7 @@ class DefaultCustomerServiceTest
     }
 
     @Test
-    void shouldIssueActivationTokenForResendForPendingCustomer() {
+    void shouldIssueActivationEmailForPendingCustomer() {
         // given
         final CustomerEntity customerEntity = mock(CustomerEntity.class);
         final Customer customer = mock(Customer.class);
@@ -377,7 +377,7 @@ class DefaultCustomerServiceTest
 
         // when
         final ActivationEmailDelivery activationEmail =
-            defaultCustomerService.issueActivationTokenForResend(CUSTOMER_ID_VALUE);
+            defaultCustomerService.issueActivationEmail(CUSTOMER_ID_VALUE);
 
         // then
         verify(customerRepository).findById(CUSTOMER_ID_EMBEDDABLE);
@@ -389,7 +389,7 @@ class DefaultCustomerServiceTest
     }
 
     @Test
-    void shouldThrowWhenIssuingActivationTokenForResendForNonPendingCustomer() {
+    void shouldThrowWhenIssuingActivationEmailForNonPendingCustomer() {
         // given
         final CustomerEntity customerEntity = mock(CustomerEntity.class);
         final Customer customer = mock(Customer.class);
@@ -399,7 +399,7 @@ class DefaultCustomerServiceTest
         given(customer.getStatus()).willReturn(CustomerStatus.ACTIVE);
 
         // when / then
-        assertThatThrownBy(() -> defaultCustomerService.issueActivationTokenForResend(CUSTOMER_ID_VALUE))
+        assertThatThrownBy(() -> defaultCustomerService.issueActivationEmail(CUSTOMER_ID_VALUE))
             .isInstanceOf(InvalidActivationTokenResendException.class)
             .hasMessage("Activation token cannot be resent while customer is in ACTIVE status");
 

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -152,6 +152,10 @@ http://localhost:8000
 At the current stage, activation email scheduling is the first customer-facing
 flow that persists durable background jobs through JobRunr.
 
+The persisted job payload carries only the customer identifier. The activation
+token is issued when the job executes, so plaintext activation secrets are not
+stored in JobRunr tables.
+
 ## Test Behavior
 
 The `test` profile disables the background job server and dashboard.

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -152,9 +152,10 @@ http://localhost:8000
 At the current stage, activation email scheduling is the first customer-facing
 flow that persists durable background jobs through JobRunr.
 
-The persisted job payload carries only the customer identifier. The activation
-token is issued when the job executes, so plaintext activation secrets are not
-stored in JobRunr tables.
+The persisted job payload carries the customer identifier and an encrypted
+activation token. Plaintext activation secrets are not stored in JobRunr
+tables, and retries reuse the same issued token instead of generating a new
+one during background execution.
 
 ## Test Behavior
 

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -83,8 +83,8 @@ That wrapper:
 - Rejects scheduling attempts outside an active transaction
 - Prevents later job scheduling flows from publishing background work before
   the underlying database changes are durable
-- Logs post-commit scheduling failures instead of surfacing them as if the
-  original database transaction failed
+- Surfaces post-commit scheduling failures back through the request path instead
+  of silently swallowing them after the original database transaction commits
 
 ## Configuration Surface
 

--- a/docs/infrastructure/jobrunr-background-job-configuration.md
+++ b/docs/infrastructure/jobrunr-background-job-configuration.md
@@ -21,10 +21,10 @@ At this stage, Kartoush provides:
 - A JobRunr-backed adapter in `app`
 - Postgres-backed persistent job storage
 - Local and development dashboard support
+- Durable activation email job scheduling after customer registration and resend
 
 At this stage, Kartoush does not yet provide:
 
-- Activation email job scheduling
 - A broader recurring cleanup job implementation
 
 Those are follow-up tasks in the same epic.
@@ -146,21 +146,22 @@ export SPRING_PROFILES_ACTIVE=dev
 http://localhost:8000
 ```
 
-4. Trigger a code path that enqueues a background job once later tasks wire one
-   in
+4. Trigger a code path that enqueues a background job, such as customer
+   registration or activation-token resend
 
-At the current stage, the dashboard and database wiring can be verified even
-though customer-facing job scheduling is still a follow-up task.
+At the current stage, activation email scheduling is the first customer-facing
+flow that persists durable background jobs through JobRunr.
 
 ## Test Behavior
 
 The `test` profile disables the background job server and dashboard.
 
-This keeps most automated tests deterministic until later tasks begin
-exercising actual job scheduling behavior.
+This keeps most automated tests deterministic while focused integration tests
+still verify that JobRunr can persist scheduled jobs.
 
-Focused integration tests may still verify that JobRunr starts and can persist
-jobs when needed.
+Activation and sign-in flow tests currently stub the scheduler so they can
+continue asserting email-driven behavior without relying on asynchronous job
+execution.
 
 ## Operational Notes
 


### PR DESCRIPTION
## Summary
- Replace synchronous activation email sending with durable background job scheduling
- Preserve resend `404` and `409` behavior by validating resend eligibility before enqueueing
- Enqueue activation email jobs with `customerId` plus an encrypted activation token so retries reuse the same issued token without storing plaintext secrets in JobRunr
- Version the encrypted job payload format so future cipher or payload changes can be introduced without breaking already-enqueued jobs
- Treat missing or non-pending customers as terminal no-ops in the job handler to avoid permanent retry noise for normal race paths
- Add an app-side activation email job handler and keep activation, sign-in, and password-reset integration tests deterministic under the test profile
- Add a JobRunr persistence test and update the JobRunr runtime doc for the first durable customer-facing job

## Testing
- ./gradlew :customer:test --tests com.kartoush.customer.internal.facade.DefaultCustomerFacadeTest --tests com.kartoush.customer.service.impl.DefaultCustomerServiceTest
- ./gradlew :app:test --tests com.kartoush.api.customer.CustomerCreationRestAssuredIntegrationTest --tests com.kartoush.api.customer.CustomerDuplicateEmailRestAssuredIntegrationTest --tests com.kartoush.api.customer.ActivationAndPasswordSetupIntegrationTest --tests com.kartoush.api.customer.ActivationEmailJobSchedulingIntegrationTest --tests com.kartoush.api.auth.CustomerSignInFlowIntegrationTest --tests com.kartoush.api.auth.CustomerPasswordResetFlowIntegrationTest --tests com.kartoush.config.jobs.ActivationEmailJobHandlerTest

Closes #295
