### PR TITLE
Add cleanup scheduled job foundation

### DIFF
--- a/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
+++ b/app/src/main/java/com/kartoush/config/jobs/BackgroundJobConfiguration.java
@@ -3,6 +3,7 @@ package com.kartoush.config.jobs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.jobs.RecurringBackgroundJobScheduler;
 import org.jobrunr.scheduling.JobScheduler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,15 +24,35 @@ public class BackgroundJobConfiguration {
 
     @Bean
     BackgroundJobScheduler platformJobScheduler(
-        final JobScheduler jobRunrJobScheduler,
+        final JobScheduler jobScheduler,
         final PlatformJobDispatcher platformJobDispatcher,
         final ObjectMapper objectMapper,
         final PlatformTransactionManager transactionManager) {
         final TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
         transactionTemplate.setPropagationBehavior(TransactionTemplate.PROPAGATION_REQUIRES_NEW);
         return new TransactionAwareBackgroundJobScheduler(
-            new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, objectMapper),
+            jobSchedulerAdapter(jobScheduler, platformJobDispatcher, objectMapper),
             transactionTemplate
         );
+    }
+
+    @Bean
+    RecurringBackgroundJobScheduler recurringBackgroundJobScheduler(
+        final JobScheduler jobScheduler,
+        final PlatformJobDispatcher platformJobDispatcher,
+        final ObjectMapper objectMapper) {
+        return new JobRunrRecurringBackgroundJobScheduler(
+            jobScheduler,
+            jobSchedulerAdapter(jobScheduler, platformJobDispatcher, objectMapper),
+            platformJobDispatcher
+        );
+    }
+
+    private JobRunrPlatformJobScheduler jobSchedulerAdapter(
+        final JobScheduler jobScheduler,
+        final PlatformJobDispatcher platformJobDispatcher,
+        final ObjectMapper objectMapper
+    ) {
+        return new JobRunrPlatformJobScheduler(jobScheduler, platformJobDispatcher, objectMapper);
     }
 }

