### PR TITLE
Send customer welcome email after initial password setup

### DIFF
--- a/app/src/main/java/com/kartoush/config/jobs/WelcomeEmailJobHandler.java
+++ b/app/src/main/java/com/kartoush/config/jobs/WelcomeEmailJobHandler.java
@@ -1,0 +1,73 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.job.WelcomeEmailJobRequest;
+import com.kartoush.notification.email.config.CustomerEmailProperties;
+import com.kartoush.notification.email.customer.CustomerEmailFactory;
+import com.kartoush.notification.email.delivery.EmailDeliveryService;
+import com.kartoush.platform.jobs.JobHandler;
+import com.kartoush.platform.types.CustomerStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class WelcomeEmailJobHandler implements JobHandler<WelcomeEmailJobRequest> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WelcomeEmailJobHandler.class);
+
+    private final CustomerService customerService;
+
+    private final CustomerEmailProperties customerEmailProperties;
+
+    private final CustomerEmailFactory customerEmailFactory;
+
+    private final EmailDeliveryService emailDeliveryService;
+
+    public WelcomeEmailJobHandler(
+        final CustomerService customerService,
+        final CustomerEmailProperties customerEmailProperties,
+        final CustomerEmailFactory customerEmailFactory,
+        final EmailDeliveryService emailDeliveryService) {
+        this.customerService = customerService;
+        this.customerEmailProperties = customerEmailProperties;
+        this.customerEmailFactory = customerEmailFactory;
+        this.emailDeliveryService = emailDeliveryService;
+    }
+
+    @Override
+    public void handle(final WelcomeEmailJobRequest request) {
+        if (!customerEmailProperties.isWelcomeEnabled()) {
+            LOG.info("Skipping welcome email job because welcome email delivery is disabled");
+            return;
+        }
+
+        final Optional<Customer> customer = customerService.getCustomerById(request.customerId());
+
+        if (customer.isEmpty()) {
+            LOG.info("Skipping welcome email job because customer {} no longer exists", request.customerId());
+            return;
+        }
+
+        final Customer activeCustomer = customer.orElseThrow();
+
+        if (activeCustomer.getStatus() != CustomerStatus.ACTIVE) {
+            LOG.info(
+                "Skipping welcome email job because customer {} is now in {} status",
+                request.customerId(),
+                activeCustomer.getStatus()
+            );
+            return;
+        }
+
+        emailDeliveryService.send(
+            customerEmailFactory.newWelcomeEmail(
+                activeCustomer.getEmail(),
+                activeCustomer.getProfile().firstName()
+            )
+        );
+    }
+}

--- a/app/src/test/java/com/kartoush/api/customer/ActivationAndPasswordSetupIntegrationTest.java
+++ b/app/src/test/java/com/kartoush/api/customer/ActivationAndPasswordSetupIntegrationTest.java
@@ -3,6 +3,7 @@ package com.kartoush.api.customer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kartoush.config.jobs.ActivationEmailJobHandler;
+import com.kartoush.config.jobs.WelcomeEmailJobHandler;
 import com.kartoush.notification.email.delivery.EmailDeliveryService;
 import com.kartoush.notification.email.EmailMessage;
 import com.kartoush.notification.email.EmailMessageType;
@@ -19,6 +20,7 @@ import com.kartoush.customer.persistence.repository.ActivationTokenRepository;
 import com.kartoush.customer.persistence.repository.CustomerRepository;
 import com.kartoush.customer.service.ActivationTokenHasher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.customer.service.job.WelcomeEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.ActivationTokenId;
 import com.kartoush.platform.types.CustomerId;
@@ -95,6 +97,9 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
     @Autowired
     private ActivationEmailJobHandler activationEmailJobHandler;
 
+    @Autowired
+    private WelcomeEmailJobHandler welcomeEmailJobHandler;
+
     @MockitoBean
     private BackgroundJobScheduler backgroundJobScheduler;
 
@@ -105,20 +110,26 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
 
     private final List<CapturedActivationEmail> capturedActivationEmails = new ArrayList<>();
 
