### PR TITLE
Add Bruno coverage for customer authentication flows

### DIFF
--- a/bruno/README.md
+++ b/bruno/README.md
@@ -16,8 +16,14 @@ Kartoush HTTP API during local development.
   Collection-level configuration
 - `environments/local.bru`
   Local environment variables for the running application
+- `auth/`
+  Customer authentication requests, including sign-in and password reset flows
 - `customers/`
   Customer API requests, including both happy-path and failure scenarios
+- `internal-customers/`
+  Internal customer management requests for administrative operations
+- `scenarios/customer-lifecycle/`
+  End-to-end customer lifecycle requests arranged in execution order
 - `internal-terms-of-service/`
   Internal Terms of Service management requests for draft and lifecycle operations
 - `terms-of-service/`
@@ -27,34 +33,42 @@ Kartoush HTTP API during local development.
 
 1. Open the `bruno/` directory as a Bruno collection.
 2. Select the `local` environment.
-3. Run `customers/02-create-customer.bru` first to create a customer and
-   capture `customerId` into the environment.
-4. Use the remaining customer requests to inspect success and error
-   behavior.
-5. Use the `internal-terms-of-service/` requests to create and manage
-   draft Terms versions through the internal lifecycle endpoints.
-6. Use the `terms-of-service/` requests to inspect the current supported
-   Terms version, retrieve a published Terms document by version, and
-   inspect the not-found response for an unpublished or missing version.
+3. For a full walkthrough, run the requests under `scenarios/customer-lifecycle/` in order.
+4. Use the `auth/` and `customers/` folders when you want endpoint-oriented exploration instead of the full scenario flow.
+5. Use the `internal-terms-of-service/` requests to create and manage draft Terms versions through the internal lifecycle endpoints.
+6. Use the `terms-of-service/` requests to inspect the current supported Terms version, retrieve a published Terms document by version, and inspect the not-found response for an unpublished or missing version.
 
-The create request also refreshes the `email` environment variable with a
-timestamp-based value so repeated runs stay usable without manual cleanup.
+The create request also refreshes the `email` environment variable with a timestamp-based value so repeated runs stay usable without manual cleanup.
 
 ## Activation Flow Caveat
 
-The activation endpoints are included in this collection, but the full
-manual happy path still depends on a development-only fallback.
+The activation endpoints are included in this collection, but the full manual happy path still depends on a development-only fallback.
 
-Kartoush does not expose the raw activation token through the API. For
-local development, the current `NoOpActivationEmailService` logs the raw
-token so it can be copied into the Bruno environment. That means:
+Kartoush does not expose the raw activation token through the API. For local development, the raw token still needs to be copied into the Bruno environment from the delivery mechanism you are using. That means:
 
 - `customers/06-resend-activation-token.bru` is usable for pending customers
-- `customers/07-activate-customer.bru` requires a valid token to be copied
-  from the local application logs into the environment
-- the invalid-token and blank-token activation requests are the current
-  out-of-the-box error-path requests for activation
+- `customers/07-activate-customer.bru` requires a valid token to be copied from delivered email, Mailtrap, or local development output into the environment
+- the invalid-token and blank-token activation requests are the current out-of-the-box error-path requests for activation
 
-Once a real email delivery implementation exists, this collection can be
-updated to use the delivered token instead of relying on the no-op log
-output.
+Once a real email delivery implementation exists, this collection can be updated further to capture the token more directly.
+
+## Password Reset Caveat
+
+The password reset request and confirm endpoints are included in this collection, but the happy-path confirm request still depends on a delivered reset token.
+
+For local development:
+
+- run `auth/03-request-password-reset.bru`
+- copy the reset token from the delivered email, Mailtrap, or local development output into `resetToken` in the Bruno environment
+- run `auth/05-confirm-password-reset.bru`
+
+The invalid-token confirm request is included as the current out-of-the-box error-path request for password reset confirmation.
+
+The scenario flow does not auto-capture reset tokens either. You still need to copy the delivered reset token into `resetToken` before running
+`scenarios/customer-lifecycle/08-confirm-password-reset.bru`.
+
+## Internal Route Auth
+
+`customers/01-list-customers.bru` now targets the internal customer-listing route and uses the local development admin credentials from the `dev` profile.
+
+The `internal-terms-of-service/` requests use the same local development admin credentials.