--- a/app/src/main/java/com/kartoush/config/jobs/CleanupExpiredTokensJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/CleanupExpiredTokensJobHandler.java
@@ -1,0 +1,47 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.auth.service.PasswordTokenCleanupResult;
+import com.kartoush.auth.service.PasswordTokenCleanupService;
+import com.kartoush.customer.service.ActivationTokenCleanupService;
+import com.kartoush.platform.jobs.JobHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public class CleanupExpiredTokensJobHandler implements JobHandler<CleanupExpiredTokensJobRequest> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CleanupExpiredTokensJobHandler.class);
+
+    private final ActivationTokenCleanupService activationTokenCleanupService;
+
+    private final PasswordTokenCleanupService passwordTokenCleanupService;
+
+    private final Clock clock;
+
+    public CleanupExpiredTokensJobHandler(
+        final ActivationTokenCleanupService activationTokenCleanupService,
+        final PasswordTokenCleanupService passwordTokenCleanupService,
+        final Clock clock
+    ) {
+        this.activationTokenCleanupService = activationTokenCleanupService;
+        this.passwordTokenCleanupService = passwordTokenCleanupService;
+        this.clock = clock;
+    }
+
+    @Override
+    public void handle(final CleanupExpiredTokensJobRequest request) {
+        final Instant expiresBefore = Instant.now(clock);
+        final long deletedActivationTokenCount = activationTokenCleanupService.deleteExpiredTokens(expiresBefore);
+        final PasswordTokenCleanupResult deletedPasswordTokens =
+            passwordTokenCleanupService.deleteExpiredTokens(expiresBefore);
+
+        LOG.info(
+            "Deleted expired tokens: activation={}, passwordReset={}, passwordSetup={}",
+            deletedActivationTokenCount,
+            deletedPasswordTokens.passwordResetDeletedCount(),
+            deletedPasswordTokens.passwordSetupDeletedCount()
+        );
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/CleanupExpiredTokensJobRequest.java
+++ b/app/src/main/java/com/kartoush/config/jobs/CleanupExpiredTokensJobRequest.java
@@ -1,0 +1,6 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.platform.jobs.JobRequest;
+
+public record CleanupExpiredTokensJobRequest() implements JobRequest {
+}

--- a/app/src/main/java/com/kartoush/config/jobs/CleanupJobConfiguration.java
+++ b/app/src/main/java/com/kartoush/config/jobs/CleanupJobConfiguration.java
@@ -1,0 +1,50 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.auth.service.PasswordTokenCleanupService;
+import com.kartoush.customer.service.ActivationTokenCleanupService;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.jobs.RecurringBackgroundJobScheduler;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+@EnableConfigurationProperties(CleanupJobProperties.class)
+public class CleanupJobConfiguration {
+
+    static final String EXPIRED_TOKEN_CLEANUP_JOB_ID = "cleanup-expired-tokens";
+
+    @Bean
+    JobHandler<CleanupExpiredTokensJobRequest> cleanupExpiredTokensJobHandler(
+        final ActivationTokenCleanupService activationTokenCleanupService,
+        final PasswordTokenCleanupService passwordTokenCleanupService,
+        final Clock clock
+    ) {
+        return new CleanupExpiredTokensJobHandler(
+            activationTokenCleanupService,
+            passwordTokenCleanupService,
+            clock
+        );
+    }
+
+    @Bean
+    ApplicationRunner cleanupJobRegistrar(
+        final RecurringBackgroundJobScheduler recurringBackgroundJobScheduler,
+        final CleanupJobProperties cleanupJobProperties
+    ) {
+        return args -> {
+            if (!cleanupJobProperties.isEnabled()) {
+                return;
+            }
+
+            recurringBackgroundJobScheduler.scheduleRecurrently(
+                EXPIRED_TOKEN_CLEANUP_JOB_ID,
+                cleanupJobProperties.getExpiredTokenCron(),
+                new CleanupExpiredTokensJobRequest()
+            );
+        };
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/CleanupJobProperties.java
+++ b/app/src/main/java/com/kartoush/config/jobs/CleanupJobProperties.java
@@ -1,0 +1,27 @@
+package com.kartoush.config.jobs;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kartoush.jobs.cleanup")
+public class CleanupJobProperties {
+
+    private boolean enabled = true;
+
+    private String expiredTokenCron = "0 0 3 * * *";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getExpiredTokenCron() {
+        return expiredTokenCron;
+    }
+
+    public void setExpiredTokenCron(final String expiredTokenCron) {
+        this.expiredTokenCron = expiredTokenCron;
+    }
+}

--- a/app/src/main/java/com/kartoush/config/jobs/JobRunrRecurringBackgroundJobScheduler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/JobRunrRecurringBackgroundJobScheduler.java
@@ -1,0 +1,51 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.platform.jobs.JobRequest;
+import com.kartoush.platform.jobs.JobSchedulingException;
+import com.kartoush.platform.jobs.RecurringBackgroundJobScheduler;
+import org.jobrunr.scheduling.JobScheduler;
+
+public class JobRunrRecurringBackgroundJobScheduler implements RecurringBackgroundJobScheduler {
+
+    private final JobScheduler jobRunrJobScheduler;
+
+    private final JobRunrPlatformJobScheduler jobRunrPlatformJobScheduler;
+
+    private final PlatformJobDispatcher platformJobDispatcher;
+
+    public JobRunrRecurringBackgroundJobScheduler(
+        final JobScheduler jobRunrJobScheduler,
+        final JobRunrPlatformJobScheduler jobRunrPlatformJobScheduler,
+        final PlatformJobDispatcher platformJobDispatcher
+    ) {
+        this.jobRunrJobScheduler = jobRunrJobScheduler;
+        this.jobRunrPlatformJobScheduler = jobRunrPlatformJobScheduler;
+        this.platformJobDispatcher = platformJobDispatcher;
+    }
+
+    @Override
+    public void scheduleRecurrently(
+        final String recurringJobId,
+        final String cronExpression,
+        final JobRequest request
+    ) {
+        final JobRunrPlatformJobScheduler.SerializedJobRequest serializedJobRequest =
+            jobRunrPlatformJobScheduler.snapshot(request);
+
+        try {
+            jobRunrJobScheduler.scheduleRecurrently(
+                recurringJobId,
+                cronExpression,
+                () -> platformJobDispatcher.dispatch(
+                    serializedJobRequest.requestType(),
+                    serializedJobRequest.payload()
+                )
+            );
+        } catch (final RuntimeException ex) {
+            throw new JobSchedulingException(
+                "Failed to register recurring job request of type " + serializedJobRequest.requestType(),
+                ex
+            );
+        }
+    }
+}

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -11,6 +11,9 @@ jobrunr:
     port: ${KARTOUSH_JOBRUNR_DASHBOARD_PORT:8000}
 
 kartoush:
+  jobs:
+    cleanup:
+      enabled: true
   email:
     customer:
       activation-base-url: ${KARTOUSH_EMAIL_ACTIVATION_BASE_URL:http://localhost:8080/dev/customers/activate}

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -13,6 +13,8 @@ kartoush:
   jobs:
     activation-email:
       encryption-key: ${KARTOUSH_JOBS_ACTIVATION_EMAIL_ENCRYPTION_KEY:}
+    cleanup:
+      enabled: true
   email:
     delivery:
       provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:brevo}

--- a/app/src/main/resources/application-test.yml
+++ b/app/src/main/resources/application-test.yml
@@ -10,6 +10,9 @@ jobrunr:
     enabled: false
 
 kartoush:
+  jobs:
+    cleanup:
+      enabled: false
   email:
     delivery:
       provider: ${KARTOUSH_EMAIL_DELIVERY_PROVIDER:noop}

--- a/app/src/test/java/com/kartoush/config/CleanupJobConfigurationTest.java
+++ b/app/src/test/java/com/kartoush/config/CleanupJobConfigurationTest.java
@@ -1,0 +1,64 @@
+package com.kartoush.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.auth.service.PasswordTokenCleanupService;
+import com.kartoush.config.jobs.CleanupExpiredTokensJobRequest;
+import com.kartoush.config.jobs.CleanupJobConfiguration;
+import com.kartoush.customer.service.ActivationTokenCleanupService;
+import com.kartoush.platform.jobs.RecurringBackgroundJobScheduler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.time.Clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class CleanupJobConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withBean(ObjectMapper.class, ObjectMapper::new)
+        .withBean(RecurringBackgroundJobScheduler.class, () -> mock(RecurringBackgroundJobScheduler.class))
+        .withBean(ActivationTokenCleanupService.class, () -> mock(ActivationTokenCleanupService.class))
+        .withBean(PasswordTokenCleanupService.class, () -> mock(PasswordTokenCleanupService.class))
+        .withBean(Clock.class, Clock::systemUTC)
+        .withUserConfiguration(CleanupJobConfiguration.class);
+
+    @Test
+    void shouldRegisterRecurringCleanupJobWhenEnabled() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(RecurringBackgroundJobScheduler.class);
+
+            final RecurringBackgroundJobScheduler recurringBackgroundJobScheduler =
+                context.getBean(RecurringBackgroundJobScheduler.class);
+
+            context.getBean(ApplicationRunner.class).run(null);
+
+            verify(recurringBackgroundJobScheduler).scheduleRecurrently(
+                "cleanup-expired-tokens",
+                "0 0 3 * * *",
+                new CleanupExpiredTokensJobRequest()
+            );
+        });
+    }
+
+    @Test
+    void shouldNotRegisterRecurringCleanupJobWhenDisabled() {
+        contextRunner
+            .withPropertyValues("kartoush.jobs.cleanup.enabled=false")
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+
+                final RecurringBackgroundJobScheduler recurringBackgroundJobScheduler =
+                    context.getBean(RecurringBackgroundJobScheduler.class);
+
+                context.getBean(ApplicationRunner.class).run(null);
+
+                verifyNoInteractions(recurringBackgroundJobScheduler);
+            });
+    }
+}