+    private final List<Email> capturedWelcomeEmails = new ArrayList<>();
+
     @BeforeEach
     void setUp() {
         activationTokenRepository.deleteAll();
         customerRepository.deleteAll();
 
         capturedActivationEmails.clear();
+        capturedWelcomeEmails.clear();
         reset(backgroundJobScheduler);
         reset(emailDeliveryService);
         doAnswer(invocation -> {
-            final ActivationEmailJobRequest request =
-                invocation.getArgument(0, ActivationEmailJobRequest.class);
-            activationEmailJobHandler.handle(request);
+            final Object request = invocation.getArgument(0);
+            if (request instanceof ActivationEmailJobRequest activationEmailJobRequest) {
+                activationEmailJobHandler.handle(activationEmailJobRequest);
+            } else if (request instanceof WelcomeEmailJobRequest welcomeEmailJobRequest) {
+                welcomeEmailJobHandler.handle(welcomeEmailJobRequest);
+            }
             return null;
-        }).when(backgroundJobScheduler).enqueue(any(ActivationEmailJobRequest.class));
+        }).when(backgroundJobScheduler).enqueue(any());
         doAnswer(invocation -> {
             final EmailMessage email = invocation.getArgument(0, EmailMessage.class);
             if (email.type() == EmailMessageType.CUSTOMER_ACTIVATION) {
@@ -126,6 +137,8 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
                     email.recipient(),
                     queryParam(email.actionUrl(), "token")
                 ));
+            } else if (email.type() == EmailMessageType.CUSTOMER_WELCOME) {
+                capturedWelcomeEmails.add(email.recipient());
             }
             return null;
         }).when(emailDeliveryService).send(any(EmailMessage.class));
@@ -272,6 +285,7 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
         assertThat(customerPasswordRepository.findById(createdCustomer.customerId())).isPresent();
         assertThat(customerPasswordRepository.findById(createdCustomer.customerId()).orElseThrow().getPasswordHash())
             .isNotEqualTo(PASSWORD);
+        assertThat(capturedWelcomeEmails).containsExactly(new Email(createdCustomer.email()));
     }
 
     @Test
@@ -284,6 +298,8 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
                     new InitialCustomerPasswordInput("setup-token", PASSWORD, PASSWORD))))
             .andExpect(status().isConflict())
             .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_PASSWORD_SETUP.name()));
+
+        assertThat(capturedWelcomeEmails).isEmpty();
     }
 
     @Test
@@ -410,6 +426,7 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
         final JsonNode response = objectMapper.readTree(responseBody);
         return new CreatedCustomer(
             response.get("customerId").asText(),
+            email,
             latestCapturedToken().rawToken());
     }
 
@@ -444,7 +461,7 @@ class ActivationAndPasswordSetupIntegrationTest extends PostgresSpringIntegratio
         return customerPasswordFacade.issuePasswordSetupToken(CustomerId.of(customerId)).rawToken();
     }
 