--- a/bruno/auth/01-sign-in.bru
+++ b/bruno/auth/01-sign-in.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Sign in customer
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host}}/api/auth/sign-in
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "password": "{{password}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body && res.body.accessToken) {
+    bru.setEnvVar("accessToken", res.body.accessToken);
+    bru.setEnvVar("tokenType", res.body.tokenType || "Bearer");
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/auth/02-sign-in-failure-invalid-password.bru
+++ b/bruno/auth/02-sign-in-failure-invalid-password.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Sign in customer with invalid password
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{host}}/api/auth/sign-in
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "password": "WrongPassword123!"
+  }
+}
+
+tests {
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/bruno/auth/03-request-password-reset.bru
+++ b/bruno/auth/03-request-password-reset.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Request password reset
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{host}}/api/auth/password-reset
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}"
+  }
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/auth/04-request-password-reset-failure-invalid-email.bru
+++ b/bruno/auth/04-request-password-reset-failure-invalid-email.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Request password reset with invalid email
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/api/auth/password-reset
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{invalidEmail}}"
+  }
+}
+
+tests {
+  test("should return 400", function() {
+    expect(res.status).to.equal(400);
+  });
+}

--- a/bruno/auth/05-confirm-password-reset.bru
+++ b/bruno/auth/05-confirm-password-reset.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Confirm password reset
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{host}}/api/auth/password-reset/confirm
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "resetToken": "{{resetToken}}",
+    "password": "{{newPassword}}",
+    "confirmPassword": "{{newPassword}}"
+  }
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/auth/06-confirm-password-reset-failure-invalid-token.bru
+++ b/bruno/auth/06-confirm-password-reset-failure-invalid-token.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Confirm password reset with invalid token
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}/api/auth/password-reset/confirm
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "resetToken": "{{invalidResetToken}}",
+    "password": "{{newPassword}}",
+    "confirmPassword": "{{newPassword}}"
+  }
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/bruno/customers/03-get-customer-by-id.bru
+++ b/bruno/customers/03-get-customer-by-id.bru
@@ -10,6 +10,10 @@ get {
   auth: none
 }
 