--- a/app/src/test/java/com/kartoush/config/jobs/CleanupExpiredTokensJobHandlerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/CleanupExpiredTokensJobHandlerTest.java
@@ -1,0 +1,41 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.auth.service.PasswordTokenCleanupResult;
+import com.kartoush.auth.service.PasswordTokenCleanupService;
+import com.kartoush.customer.service.ActivationTokenCleanupService;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CleanupExpiredTokensJobHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-05-18T03:00:00Z");
+
+    private final ActivationTokenCleanupService activationTokenCleanupService = mock(ActivationTokenCleanupService.class);
+
+    private final PasswordTokenCleanupService passwordTokenCleanupService = mock(PasswordTokenCleanupService.class);
+
+    private final CleanupExpiredTokensJobHandler handler =
+        new CleanupExpiredTokensJobHandler(
+            activationTokenCleanupService,
+            passwordTokenCleanupService,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+
+    @Test
+    void shouldDeleteExpiredTokensAcrossModules() {
+        when(activationTokenCleanupService.deleteExpiredTokens(NOW)).thenReturn(4L);
+        when(passwordTokenCleanupService.deleteExpiredTokens(NOW)).thenReturn(new PasswordTokenCleanupResult(3L, 2L));
+
+        handler.handle(new CleanupExpiredTokensJobRequest());
+
+        verify(activationTokenCleanupService).deleteExpiredTokens(NOW);
+        verify(passwordTokenCleanupService).deleteExpiredTokens(NOW);
+    }
+}