-    private record CreatedCustomer(String customerId, String rawToken) {
+    private record CreatedCustomer(String customerId, String email, String rawToken) {
     }
 
     private record CapturedActivationEmail(Email email, String rawToken) {

--- a/app/src/test/java/com/kartoush/config/jobs/WelcomeEmailJobHandlerTest.java
+++ b/app/src/test/java/com/kartoush/config/jobs/WelcomeEmailJobHandlerTest.java
@@ -1,0 +1,106 @@
+package com.kartoush.config.jobs;
+
+import com.kartoush.customer.domain.Customer;
+import com.kartoush.customer.domain.CustomerProfile;
+import com.kartoush.customer.service.CustomerService;
+import com.kartoush.customer.service.job.WelcomeEmailJobRequest;
+import com.kartoush.notification.email.EmailMessage;
+import com.kartoush.notification.email.config.CustomerEmailProperties;
+import com.kartoush.notification.email.customer.CustomerEmailFactory;
+import com.kartoush.notification.email.delivery.EmailDeliveryService;
+import com.kartoush.platform.types.CustomerId;
+import com.kartoush.platform.types.Email;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WelcomeEmailJobHandlerTest {
+
+    private static final String CUSTOMER_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    private static final Email EMAIL = new Email("jack@kartoush.com");
+
+    private final CustomerService customerService = mock(CustomerService.class);
+
+    private final CustomerEmailProperties customerEmailProperties = new CustomerEmailProperties();
+
+    private final CustomerEmailFactory customerEmailFactory = mock(CustomerEmailFactory.class);
+
+    private final EmailDeliveryService emailDeliveryService = mock(EmailDeliveryService.class);
+
+    private final WelcomeEmailJobHandler handler =
+        new WelcomeEmailJobHandler(
+            customerService,
+            customerEmailProperties,
+            customerEmailFactory,
+            emailDeliveryService
+        );
+
+    @Test
+    void shouldSendWelcomeEmailForActiveCustomer() {
+        final WelcomeEmailJobRequest request = new WelcomeEmailJobRequest(CUSTOMER_ID);
+        final Customer customer = activeCustomer();
+        final EmailMessage emailMessage = mock(EmailMessage.class);
+
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
+        when(customerEmailFactory.newWelcomeEmail(EMAIL, "Jack")).thenReturn(emailMessage);
+
+        handler.handle(request);
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(customerEmailFactory).newWelcomeEmail(EMAIL, "Jack");
+        verify(emailDeliveryService).send(emailMessage);
+    }
+
+    @Test
+    void shouldSkipWhenWelcomeEmailDeliveryIsDisabled() {
+        customerEmailProperties.setWelcomeEnabled(false);
+
+        handler.handle(new WelcomeEmailJobRequest(CUSTOMER_ID));
+
+        verify(customerService, never()).getCustomerById(CUSTOMER_ID);
+        verify(emailDeliveryService, never()).send(any());
+    }
+
+    @Test
+    void shouldSkipWhenCustomerCannotBeReloaded() {
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
+
+        handler.handle(new WelcomeEmailJobRequest(CUSTOMER_ID));
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(emailDeliveryService, never()).send(any());
+    }
+
+    @Test
+    void shouldSkipWhenCustomerIsNoLongerActive() {
+        final Customer customer = Customer.createNew(
+            CustomerId.of(CUSTOMER_ID),
+            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
+            EMAIL
+        );
+
+        when(customerService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer));
+
+        handler.handle(new WelcomeEmailJobRequest(CUSTOMER_ID));
+
+        verify(customerService).getCustomerById(CUSTOMER_ID);
+        verify(customerEmailFactory, never()).newWelcomeEmail(any(), any());
+        verify(emailDeliveryService, never()).send(any());
+    }
+
+    private Customer activeCustomer() {
+        final Customer customer = Customer.createNew(
+            CustomerId.of(CUSTOMER_ID),
+            CustomerProfile.of("Jack", "Kartoush", "+13125550100"),
+            EMAIL
+        );
+        customer.activate();
+        return customer;
+    }
+}

--- a/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
+++ b/customer/src/main/java/com/kartoush/customer/internal/facade/DefaultCustomerFacade.java
@@ -21,6 +21,7 @@ import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.customer.service.job.WelcomeEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
@@ -134,6 +135,7 @@ public class DefaultCustomerFacade implements CustomerFacade {
     }
 
     @Override
+    @Transactional
     public void setInitialPassword(final String customerId, final InitialCustomerPasswordInput input) {
         customerPasswordSetupValidator.validate(input);
 
@@ -149,6 +151,8 @@ public class DefaultCustomerFacade implements CustomerFacade {
             input.setupToken(),
             input.password()
         );
+
+        backgroundJobScheduler.enqueue(new WelcomeEmailJobRequest(customer.getId().value()));
     }
 
     @Override

--- a/customer/src/main/java/com/kartoush/customer/service/job/WelcomeEmailJobRequest.java
+++ b/customer/src/main/java/com/kartoush/customer/service/job/WelcomeEmailJobRequest.java
@@ -1,0 +1,6 @@
+package com.kartoush.customer.service.job;
+
+import com.kartoush.platform.jobs.JobRequest;
+
+public record WelcomeEmailJobRequest(String customerId) implements JobRequest {
+}

--- a/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
+++ b/customer/src/test/java/com/kartoush/customer/internal/facade/DefaultCustomerFacadeTest.java
@@ -17,6 +17,7 @@ import com.kartoush.customer.service.CustomerService;
 import com.kartoush.customer.service.IssuedActivationToken;
 import com.kartoush.customer.service.job.ActivationEmailJobCipher;
 import com.kartoush.customer.service.job.ActivationEmailJobRequest;
+import com.kartoush.customer.service.job.WelcomeEmailJobRequest;
 import com.kartoush.platform.jobs.BackgroundJobScheduler;
 import com.kartoush.platform.types.CustomerId;
 import com.kartoush.platform.types.CustomerStatus;
@@ -151,6 +152,7 @@ class DefaultCustomerFacadeTest {
             SETUP_TOKEN,
             "Password123!"
         );
+        verify(backgroundJobScheduler).enqueue(new WelcomeEmailJobRequest(CUSTOMER_ID));
     }
 
     @Test