+headers {
+  authorization: {{tokenType}} {{accessToken}}
+}
+
 tests {
   test("should return 200", function() {
     expect(res.status).to.equal(200);

--- a/bruno/customers/05-get-missing-customer.bru
+++ b/bruno/customers/05-get-missing-customer.bru
@@ -1,17 +1,17 @@
 meta {
-  name: Get missing customer
+  name: Get customer without bearer token
   type: http
   seq: 5
 }
 
 get {
-  url: {{host}}/api/customers/{{missingCustomerId}}
+  url: {{host}}/api/customers/{{customerId}}
   body: none
   auth: none
 }
 
 tests {
-  test("should return 404", function() {
-    expect(res.status).to.equal(404);
+  test("should return 401", function() {
+    expect(res.status).to.equal(401);
   });
 }

--- a/bruno/customers/13-set-initial-password.bru
+++ b/bruno/customers/13-set-initial-password.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Set initial password
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{host}}/api/customers/{{customerId}}/initial-password
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "setupToken": "{{passwordSetupToken}}",
+    "password": "{{password}}",
+    "confirmPassword": "{{password}}"
+  }
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,7 +1,6 @@
 vars {
   host: http://localhost:8080
   customerId: 01KPHNWQVXB3GJ6YRWVFBVZJCZ
-  missingCustomerId: 01MISSINGCUSTOMER0000000000000
   firstName: Jack
   lastName: Kartoush
   updatedFirstName: Jackson
@@ -10,10 +9,18 @@ vars {
   invalidEmail: not-an-email
   phoneNumber: +13125550100
   updatedPhoneNumber: +13125550101
+  password: Password123!
+  newPassword: BetterPassword123!
+  accessToken: 
+  tokenType: Bearer
   activationToken: N7o09al5ldRf1hPTDHMYfwAOhAKvlDntLnQYLhyW5MI
   invalidActivationToken: invalid-activation-token
+  passwordSetupToken: 
+  resetToken: 
+  invalidResetToken: invalid-reset-token
   currentTermsVersion: 2026.04.01
   missingTermsVersion: 2026.03.01
+  internalAdminBasicToken: a2FydG91c2gtYWRtaW46Y2hhbmdlLW1l
   internalTermsOfServiceId: replace-during-draft-create
   internalTermsVersion: 2026.05.01
   internalTermsContent: ## Terms of Service\n\nDraft terms content for internal management testing.

--- a/bruno/internal-customers/01-list-customers.bru
+++ b/bruno/internal-customers/01-list-customers.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 get {
-  url: {{host}}/api/customers
+  url: {{host}}/internal/customers
   body: none
   auth: none
+}
+
+headers {
+  authorization: Basic {{internalAdminBasicToken}}
 }
 
 tests {

--- a/bruno/internal-terms-of-service/01-create-terms-draft.bru
+++ b/bruno/internal-terms-of-service/01-create-terms-draft.bru
@@ -11,6 +11,7 @@ post {
 }
 
 headers {
+  authorization: Basic {{internalAdminBasicToken}}
   content-type: application/json
 }
 

--- a/bruno/internal-terms-of-service/02-update-terms-draft.bru
+++ b/bruno/internal-terms-of-service/02-update-terms-draft.bru
@@ -11,6 +11,7 @@ put {
 }
 
 headers {
+  authorization: Basic {{internalAdminBasicToken}}
   content-type: application/json
 }
 

--- a/bruno/internal-terms-of-service/03-schedule-terms.bru
+++ b/bruno/internal-terms-of-service/03-schedule-terms.bru
@@ -11,6 +11,7 @@ post {
 }
 
 headers {
+  authorization: Basic {{internalAdminBasicToken}}
   content-type: application/json
 }
 

--- a/bruno/internal-terms-of-service/04-unschedule-terms.bru
+++ b/bruno/internal-terms-of-service/04-unschedule-terms.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  authorization: Basic {{internalAdminBasicToken}}
+}
+
 tests {
   test("should return 200", function() {
     expect(res.status).to.equal(200);

--- a/bruno/internal-terms-of-service/05-activate-terms-now.bru
+++ b/bruno/internal-terms-of-service/05-activate-terms-now.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  authorization: Basic {{internalAdminBasicToken}}
+}
+
 tests {
   test("should return 200", function() {
     expect(res.status).to.equal(200);

--- a/bruno/internal-terms-of-service/06-promote-due-terms.bru
+++ b/bruno/internal-terms-of-service/06-promote-due-terms.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  authorization: Basic {{internalAdminBasicToken}}
+}
+
 tests {
   test("should return 200 or 409", function() {
     expect([200, 409]).to.include(res.status);

--- a/bruno/scenarios/customer-lifecycle/01-create-customer.bru
+++ b/bruno/scenarios/customer-lifecycle/01-create-customer.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Create customer
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host}}/api/customers
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "firstName": "{{firstName}}",
+    "lastName": "{{lastName}}",
+    "email": "{{email}}",
+    "phoneNumber": "{{phoneNumber}}",
+    "termsAccepted": true,
+    "termsVersion": "{{currentTermsVersion}}"
+  }
+}
+
+script:pre-request {
+  const uniqueEmail = `jack+bruno-${Date.now()}@kartoush.dev`;
+  bru.setEnvVar("email", uniqueEmail);
+  bru.setEnvVar("accessToken", "");
+  bru.setEnvVar("passwordSetupToken", "");
+  bru.setEnvVar("resetToken", "");
+}
+
+script:post-response {
+  if (res.status === 201 && res.body && res.body.customerId) {
+    bru.setEnvVar("customerId", res.body.customerId);
+  }
+}
+
+tests {
+  test("should return 201", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/bruno/scenarios/customer-lifecycle/02-activate-customer.bru
+++ b/bruno/scenarios/customer-lifecycle/02-activate-customer.bru
@@ -1,7 +1,7 @@
 meta {
   name: Activate customer
   type: http
-  seq: 7
+  seq: 2
 }
 
 post {
@@ -20,14 +20,14 @@ body {
   }
 }
 
-tests {
-  test("should return 200 when a valid activation token is supplied", function() {
-    expect(res.status).to.equal(200);
-  });
-}
-
 script:post-response {
   if (res.status === 200 && res.body && res.body.passwordSetupToken) {
     bru.setEnvVar("passwordSetupToken", res.body.passwordSetupToken);
   }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
 }

--- a/bruno/scenarios/customer-lifecycle/03-set-initial-password.bru
+++ b/bruno/scenarios/customer-lifecycle/03-set-initial-password.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Set initial password
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{host}}/api/customers/{{customerId}}/initial-password
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "setupToken": "{{passwordSetupToken}}",
+    "password": "{{password}}",
+    "confirmPassword": "{{password}}"
+  }
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/scenarios/customer-lifecycle/04-sign-in.bru
+++ b/bruno/scenarios/customer-lifecycle/04-sign-in.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Sign in customer
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/api/auth/sign-in
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "password": "{{password}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body && res.body.accessToken) {
+    bru.setEnvVar("accessToken", res.body.accessToken);
+    bru.setEnvVar("tokenType", res.body.tokenType || "Bearer");
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/scenarios/customer-lifecycle/05-get-customer.bru
+++ b/bruno/scenarios/customer-lifecycle/05-get-customer.bru
@@ -1,10 +1,10 @@
 meta {
-  name: Delete customer
+  name: Get customer
   type: http
-  seq: 12
+  seq: 5
 }
 
-delete {
+get {
   url: {{host}}/api/customers/{{customerId}}
   body: none
   auth: none
@@ -15,7 +15,7 @@ headers {
 }
 
 tests {
-  test("should return 204", function() {
-    expect(res.status).to.equal(204);
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
   });
 }

--- a/bruno/scenarios/customer-lifecycle/06-update-customer.bru
+++ b/bruno/scenarios/customer-lifecycle/06-update-customer.bru
@@ -1,7 +1,7 @@
 meta {
   name: Update customer
   type: http
-  seq: 4
+  seq: 6
 }
 
 put {

--- a/bruno/scenarios/customer-lifecycle/07-request-password-reset.bru
+++ b/bruno/scenarios/customer-lifecycle/07-request-password-reset.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Request password reset
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{host}}/api/auth/password-reset
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}"
+  }
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/scenarios/customer-lifecycle/08-confirm-password-reset.bru
+++ b/bruno/scenarios/customer-lifecycle/08-confirm-password-reset.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Confirm password reset
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host}}/api/auth/password-reset/confirm
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "resetToken": "{{resetToken}}",
+    "password": "{{newPassword}}",
+    "confirmPassword": "{{newPassword}}"
+  }
+}
+
+tests {
+  test("should return 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/scenarios/customer-lifecycle/09-sign-in-with-new-password.bru
+++ b/bruno/scenarios/customer-lifecycle/09-sign-in-with-new-password.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Sign in with new password
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{host}}/api/auth/sign-in
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body {
+  {
+    "email": "{{email}}",
+    "password": "{{newPassword}}"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body && res.body.accessToken) {
+    bru.setEnvVar("accessToken", res.body.accessToken);
+    bru.setEnvVar("tokenType", res.body.tokenType || "Bearer");
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}


### PR DESCRIPTION
## Summary
- add Bruno requests for customer sign-in and password reset flows, including representative failure cases
- add an ordered `scenarios/customer-lifecycle/` flow so the full customer journey can be exercised without jumping between folders
- align the existing Bruno customer and internal requests with the current API security model and internal route split

Closes #352

## Testing
- Not run, because this is Bruno collection and documentation work