--- a/app/src/test/java/com/kartoush/config/jobs/JobRunrRecurringBackgroundJobSchedulerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/JobRunrRecurringBackgroundJobSchedulerTest.java
@@ -1,0 +1,60 @@
+package com.kartoush.config.jobs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kartoush.platform.jobs.JobSchedulingException;
+import org.jobrunr.jobs.lambdas.JobLambda;
+import org.jobrunr.scheduling.JobScheduler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class JobRunrRecurringBackgroundJobSchedulerTest {
+
+    private static final String RECURRING_JOB_ID = "cleanup-expired-tokens";
+    private static final String CRON_EXPRESSION = "0 0 3 * * *";
+
+    private final JobScheduler jobRunrJobScheduler = mock(JobScheduler.class);
+
+    private final PlatformJobDispatcher platformJobDispatcher = mock(PlatformJobDispatcher.class);
+
+    private final JobRunrPlatformJobScheduler jobRunrPlatformJobScheduler =
+        new JobRunrPlatformJobScheduler(jobRunrJobScheduler, platformJobDispatcher, new ObjectMapper());
+
+    private final JobRunrRecurringBackgroundJobScheduler recurringBackgroundJobScheduler =
+        new JobRunrRecurringBackgroundJobScheduler(
+            jobRunrJobScheduler,
+            jobRunrPlatformJobScheduler,
+            platformJobDispatcher
+        );
+
+    @Test
+    void shouldRegisterRecurringJob() {
+        recurringBackgroundJobScheduler.scheduleRecurrently(
+            RECURRING_JOB_ID,
+            CRON_EXPRESSION,
+            new CleanupExpiredTokensJobRequest()
+        );
+
+        verify(jobRunrJobScheduler).scheduleRecurrently(eq(RECURRING_JOB_ID), eq(CRON_EXPRESSION), any(JobLambda.class));
+    }
+
+    @Test
+    void shouldWrapRecurringRegistrationFailure() {
+        doThrow(new RuntimeException("boom")).when(jobRunrJobScheduler)
+            .scheduleRecurrently(eq(RECURRING_JOB_ID), eq(CRON_EXPRESSION), any(JobLambda.class));
+
+        assertThatThrownBy(() -> recurringBackgroundJobScheduler.scheduleRecurrently(
+            RECURRING_JOB_ID,
+            CRON_EXPRESSION,
+            new CleanupExpiredTokensJobRequest()
+        ))
+            .isInstanceOf(JobSchedulingException.class)
+            .hasMessageContaining("Failed to register recurring job request of type")
+            .hasCauseInstanceOf(RuntimeException.class);
+    }
+}

--- a/auth/src/main/java/com/kartoush/auth/persistence/repository/PasswordResetTokenRepository.java
+++ b/auth/src/main/java/com/kartoush/auth/persistence/repository/PasswordResetTokenRepository.java
@@ -3,9 +3,12 @@ package com.kartoush.auth.persistence.repository;
 import com.kartoush.auth.persistence.entity.PasswordResetTokenEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetTokenEntity, String> {
 
     Optional<PasswordResetTokenEntity> findByCustomerIdAndTokenHash(String customerId, String tokenHash);
+
+    long deleteByExpiresAtBefore(Instant expiresBefore);
 }

--- a/auth/src/main/java/com/kartoush/auth/persistence/repository/PasswordSetupTokenRepository.java
+++ b/auth/src/main/java/com/kartoush/auth/persistence/repository/PasswordSetupTokenRepository.java
@@ -3,9 +3,12 @@ package com.kartoush.auth.persistence.repository;
 import com.kartoush.auth.persistence.entity.PasswordSetupTokenEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public interface PasswordSetupTokenRepository extends JpaRepository<PasswordSetupTokenEntity, String> {
 
     Optional<PasswordSetupTokenEntity> findByCustomerIdAndTokenHash(String customerId, String tokenHash);
+
+    long deleteByExpiresAtBefore(Instant expiresBefore);
 }

--- a/auth/src/main/java/com/kartoush/auth/service/PasswordTokenCleanupResult.java
+++ b/auth/src/main/java/com/kartoush/auth/service/PasswordTokenCleanupResult.java
@@ -1,0 +1,4 @@
+package com.kartoush.auth.service;
+
+public record PasswordTokenCleanupResult(long passwordResetDeletedCount, long passwordSetupDeletedCount) {
+}