--- a/notification/src/main/java/com/kartoush/notification/email/EmailMessageType.java
+++ b/notification/src/main/java/com/kartoush/notification/email/EmailMessageType.java
@@ -2,5 +2,6 @@ package com.kartoush.notification.email;
 
 public enum EmailMessageType {
     CUSTOMER_ACTIVATION,
-    CUSTOMER_PASSWORD_RESET
+    CUSTOMER_PASSWORD_RESET,
+    CUSTOMER_WELCOME
 }

--- a/notification/src/main/java/com/kartoush/notification/email/config/CustomerEmailProperties.java
+++ b/notification/src/main/java/com/kartoush/notification/email/config/CustomerEmailProperties.java
@@ -18,6 +18,10 @@ public class CustomerEmailProperties {
 
     private String passwordResetBaseUrl = "https://kartoush.dev/reset-password";
 
+    private boolean welcomeEnabled = true;
+
+    private String welcomeBaseUrl = "https://kartoush.dev/sign-in";
+
     public String getSenderName() {
         return senderName;
     }
@@ -50,11 +54,28 @@ public class CustomerEmailProperties {
         this.passwordResetBaseUrl = passwordResetBaseUrl;
     }
 
+    public boolean isWelcomeEnabled() {
+        return welcomeEnabled;
+    }
+
+    public void setWelcomeEnabled(final boolean welcomeEnabled) {
+        this.welcomeEnabled = welcomeEnabled;
+    }
+
+    public String getWelcomeBaseUrl() {
+        return welcomeBaseUrl;
+    }
+
+    public void setWelcomeBaseUrl(final String welcomeBaseUrl) {
+        this.welcomeBaseUrl = welcomeBaseUrl;
+    }
+
     @PostConstruct
     void validate() {
         NotificationPropertyValidator.validateRequiredText(senderName, "kartoush.email.customer.sender-name");
         NotificationPropertyValidator.validateHttpUrl(activationBaseUrl, "kartoush.email.customer.activation-base-url");
         NotificationPropertyValidator.validateHttpUrl(passwordResetBaseUrl, "kartoush.email.customer.password-reset-base-url");
+        NotificationPropertyValidator.validateHttpUrl(welcomeBaseUrl, "kartoush.email.customer.welcome-base-url");
 
         try {
             new Email(senderAddress);

--- a/notification/src/main/java/com/kartoush/notification/email/customer/CustomerEmailFactory.java
+++ b/notification/src/main/java/com/kartoush/notification/email/customer/CustomerEmailFactory.java
@@ -9,4 +9,6 @@ public interface CustomerEmailFactory {
     EmailMessage newActivationEmail(Email recipient, CustomerId customerId, String rawActivationToken);
 
     EmailMessage newPasswordResetEmail(Email recipient, String rawResetToken);
+
+    EmailMessage newWelcomeEmail(Email recipient, String firstName);
 }

--- a/notification/src/main/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactory.java
+++ b/notification/src/main/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactory.java
@@ -65,6 +65,37 @@ public class DefaultCustomerEmailFactory implements CustomerEmailFactory {
             properties.getSenderName(), "Reset your Kartoush password", passwordResetBody, actionUrl, passwordResetHtmlBody);
     }
 
+    @Override
+    public EmailMessage newWelcomeEmail(final Email recipient, final String firstName) {
+        final String actionUrl = properties.getWelcomeBaseUrl();
+        final String welcomeBody = String.format(
+            "Welcome to Kartoush, %s.%n%n"
+                + "Your account is ready.%n"
+                + "You can continue here:%n"
+                + "%s",
+            firstName,
+            actionUrl
+        );
+        final String welcomeHtmlBody = """
+            <p>Welcome to Kartoush, %s.</p>
+            <p>Your account is ready.</p>
+            <p><a href="%s">Continue to Kartoush</a></p>
+            <p>If the button does not work, copy and paste this URL into your browser:</p>
+            <p>%s</p>
+            """.formatted(firstName, actionUrl, actionUrl).trim();
+
+        return new EmailMessage(
+            EmailMessageType.CUSTOMER_WELCOME,
+            recipient,
+            new Email(properties.getSenderAddress()),
+            properties.getSenderName(),
+            "Welcome to Kartoush",
+            welcomeBody,
+            actionUrl,
+            welcomeHtmlBody
+        );
+    }
+
     private String encode(final String value) {
         return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }

--- a/notification/src/main/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactory.java
+++ b/notification/src/main/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactory.java
@@ -68,6 +68,7 @@ public class DefaultCustomerEmailFactory implements CustomerEmailFactory {
     @Override
     public EmailMessage newWelcomeEmail(final Email recipient, final String firstName) {
         final String actionUrl = properties.getWelcomeBaseUrl();
+        final String escapedFirstName = escapeHtml(firstName);
         final String welcomeBody = String.format(
             "Welcome to Kartoush, %s.%n%n"
                 + "Your account is ready.%n"
@@ -82,7 +83,7 @@ public class DefaultCustomerEmailFactory implements CustomerEmailFactory {
             <p><a href="%s">Continue to Kartoush</a></p>
             <p>If the button does not work, copy and paste this URL into your browser:</p>
             <p>%s</p>
-            """.formatted(firstName, actionUrl, actionUrl).trim();
+            """.formatted(escapedFirstName, actionUrl, actionUrl).trim();
 
         return new EmailMessage(
             EmailMessageType.CUSTOMER_WELCOME,
@@ -98,5 +99,14 @@ public class DefaultCustomerEmailFactory implements CustomerEmailFactory {
 
     private String encode(final String value) {
         return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private String escapeHtml(final String value) {
+        return value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#39;");
     }
 }

--- a/notification/src/test/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactoryTest.java
+++ b/notification/src/test/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactoryTest.java
@@ -63,6 +63,18 @@ class DefaultCustomerEmailFactoryTest {
             .contains("Continue to Kartoush");
     }
 
+    @Test
+    void shouldEscapeWelcomeEmailFirstNameInHtmlBody() {
+        final DefaultCustomerEmailFactory factory = new DefaultCustomerEmailFactory(emailProperties());
+
+        final EmailMessage email = factory.newWelcomeEmail(RECIPIENT, "<a href=\"https://evil.example\">Jack</a>");
+
+        assertThat(email.textBody()).contains("<a href=\"https://evil.example\">Jack</a>");
+        assertThat(email.htmlBody())
+            .contains("&lt;a href=&quot;https://evil.example&quot;&gt;Jack&lt;/a&gt;")
+            .doesNotContain("<a href=\"https://evil.example\">Jack</a>");
+    }
+
     private CustomerEmailProperties emailProperties() {
         final CustomerEmailProperties properties = new CustomerEmailProperties();
         properties.setSenderName("Kartoush");

--- a/notification/src/test/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactoryTest.java
+++ b/notification/src/test/java/com/kartoush/notification/email/customer/DefaultCustomerEmailFactoryTest.java
@@ -17,13 +17,7 @@ class DefaultCustomerEmailFactoryTest {
 
     @Test
     void shouldBuildActivationEmail() {
-        final CustomerEmailProperties properties = new CustomerEmailProperties();
-        properties.setSenderName("Kartoush");
-        properties.setSenderAddress("no-reply@kartoush.dev");
-        properties.setActivationBaseUrl("https://kartoush.dev/activate");
-        properties.setPasswordResetBaseUrl("https://kartoush.dev/reset-password");
-
-        final DefaultCustomerEmailFactory factory = new DefaultCustomerEmailFactory(properties);
+        final DefaultCustomerEmailFactory factory = new DefaultCustomerEmailFactory(emailProperties());
 
         final EmailMessage email = factory.newActivationEmail(RECIPIENT, CUSTOMER_ID, "activation-token");
 
@@ -39,13 +33,7 @@ class DefaultCustomerEmailFactoryTest {
 
     @Test
     void shouldBuildPasswordResetEmail() {
-        final CustomerEmailProperties properties = new CustomerEmailProperties();
-        properties.setSenderName("Kartoush");
-        properties.setSenderAddress("no-reply@kartoush.dev");
-        properties.setActivationBaseUrl("https://kartoush.dev/activate");
-        properties.setPasswordResetBaseUrl("https://kartoush.dev/reset-password");
-
-        final DefaultCustomerEmailFactory factory = new DefaultCustomerEmailFactory(properties);
+        final DefaultCustomerEmailFactory factory = new DefaultCustomerEmailFactory(emailProperties());
 
         final EmailMessage email = factory.newPasswordResetEmail(RECIPIENT, "reset-token");
 
@@ -57,5 +45,31 @@ class DefaultCustomerEmailFactoryTest {
         assertThat(email.htmlBody())
             .contains("<a href=\"https://kartoush.dev/reset-password?email=jack%40kartoush.com&token=reset-token\">")
             .contains("Reset your Kartoush password");
+    }
+
+    @Test
+    void shouldBuildWelcomeEmail() {
+        final DefaultCustomerEmailFactory factory = new DefaultCustomerEmailFactory(emailProperties());
+
+        final EmailMessage email = factory.newWelcomeEmail(RECIPIENT, "Jack");
+
+        assertThat(email.type()).isEqualTo(EmailMessageType.CUSTOMER_WELCOME);
+        assertThat(email.recipient()).isEqualTo(RECIPIENT);
+        assertThat(email.subject()).isEqualTo("Welcome to Kartoush");
+        assertThat(email.actionUrl()).isEqualTo("https://kartoush.dev/sign-in");
+        assertThat(email.textBody()).contains("Welcome to Kartoush, Jack.");
+        assertThat(email.htmlBody())
+            .contains("<a href=\"https://kartoush.dev/sign-in\">")
+            .contains("Continue to Kartoush");
+    }
+
+    private CustomerEmailProperties emailProperties() {
+        final CustomerEmailProperties properties = new CustomerEmailProperties();
+        properties.setSenderName("Kartoush");
+        properties.setSenderAddress("no-reply@kartoush.dev");
+        properties.setActivationBaseUrl("https://kartoush.dev/activate");
+        properties.setPasswordResetBaseUrl("https://kartoush.dev/reset-password");
+        properties.setWelcomeBaseUrl("https://kartoush.dev/sign-in");
+        return properties;
     }
 }


### PR DESCRIPTION
## Summary
- Add durable welcome email delivery after successful initial password setup
- Extend the customer email factory with a welcome message type and welcome URL configuration
- Add an app-side welcome email job handler that reloads customer state, skips disabled or invalid deliveries, and escapes user-controlled welcome HTML content

Closes #290

## Testing
- ./gradlew :notification:test --tests com.kartoush.notification.email.customer.DefaultCustomerEmailFactoryTest
- ./gradlew :customer:test --tests com.kartoush.customer.internal.facade.DefaultCustomerFacadeTest
- ./gradlew :app:test --tests com.kartoush.config.jobs.WelcomeEmailJobHandlerTest --tests com.kartoush.api.customer.ActivationAndPasswordSetupIntegrationTest -x :app:jacocoTestReport