--- a/auth/src/main/java/com/kartoush/auth/service/PasswordTokenCleanupService.java
+++ b/auth/src/main/java/com/kartoush/auth/service/PasswordTokenCleanupService.java
@@ -1,0 +1,8 @@
+package com.kartoush.auth.service;
+
+import java.time.Instant;
+
+public interface PasswordTokenCleanupService {
+
+    PasswordTokenCleanupResult deleteExpiredTokens(Instant expiresBefore);
+}

--- a/auth/src/main/java/com/kartoush/auth/service/impl/DefaultPasswordTokenCleanupService.java
+++ b/auth/src/main/java/com/kartoush/auth/service/impl/DefaultPasswordTokenCleanupService.java
@@ -1,0 +1,35 @@
+package com.kartoush.auth.service.impl;
+
+import com.kartoush.auth.persistence.repository.PasswordResetTokenRepository;
+import com.kartoush.auth.persistence.repository.PasswordSetupTokenRepository;
+import com.kartoush.auth.service.PasswordTokenCleanupResult;
+import com.kartoush.auth.service.PasswordTokenCleanupService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+public class DefaultPasswordTokenCleanupService implements PasswordTokenCleanupService {
+
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+
+    private final PasswordSetupTokenRepository passwordSetupTokenRepository;
+
+    public DefaultPasswordTokenCleanupService(
+        final PasswordResetTokenRepository passwordResetTokenRepository,
+        final PasswordSetupTokenRepository passwordSetupTokenRepository
+    ) {
+        this.passwordResetTokenRepository = passwordResetTokenRepository;
+        this.passwordSetupTokenRepository = passwordSetupTokenRepository;
+    }
+
+    @Override
+    @Transactional
+    public PasswordTokenCleanupResult deleteExpiredTokens(final Instant expiresBefore) {
+        final long passwordResetDeletedCount = passwordResetTokenRepository.deleteByExpiresAtBefore(expiresBefore);
+        final long passwordSetupDeletedCount = passwordSetupTokenRepository.deleteByExpiresAtBefore(expiresBefore);
+
+        return new PasswordTokenCleanupResult(passwordResetDeletedCount, passwordSetupDeletedCount);
+    }
+}

--- a/auth/src/test/java/com/kartoush/auth/service/impl/DefaultPasswordTokenCleanupServiceTest.java
+++ b/auth/src/test/java/com/kartoush/auth/service/impl/DefaultPasswordTokenCleanupServiceTest.java
@@ -1,0 +1,38 @@
+package com.kartoush.auth.service.impl;
+
+import com.kartoush.auth.persistence.repository.PasswordResetTokenRepository;
+import com.kartoush.auth.persistence.repository.PasswordSetupTokenRepository;
+import com.kartoush.auth.service.PasswordTokenCleanupResult;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultPasswordTokenCleanupServiceTest {
+
+    private final PasswordResetTokenRepository passwordResetTokenRepository = mock(PasswordResetTokenRepository.class);
+
+    private final PasswordSetupTokenRepository passwordSetupTokenRepository = mock(PasswordSetupTokenRepository.class);
+
+    private final DefaultPasswordTokenCleanupService service =
+        new DefaultPasswordTokenCleanupService(passwordResetTokenRepository, passwordSetupTokenRepository);
+
+    @Test
+    void shouldDeleteExpiredPasswordTokens() {
+        final Instant expiresBefore = Instant.parse("2026-05-18T03:00:00Z");
+
+        when(passwordResetTokenRepository.deleteByExpiresAtBefore(expiresBefore)).thenReturn(3L);
+        when(passwordSetupTokenRepository.deleteByExpiresAtBefore(expiresBefore)).thenReturn(2L);
+
+        final PasswordTokenCleanupResult result = service.deleteExpiredTokens(expiresBefore);
+
+        assertThat(result.passwordResetDeletedCount()).isEqualTo(3L);
+        assertThat(result.passwordSetupDeletedCount()).isEqualTo(2L);
+        verify(passwordResetTokenRepository).deleteByExpiresAtBefore(expiresBefore);
+        verify(passwordSetupTokenRepository).deleteByExpiresAtBefore(expiresBefore);
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/persistence/repository/ActivationTokenRepository.java
+++ b/customer/src/main/java/com/kartoush/customer/persistence/repository/ActivationTokenRepository.java
@@ -5,6 +5,7 @@ import com.kartoush.customer.persistence.model.ActivationTokenIdEmbeddable;
 import com.kartoush.customer.persistence.model.CustomerIdEmbeddable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,6 @@ public interface ActivationTokenRepository extends JpaRepository<ActivationToken
         String tokenHash);
 
     List<ActivationTokenEntity> findAllByCustomerIdAndConsumedAtIsNull(CustomerIdEmbeddable customerId);
+
+    long deleteByExpiresAtBefore(Instant expiresBefore);
 }

--- a/customer/src/main/java/com/kartoush/customer/service/ActivationTokenCleanupService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/ActivationTokenCleanupService.java
@@ -1,0 +1,8 @@
+package com.kartoush.customer.service;
+
+import java.time.Instant;
+
+public interface ActivationTokenCleanupService {
+
+    long deleteExpiredTokens(Instant expiresBefore);
+}

--- a/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenCleanupService.java
+++ b/customer/src/main/java/com/kartoush/customer/service/impl/DefaultActivationTokenCleanupService.java
@@ -1,0 +1,24 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
+import com.kartoush.customer.service.ActivationTokenCleanupService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+public class DefaultActivationTokenCleanupService implements ActivationTokenCleanupService {
+
+    private final ActivationTokenRepository activationTokenRepository;
+
+    public DefaultActivationTokenCleanupService(final ActivationTokenRepository activationTokenRepository) {
+        this.activationTokenRepository = activationTokenRepository;
+    }
+
+    @Override
+    @Transactional
+    public long deleteExpiredTokens(final Instant expiresBefore) {
+        return activationTokenRepository.deleteByExpiresAtBefore(expiresBefore);
+    }
+}

--- a/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenCleanupServiceTest.java
+++ b/customer/src/test/java/com/kartoush/customer/service/impl/DefaultActivationTokenCleanupServiceTest.java
@@ -1,0 +1,31 @@
+package com.kartoush.customer.service.impl;
+
+import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultActivationTokenCleanupServiceTest {
+
+    private final ActivationTokenRepository activationTokenRepository = mock(ActivationTokenRepository.class);
+
+    private final DefaultActivationTokenCleanupService service =
+        new DefaultActivationTokenCleanupService(activationTokenRepository);
+
+    @Test
+    void shouldDeleteExpiredActivationTokens() {
+        final Instant expiresBefore = Instant.parse("2026-05-18T03:00:00Z");
+
+        when(activationTokenRepository.deleteByExpiresAtBefore(expiresBefore)).thenReturn(4L);
+
+        final long deletedCount = service.deleteExpiredTokens(expiresBefore);
+
+        assertThat(deletedCount).isEqualTo(4L);
+        verify(activationTokenRepository).deleteByExpiresAtBefore(expiresBefore);
+    }
+}

--- a/platform/platform-jobs/src/main/java/com/kartoush/platform/jobs/RecurringBackgroundJobScheduler.java
+++ b/platform/platform-jobs/src/main/java/com/kartoush/platform/jobs/RecurringBackgroundJobScheduler.java
@@ -1,0 +1,10 @@
+package com.kartoush.platform.jobs;
+
+/**
+ * Registers durable recurring background work without exposing infrastructure
+ * details to application code.
+ */
+public interface RecurringBackgroundJobScheduler {
+
+    void scheduleRecurrently(String recurringJobId, String cronExpression, JobRequest request);
+}


### PR DESCRIPTION
## Summary
- Add the first recurring cleanup job foundation behind the existing background-job boundary.
- Register a daily recurring cleanup job for expired activation, password reset, and password setup tokens.
- Keep cleanup logic inside auth and customer services while using a JobRunr-backed recurring scheduler adapter in `app`.

## Scope
- Add a recurring background job scheduler contract in `platform-jobs`.
- Add a JobRunr recurring adapter and cleanup job registration in `app`.
- Add conservative expired-token cleanup services in `auth` and `customer`.
- Disable recurring cleanup registration in the `test` profile while leaving it enabled in `dev` and `prod`.

## Testing
- `./gradlew :customer:test --tests com.kartoush.customer.service.impl.DefaultActivationTokenCleanupServiceTest`
- `./gradlew :auth:test --tests com.kartoush.auth.service.impl.DefaultPasswordTokenCleanupServiceTest`
- `./gradlew :app:test --tests com.kartoush.config.jobs.CleanupExpiredTokensJobHandlerTest --tests com.kartoush.config.jobs.JobRunrRecurringBackgroundJobSchedulerTest --tests com.kartoush.config.CleanupJobConfigurationTest -x :app:jacocoTestReport`

Closes #299
